### PR TITLE
Update version of numpy 1.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ future
 gdown
 lxml
 networkx==2.2.0
-numpy>=1.9.0
+numpy>=1.16.0
 ordered_set
 pillow
 pycollada!=0.7  # required for robot model using collada


### PR DESCRIPTION
To fix the following error,

```
ModuleNotFoundError: No module named 'numpy.core._multiarray_umath'
```
