### PR TITLE
[TrimeshViewer] Fixed update interval of pyglet

### DIFF
--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import threading
 
 import pyglet


### PR DESCRIPTION
For python2 (python2 is deprecated...), 
`pyglet.clock.schedule_interval` not work because the expression `1 / 30` equals `0`.
This patch fixes this behavior.