### PR TITLE
Enable to use just one controller action in angle_vector

### DIFF
--- a/skrobot/interfaces/ros/base.py
+++ b/skrobot/interfaces/ros/base.py
@@ -267,8 +267,10 @@ class ROSRobotInterfaceBase(object):
                 tmp_actions.append(action)
                 tmp_actions_name.append(controller_action)
                 if 'controller_type' in controller:
-                    controller_type_actions[controller['controller_type']] = [action]
-                    controller_type_params[controller['controller_type']] = [controller]
+                    controller_type_actions[
+                        controller['controller_type']] = [action]
+                    controller_type_params[
+                        controller['controller_type']] = [controller]
             for action, action_name in zip(tmp_actions, tmp_actions_name):
                 if self.controller_timeout is None:
                     rospy.logwarn(
@@ -302,7 +304,8 @@ class ROSRobotInterfaceBase(object):
         else:  # not creating actions, just search
             self.controller_type = controller_type
         self.controller_table[controller_type] = tmp_actions
-        self.controller_param_table[controller_type] = self.default_controller()
+        self.controller_param_table[controller_type] \
+            = self.default_controller()
         self.controller_table.update(controller_type_actions)
         self.controller_param_table.update(controller_type_params)
         return self.controller_table[controller_type]
@@ -553,7 +556,7 @@ class ROSRobotInterfaceBase(object):
 
         cacts = self.controller_table[controller_type]
         controller_params = self.controller_param_table[controller_type]
-        for action, controller_param in zip(cacts, self.default_controller()):
+        for action, controller_param in zip(cacts, controller_params):
             self.send_ros_controller(
                 action,
                 controller_param['joint_names'],

--- a/skrobot/interfaces/ros/base.py
+++ b/skrobot/interfaces/ros/base.py
@@ -118,6 +118,7 @@ class ROSRobotInterfaceBase(object):
                              queue_size=joint_states_queue_size)
 
         self.controller_table = {}
+        self.controller_param_table = {}
         self.controller_type = default_controller
         self.controller_actions = self.add_controller(
             self.controller_type, create_actions=True, joint_enable_check=True)
@@ -251,6 +252,8 @@ class ROSRobotInterfaceBase(object):
         """
         tmp_actions = []
         tmp_actions_name = []
+        controller_type_actions = {}
+        controller_type_params = {}
         if create_actions:
             for controller in self.default_controller():
                 controller_action = controller['controller_action']
@@ -263,6 +266,9 @@ class ROSRobotInterfaceBase(object):
                                                 controller['action_type'])
                 tmp_actions.append(action)
                 tmp_actions_name.append(controller_action)
+                if 'controller_type' in controller:
+                    controller_type_actions[controller['controller_type']] = [action]
+                    controller_type_params[controller['controller_type']] = [controller]
             for action, action_name in zip(tmp_actions, tmp_actions_name):
                 if self.controller_timeout is None:
                     rospy.logwarn(
@@ -296,10 +302,14 @@ class ROSRobotInterfaceBase(object):
         else:  # not creating actions, just search
             self.controller_type = controller_type
         self.controller_table[controller_type] = tmp_actions
+        self.controller_param_table[controller_type] = self.default_controller()
+        self.controller_table.update(controller_type_actions)
+        self.controller_param_table.update(controller_type_params)
         return self.controller_table[controller_type]
 
     def default_controller(self):
         return [dict(
+            controller_type='fullbody_controller',
             controller_action='fullbody_controller/'
             'follow_joint_trajectory_action',
             controller_state='fullbody_controller/state',
@@ -395,7 +405,8 @@ class ROSRobotInterfaceBase(object):
             angle_velocities = np.zeros_like(av)
         duration = time
         traj_points = [(av, angle_velocities, duration), ]
-        for action, controller_param in zip(cacts, self.default_controller()):
+        controller_params = self.controller_param_table[controller_type]
+        for action, controller_param in zip(cacts, controller_params):
             self.send_ros_controller(
                 action,
                 controller_param['joint_names'],
@@ -541,6 +552,7 @@ class ROSRobotInterfaceBase(object):
             prev_av = av
 
         cacts = self.controller_table[controller_type]
+        controller_params = self.controller_param_table[controller_type]
         for action, controller_param in zip(cacts, self.default_controller()):
             self.send_ros_controller(
                 action,
@@ -567,7 +579,7 @@ class ROSRobotInterfaceBase(object):
         if controller_type:
             controller_actions = self.controller_table[controller_type]
         else:
-            controller_actions = self.controller_actions
+            controller_actions = self.controller_table[self.controller_type]
         for action in controller_actions:
             # TODO(simultaneously wait_for_result)
             action.wait_for_result(timeout=rospy.Duration(timeout))
@@ -591,9 +603,11 @@ class ROSRobotInterfaceBase(object):
         av_duration : float
             time of angle vector.
         """
+        if controller_type is None:
+            controller_type = self.controller_type
         unordered_joint_names = set(
             _flatten([c['joint_names']
-                      for c in self.default_controller()]))
+                      for c in self.controller_param_table[controller_type]]))
         joint_list = self.robot.joint_list
         diff_avs = self.sub_angle_vector(end_av, start_av)
         time_list = []

--- a/skrobot/interfaces/ros/panda.py
+++ b/skrobot/interfaces/ros/panda.py
@@ -8,6 +8,7 @@ class PandaROSRobotInterface(ROSRobotInterfaceBase):
     @property
     def rarm_controller(self):
         return dict(
+            controller_type='rarm_controller',
             controller_action='position_joint_trajectory_controller/follow_joint_trajectory',  # NOQA
             controller_state='position_joint_trajectory_controller/state',
             action_type=control_msgs.msg.FollowJointTrajectoryAction,

--- a/skrobot/interfaces/ros/pr2.py
+++ b/skrobot/interfaces/ros/pr2.py
@@ -75,6 +75,7 @@ class PR2ROSRobotInterface(ROSRobotMoveBaseInterface):
     @property
     def larm_controller(self):
         return dict(
+            controller_type='larm_controller',
             controller_action='l_arm_controller/follow_joint_trajectory',
             controller_state='l_arm_controller/state',
             action_type=control_msgs.msg.FollowJointTrajectoryAction,
@@ -89,6 +90,7 @@ class PR2ROSRobotInterface(ROSRobotMoveBaseInterface):
     @property
     def rarm_controller(self):
         return dict(
+            controller_type='rarm_controller',
             controller_action='r_arm_controller/follow_joint_trajectory',
             controller_state='r_arm_controller/state',
             action_type=control_msgs.msg.FollowJointTrajectoryAction,
@@ -103,6 +105,7 @@ class PR2ROSRobotInterface(ROSRobotMoveBaseInterface):
     @property
     def head_controller(self):
         return dict(
+            controller_type='head_controller',
             controller_action='head_traj_controller/follow_joint_trajectory',
             controller_state='head_traj_controller/state',
             action_type=control_msgs.msg.FollowJointTrajectoryAction,
@@ -111,6 +114,7 @@ class PR2ROSRobotInterface(ROSRobotMoveBaseInterface):
     @property
     def torso_controller(self):
         return dict(
+            controller_type='torso_controller',
             controller_action='torso_controller/follow_joint_trajectory',
             controller_state='torso_controller/state',
             action_type=control_msgs.msg.FollowJointTrajectoryAction,


### PR DESCRIPTION
Edited to ros  interface to enable option `'controller_type'` of `ROSRobotInterfaceBase.angle_vector()`.
It is supposed to `default_controller()` returns all of controller settings. If controller settings have `'controller_type'`, you can designate it as option of `angle_vector()`.