### PR TITLE
Modified update_vertex_list timing

### DIFF
--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -44,7 +44,9 @@ class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
 
     def on_draw(self):
         if not self._redraw:
-            super(TrimeshSceneViewer, self).on_draw()
+            with self.lock:
+                self._update_vertex_list()
+                super(TrimeshSceneViewer, self).on_draw()
             return
 
         with self.lock:
@@ -55,7 +57,7 @@ class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
                 link.update(force=True)
                 transform = link.worldcoords().T()
                 self.scene.graph.update(str(id(link)), matrix=transform)
-        super(TrimeshSceneViewer, self).on_draw()
+            super(TrimeshSceneViewer, self).on_draw()
 
         self._redraw = False
 


### PR DESCRIPTION
In current, `TrimeshSceneViewer` has the following error.

```
In [1]: import skrobot
   ...:
   ...: robot_model = skrobot.models.Kuka()
   ...: viewer = skrobot.viewers.TrimeshSceneViewer()
   ...: viewer.add(robot_model)
   ...: viewer.show()
   ...:
   ...: axes = []
   ...: for _ in range(100):
   ...:     axis = skrobot.models.Axis()
   ...:     axes.append(axis)
   ...:     viewer.add(axis)
   ...:

Exception in thread Thread-29:
Traceback (most recent call last):
  File "/home/iory/.pyenv/versions/anaconda3-5.3.1/envs/dl/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/iory/.pyenv/versions/anaconda3-5.3.1/envs/dl/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/iory/scikit-robot/skrobot/viewers/_trimesh.py", line 37, in _init_and_start_app
    pyglet.app.run()
  File "/home/iory/.pyenv/versions/anaconda3-5.3.1/envs/dl/lib/python3.6/site-packages/pyglet/app/__init__.py", line 138, in run
    event_loop.run()
  File "/home/iory/.pyenv/versions/anaconda3-5.3.1/envs/dl/lib/python3.6/site-packages/pyglet/app/base.py", line 142, in run
    self._run()
  File "/home/iory/.pyenv/versions/anaconda3-5.3.1/envs/dl/lib/python3.6/site-packages/pyglet/app/base.py", line 154, in _run
    timeout = self.idle()
  File "/home/iory/.pyenv/versions/anaconda3-5.3.1/envs/dl/lib/python3.6/site-packages/pyglet/app/base.py", line 275, in idle
    redraw_all = self.clock.call_scheduled_functions(dt)
  File "/home/iory/.pyenv/versions/anaconda3-5.3.1/envs/dl/lib/python3.6/site-packages/pyglet/clock.py", line 346, in call_scheduled_functions
    item.func(now - item.last_ts, *item.args, **item.kwargs)
  File "/home/iory/scikit-robot/skrobot/viewers/_trimesh.py", line 43, in on_update
    self.on_draw()
  File "/home/iory/scikit-robot/skrobot/viewers/_trimesh.py", line 58, in on_draw
    super(TrimeshSceneViewer, self).on_draw()
  File "/home/iory/src/github.com/mikedh/trimesh/trimesh/viewer/windowed.py", line 673, in on_draw
    mode = self.vertex_list_mode[geometry_name]
KeyError: '139825500622016'
```
This PR modifies the timing of `TrimeshSceneViewer._update_vertex_list` to fix the error.