### PR TITLE
Set (640, 480) as default resolution of TrimeshSceneViewer

### DIFF
--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -12,6 +12,9 @@ from .. import model as model_module
 class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
 
     def __init__(self, resolution=None):
+        if resolution is None:
+            resolution = (640, 480)
+
         self._links = collections.OrderedDict()
 
         self._redraw = True


### PR DESCRIPTION
Default size in trimesh is too large.