### PR TITLE
[math] Avoid rpy_angle's small yaw case

### DIFF
--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -525,7 +525,10 @@ def rpy_angle(matrix):
     (array([1.57079633, 1.04719755, 0.52359878]),
      array([ 4.71238898,  2.0943951 , -2.61799388]))
     """
-    a = np.arctan2(matrix[1, 0], matrix[0, 0])
+    if np.sqrt(matrix[1, 0] ** 2 + matrix[0, 0] ** 2) < _EPS:
+        a = 0.0
+    else:
+        a = np.arctan2(matrix[1, 0], matrix[0, 0])
     sa = np.sin(a)
     ca = np.cos(a)
     b = np.arctan2(-matrix[2, 0], ca * matrix[0, 0] + sa * matrix[1, 0])

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -108,6 +108,13 @@ class TestMath(unittest.TestCase):
         testing.assert_almost_equal(
             b, np.array([3.66519143, 2.51327412, -2.0943951]))
 
+        rot = np.array([[0, 0, 1],
+                        [0, -1, 0],
+                        [1, 0, 0]])
+        testing.assert_almost_equal(
+            rpy_angle(rot)[0],
+            np.array([0, - pi / 2.0, pi]))
+
     def test_rotation_matrix(self):
         testing.assert_almost_equal(
             rotation_matrix(pi, [1, 1, 1]),


### PR DESCRIPTION
# Fixed rpy_angle's corner case.

## Previous
```
In [1]: import skrobot
   ...: import numpy as np
   ...: rot = skrobot.coordinates.math.rodrigues([1, 0, 1], np.pi)
   ...: skrobot.coordinates.math.rpy_angle(rot)[0]


Out[1]: array([ 0.37184908, -1.57079633,  2.76974358])
```
## With this PR
```
In [1]: import skrobot
   ...: import numpy as np
   ...: rot = skrobot.coordinates.math.rodrigues([1, 0, 1], np.pi)
   ...: skrobot.coordinates.math.rpy_angle(rot)[0]

Out[1]: array([ 0.        , -1.57079633,  3.14159265])
```