### PR TITLE
[math] Add rotation_matrix_from_axis

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -32,6 +32,7 @@ Utilities functions
    skrobot.coordinates.math.matrix_exponent
    skrobot.coordinates.math.outer_product_matrix
    skrobot.coordinates.math.rotation_matrix_from_rpy
+   skrobot.coordinates.math.rotation_matrix_from_axis
    skrobot.coordinates.math.rodrigues
    skrobot.coordinates.math.rotation_angle
    skrobot.coordinates.math.rotation_distance

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -888,6 +888,41 @@ def rotation_matrix_from_rpy(rpy):
     return quaternion2matrix(quat_from_rpy(rpy))
 
 
+def rotation_matrix_from_axis(x_axis, y_axis=(0, 1, 0)):
+    """Return rotation matrix orienting x_axis
+
+    Parameters
+    ----------
+    x_axis : list or tuple or numpy.ndarray
+        x_axis
+    y_axis : list or tuple or numpy.ndarray
+        y_axis. This input axis is normalized using Gram-Schmidt.
+
+    Returns
+    -------
+    rotation_matrix : numpy.ndarray
+        Rotation matrix
+
+    Examples
+    --------
+    >>> from skrobot.coordinates.math import rotation_matrix_from_axis
+    >>> rotation_matrix_from_axis((1, 0, 0), (0, 1, 0))
+    array([[1., 0., 0.],
+           [0., 1., 0.],
+           [0., 0., 1.]])
+    >>> rotation_matrix_from_axis((1, 1, 1), (0, 1, 0))
+    array([[ 0.57735027, -0.40824829, -0.70710678],
+           [ 0.57735027,  0.81649658,  0.        ],
+           [ 0.57735027, -0.40824829,  0.70710678]])
+    """
+    e1 = normalize_vector(x_axis)
+    e2 = normalize_vector(y_axis - np.dot(y_axis, e1) * e1)
+    z_axis = np.cross(e1, e2)
+    e3 = normalize_vector(
+        z_axis - np.dot(z_axis, e1) * e1 - np.dot(z_axis, e2) * e2)
+    return np.vstack([e1, e2, e3]).T
+
+
 def rodrigues(axis, theta=None):
     """Rodrigues formula.
 

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -30,6 +30,7 @@ from skrobot.coordinates.math import rotate_vector
 from skrobot.coordinates.math import rotation_angle
 from skrobot.coordinates.math import rotation_distance
 from skrobot.coordinates.math import rotation_matrix
+from skrobot.coordinates.math import rotation_matrix_from_axis
 from skrobot.coordinates.math import rotation_matrix_from_rpy
 from skrobot.coordinates.math import rpy2quaternion
 from skrobot.coordinates.math import rpy_angle
@@ -236,6 +237,15 @@ class TestMath(unittest.TestCase):
                         np.eye(3), 0.2, 'x'), 0.4, 'y'), 0.6, 'z'),
             decimal=5)
 
+    def test_normalize_vector(self):
+        testing.assert_almost_equal(
+            normalize_vector([5, 0, 0]),
+            np.array([1, 0, 0]))
+
+        testing.assert_almost_equal(
+            np.linalg.norm(normalize_vector([1, 1, 1])),
+            1.0)
+
     def test_matrix2quaternion(self):
         testing.assert_almost_equal(matrix2quaternion(np.eye(3)),
                                     np.array([1, 0, 0, 0]))
@@ -273,6 +283,28 @@ class TestMath(unittest.TestCase):
             y = np.random.random()
             testing.assert_almost_equal(rpy_matrix(y, p, r),
                                         rotation_matrix_from_rpy([y, p, r]))
+
+    def test_rotation_matrix_from_axis(self):
+        x_axis = (1, 0, 0)
+        y_axis = (0, 1, 0)
+        rot = rotation_matrix_from_axis(x_axis, y_axis)
+        testing.assert_array_almost_equal(rot, np.eye(3))
+
+        x_axis = (1, 1, 1)
+        y_axis = (0, 0, 1)
+        rot = rotation_matrix_from_axis(x_axis, y_axis)
+        testing.assert_array_almost_equal(
+            rot, [[0.57735027, -0.40824829, 0.70710678],
+                  [0.57735027, -0.40824829, -0.70710678],
+                  [0.57735027, 0.81649658, 0.0]])
+
+        x_axis = (1, 1, 1)
+        y_axis = (0, 0, -1)
+        rot = rotation_matrix_from_axis(x_axis, y_axis)
+        testing.assert_array_almost_equal(
+            rot, [[0.57735027, 0.40824829, -0.70710678],
+                  [0.57735027, 0.40824829, 0.70710678],
+                  [0.57735027, -0.81649658, 0.0]])
 
     def test_rotation_distance(self):
         mat1 = np.eye(3)


### PR DESCRIPTION
`rotation_matrix_from_axis` creates rotation matrix from two-axis vector.
You can view the result of this function as the following codes.
```
from skrobot.coordinates.math import rotation_matrix_from_axis
import skrobot


viewer = skrobot.viewers.TrimeshSceneViewer()
axis = skrobot.models.Axis(pos=(0.05, 0.05, 0))
viewer.add(axis)
viewer.show()

x_axis = (1, 0, 0)
y_axis = (0, 1, 0)
rot = rotation_matrix_from_axis(x_axis, y_axis)
axis.rotation = rot
```

![-home-iory- pyenv-versions-anaconda3-5 3 1-envs-scikit-robot-bin-ipython_001](https://user-images.githubusercontent.com/4690682/76698405-da0c3b00-66e5-11ea-85e7-abc00c02a018.png)

```
x_axis = (1, 1, 1)
y_axis = (0, 0, 1)
rot = rotation_matrix_from_axis(x_axis, y_axis)
axis.rotation = rot
```
![-home-iory- pyenv-versions-anaconda3-5 3 1-envs-scikit-robot-bin-ipython_002](https://user-images.githubusercontent.com/4690682/76698410-e42e3980-66e5-11ea-9320-7cd46a7f9de1.png)

```
x_axis = (1, 1, 1)
y_axis = (0, 0, -1)
rot = rotation_matrix_from_axis(x_axis, y_axis)
axis.rotation = rot
```

![-home-iory- pyenv-versions-anaconda3-5 3 1-envs-scikit-robot-bin-ipython_003](https://user-images.githubusercontent.com/4690682/76698413-f1e3bf00-66e5-11ea-8a6c-544666824e63.png)


