### PR TITLE
Add xy,yx,yz,zy,zx,xz axis option for difference_rotation

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -37,6 +37,7 @@ Utilities functions
    skrobot.coordinates.math.rotation_angle
    skrobot.coordinates.math.rotation_distance
    skrobot.coordinates.math.axis_angle_from_matrix
+   skrobot.coordinates.math.angle_between_vectors
 
 
 Jacobian Functions

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -7,6 +7,7 @@ from skrobot.coordinates.dual_quaternion import DualQuaternion
 from skrobot.coordinates.math import _check_valid_rotation
 from skrobot.coordinates.math import _check_valid_translation
 from skrobot.coordinates.math import _wrap_axis
+from skrobot.coordinates.math import angle_between_vectors
 from skrobot.coordinates.math import matrix2quaternion
 from skrobot.coordinates.math import matrix_log
 from skrobot.coordinates.math import normalize_vector
@@ -695,9 +696,10 @@ class Coordinates(object):
             if np.abs(np.linalg.norm(np.array(a0) - np.array(a1))) < 0.001:
                 dif_rot = np.array([0, 0, 0], 'f')
             else:
-                dif_rot = np.matmul(self.worldrot().T,
-                                    np.arccos(np.dot(a0, a1))
-                                    * normalize_vector(np.cross(a0, a1)))
+                dif_rot = np.matmul(
+                    self.worldrot().T,
+                    angle_between_vectors(a0, a1, normalize=False)
+                    * normalize_vector(np.cross(a0, a1)))
         elif rotation_axis in ['xx', 'yy', 'zz']:
             ax = rotation_axis[0]
             a0 = self.axis(ax)
@@ -706,7 +708,8 @@ class Coordinates(object):
                 a2 = - a2
             dif_rot = np.matmul(
                 self.worldrot().T,
-                np.arccos(np.dot(a0, a2)) * normalize_vector(np.cross(a0, a2)))
+                angle_between_vectors(a0, a2, normalize=False)
+                * normalize_vector(np.cross(a0, a2)))
         elif rotation_axis in ['xy', 'yx', 'yz', 'zy', 'zx', 'xz']:
             if rotation_axis in ['xy', 'yx']:
                 ax1 = 'z'
@@ -721,7 +724,8 @@ class Coordinates(object):
             a1 = coords.axis(ax1)
             dif_rot = np.matmul(
                 self.worldrot().T,
-                np.arccos(np.dot(a0, a1)) * normalize_vector(np.cross(a0, a1)))
+                angle_between_vectors(a0, a1, normalize=False)
+                * normalize_vector(np.cross(a0, a1)))
             norm = np.linalg.norm(dif_rot)
             if np.isclose(norm, 0.0):
                 self_coords = self.copy_worldcoords()
@@ -731,7 +735,8 @@ class Coordinates(object):
             a1 = coords.axis(ax2)
             dif_rot = np.matmul(
                 self_coords.worldrot().T,
-                np.arccos(np.dot(a0, a1)) * normalize_vector(np.cross(a0, a1)))
+                angle_between_vectors(a0, a1, normalize=False)
+                * normalize_vector(np.cross(a0, a1)))
         elif rotation_axis in ['xm', 'ym', 'zm']:
             rot = coords.worldrot()
             ax = rotation_axis[0]

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -640,8 +640,8 @@ class Coordinates(object):
         coords : skrobot.coordinates.Coordinates
             given coordinates
         rotation_axis : str or bool or None (optional)
-            we can take ['x', 'y', 'z', 'xx', 'yy', 'zz', 'xm', 'ym', 'zm']
-            or True, False(None).
+            we can take 'x', 'y', 'z', 'xx', 'yy', 'zz', 'xm', 'ym', 'zm',
+            'xy', 'yx', 'yz', 'zy', 'zx', 'xz', True or False(None).
 
         Returns
         -------
@@ -707,6 +707,31 @@ class Coordinates(object):
             dif_rot = np.matmul(
                 self.worldrot().T,
                 np.arccos(np.dot(a0, a2)) * normalize_vector(np.cross(a0, a2)))
+        elif rotation_axis in ['xy', 'yx', 'yz', 'zy', 'zx', 'xz']:
+            if rotation_axis in ['xy', 'yx']:
+                ax1 = 'z'
+                ax2 = 'x'
+            elif rotation_axis in ['yz', 'zy']:
+                ax1 = 'x'
+                ax2 = 'y'
+            else:
+                ax1 = 'y'
+                ax2 = 'z'
+            a0 = self.axis(ax1)
+            a1 = coords.axis(ax1)
+            dif_rot = np.matmul(
+                self.worldrot().T,
+                np.arccos(np.dot(a0, a1)) * normalize_vector(np.cross(a0, a1)))
+            norm = np.linalg.norm(dif_rot)
+            if np.isclose(norm, 0.0):
+                self_coords = self.copy_worldcoords()
+            else:
+                self_coords = self.copy_worldcoords().rotate(norm, dif_rot)
+            a0 = self_coords.axis(ax2)
+            a1 = coords.axis(ax2)
+            dif_rot = np.matmul(
+                self_coords.worldrot().T,
+                np.arccos(np.dot(a0, a1)) * normalize_vector(np.cross(a0, a1)))
         elif rotation_axis in ['xm', 'ym', 'zm']:
             rot = coords.worldrot()
             ax = rotation_axis[0]

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -600,11 +600,12 @@ class Coordinates(object):
         coords : skrobot.coordinates.Coordinates
             given coordinates
         translation_axis : str or bool or None (optional)
-            we can take ['x', 'y', 'z', 'xy', 'yz', 'zx']
+            we can take 'x', 'y', 'z', 'xy', 'yz', 'zx', 'xx', 'yy', 'zz',
+            True or False(None).
 
         Returns
         -------
-        dif_pos : np.ndarray
+        dif_pos : numpy.ndarray
             difference position of self coordinates and coords
             considering translation_axis.
 
@@ -644,7 +645,7 @@ class Coordinates(object):
 
         Returns
         -------
-        dif_rot : np.ndarray
+        dif_rot : numpy.ndarray
             difference rotation of self coordinates and coords
             considering rotation_axis.
 

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -684,10 +684,10 @@ class Coordinates(object):
             a0 = coords0.axis(ax)
             a1 = coords1.axis(ax)
             a1_mirror = - a1
-            dr1 = np.arccos(np.dot(a0, a1)) * \
-                normalize_vector(np.cross(a0, a1))
-            dr1m = np.arccos(np.dot(a0, a1_mirror)) * \
-                normalize_vector(np.cross(a0, a1_mirror))
+            dr1 = angle_between_vectors(a0, a1, normalize=False) \
+                * normalize_vector(np.cross(a0, a1))
+            dr1m = angle_between_vectors(a0, a1_mirror, normalize=False) \
+                * normalize_vector(np.cross(a0, a1_mirror))
             return np.linalg.norm(dr1) < np.linalg.norm(dr1m)
 
         if rotation_axis in ['x', 'y', 'z']:

--- a/skrobot/coordinates/geo.py
+++ b/skrobot/coordinates/geo.py
@@ -93,7 +93,7 @@ def orient_coords_to_axis(target_coords, v, axis='z', eps=0.005):
     axis = _wrap_axis(axis)
     ax = target_coords.rotate_vector(axis)
     rot_axis = np.cross(ax, nv)
-    rot_angle_cos = np.dot(nv, ax)
+    rot_angle_cos = np.clip(np.dot(nv, ax), -1.0, 1.0)
     if np.isclose(rot_angle_cos, 1.0, atol=eps):
         return target_coords
     elif np.isclose(rot_angle_cos, -1.0, atol=eps):

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -1428,6 +1428,29 @@ def axis_angle_from_matrix(rotation):
     return axis_angle_from_quaternion(quat_from_rotation_matrix(rotation))
 
 
+def angle_between_vectors(v1, v2, normalize=True):
+    """Returns the smallest angle in radians between two vectors.
+
+    Parameters
+    ----------
+    v1 : numpy.ndarray, list[float] or tuple(float)
+        input vector.
+    v2 : numpy.ndarray, list[float] or tuple(float)
+        input vector.
+    normalize : bool
+        If normalize is True, normalize v1 and v2.
+
+    Returns
+    -------
+    theta : float
+        smallest angle between v1 and v2.
+    """
+    if normalize:
+        v1 = normalize_vector(v1)
+        v2 = normalize_vector(v2)
+    return np.arccos(np.clip(np.dot(v1, v2), -1.0, 1.0))
+
+
 def random_rotation():
     """Generates a random 3x3 rotation matrix.
 

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -262,6 +262,33 @@ class TestCoordinates(unittest.TestCase):
         dif_rot = coord1.difference_rotation(coord2, 'xm')
         testing.assert_almost_equal(dif_rot, [-pi / 2.0, 0, 0])
 
+        # norm == 0 case
+        coord1 = make_coords()
+        coord2 = make_coords()
+        dif_rot = coord1.difference_rotation(coord2, 'xy')
+        testing.assert_almost_equal(dif_rot, [0, 0, 0])
+
+        coord1 = make_coords()
+        coord2 = make_coords().rotate(pi / 2, 'x').rotate(pi / 2, 'y')
+        dif_rot = coord1.difference_rotation(coord2, 'xy')
+        testing.assert_almost_equal(dif_rot, [0, 0, pi / 2])
+        dif_rot = coord1.difference_rotation(coord2, 'yx')
+        testing.assert_almost_equal(dif_rot, [0, 0, pi / 2])
+
+        coord1 = make_coords()
+        coord2 = make_coords().rotate(pi / 2, 'y').rotate(pi / 2, 'z')
+        dif_rot = coord1.difference_rotation(coord2, 'yz')
+        testing.assert_almost_equal(dif_rot, [pi / 2, 0, 0])
+        dif_rot = coord1.difference_rotation(coord2, 'zy')
+        testing.assert_almost_equal(dif_rot, [pi / 2, 0, 0])
+
+        coord1 = make_coords()
+        coord2 = make_coords().rotate(pi / 2, 'z').rotate(pi / 2, 'x')
+        dif_rot = coord1.difference_rotation(coord2, 'zx')
+        testing.assert_almost_equal(dif_rot, [0, pi / 2, 0])
+        dif_rot = coord1.difference_rotation(coord2, 'xz')
+        testing.assert_almost_equal(dif_rot, [0, pi / 2, 0])
+
 
 class TestCascadedCoordinates(unittest.TestCase):
 

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -262,6 +262,12 @@ class TestCoordinates(unittest.TestCase):
         dif_rot = coord1.difference_rotation(coord2, 'xm')
         testing.assert_almost_equal(dif_rot, [-pi / 2.0, 0, 0])
 
+        # corner case
+        coord1 = make_coords()
+        coord2 = make_coords().rotate(0.2564565431501872, 'y')
+        dif_rot = coord1.difference_rotation(coord2, 'zy')
+        testing.assert_almost_equal(dif_rot, [0, 0, 0])
+
         # norm == 0 case
         coord1 = make_coords()
         coord2 = make_coords()

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -6,6 +6,7 @@ from numpy import pi
 from numpy import testing
 
 from skrobot.coordinates.math import _check_valid_rotation
+from skrobot.coordinates.math import angle_between_vectors
 from skrobot.coordinates.math import matrix2quaternion
 from skrobot.coordinates.math import matrix_exponent
 from skrobot.coordinates.math import matrix_log
@@ -411,6 +412,15 @@ class TestMath(unittest.TestCase):
         testing.assert_almost_equal(
             q,
             matrix2quaternion(rotation_matrix(0.1, [1, 0, 0])))
+
+    def test_angle_between_vectors(self):
+        v = (1., 1., 1.)
+        theta = angle_between_vectors(v, v)
+        testing.assert_almost_equal(theta, 0.0)
+
+        unit_v = normalize_vector(v)
+        theta = angle_between_vectors(unit_v, unit_v, normalize=False)
+        testing.assert_almost_equal(theta, 0.0)
 
     def test_random_rotation(self):
         testing.assert_almost_equal(


### PR DESCRIPTION
```
import skrobot

r = skrobot.models.PR2()
axis = skrobot.models.Axis.from_coords(skrobot.coordinates.Coordinates(pos=(0.5, -0.2, 0.7)))
end_coords_axis = skrobot.models.Axis.from_cascoords(r.rarm.end_coords.parent)
v = skrobot.viewers.TrimeshSceneViewer()
v.add(r)
v.add(axis)
v.add(end_coords_axis)
v.show()
r.reset_pose()

r.rarm.inverse_kinematics(axis, rotation_axis='xz', rthre=np.deg2rad(0.1))
print(np.rad2deg(r.rarm.end_coords.difference_rotation(axis)))
[-14.15904733  -0.08013411 -60.73068086]

r.rarm.inverse_kinematics(axis, rotation_axis='yz', rthre=np.deg2rad(0.1))
print(np.rad2deg(r.rarm.end_coords.difference_rotation(axis)))
[ 1.25688155e-02  2.17949891e+00 -6.10568915e+01]
```