### PR TITLE
 [coordinates] Enable init from 4x4 homogeneous transformation matrix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '0.0.4'
+version = '0.0.5'
 
 
 if sys.argv[-1] == 'release':

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -77,24 +77,33 @@ def transform_coords(c1, c2, out=None):
 
 class Coordinates(object):
 
+    """Coordinates class to manipulate rotation and translation.
+
+    Parameters
+    ----------
+    pos : list or numpy.ndarray
+        shape of (3,) translation vector. or
+        4x4 homogeneous transformation matrix.
+        If the homogeneous transformation matrix is given,
+        `rot` will be overwritten.
+    rot : list or numpy.ndarray
+        we can take 3x3 rotation matrix or
+        [yaw, pitch, roll] or
+        quaternion [w, x, y, z] order
+    name : string or None
+        name of this coordinates
+    """
+
     def __init__(self,
                  pos=[0, 0, 0],
                  rot=np.eye(3),
                  name=None,
                  hook=None):
-        """Initialization of Coordinates
-
-        Parameters
-        ----------
-        pos : list or np.ndarray
-            shape of (3,) translation vector
-        rot : list or np.ndarray
-            we can take 3x3 rotation matrix or
-            [yaw, pitch, roll] or
-            quaternion [w, x, y, z] order
-        name : string or None
-            name of this coordinates
-        """
+        if (isinstance(pos, list) or isinstance(pos, np.ndarray)):
+            T = np.array(pos, dtype=np.float64)
+            if T.shape == (4, 4):
+                pos = T[:3, 3]
+                rot = T[:3, :3]
         self.rotation = rot
         self.translation = pos
         if name is None:

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -12,6 +12,24 @@ from skrobot.coordinates.math import rpy_matrix
 
 class TestCoordinates(unittest.TestCase):
 
+    def test___init__(self):
+        coord = make_coords(pos=[1, 1, 1])
+        testing.assert_array_equal(coord.translation, [1, 1, 1])
+
+        coord = make_coords(pos=[1, 0, 1], rot=[pi, 0, 0])
+        testing.assert_array_equal(coord.translation, [1, 0, 1])
+        testing.assert_almost_equal(coord.rotation,
+                                    [[-1, 0, 0], [0, -1, 0], [0, 0, 1]])
+
+        coord = make_coords([[-1, 0, 0, 1],
+                             [0, -1, 0, 0],
+                             [0, 0, 1, -1],
+                             [0, 0, 0, 1]],
+                            rot=[pi, 0, 0])
+        testing.assert_array_equal(coord.translation, [1, 0, -1])
+        testing.assert_almost_equal(coord.rotation,
+                                    [[-1, 0, 0], [0, -1, 0], [0, 0, 1]])
+
     def test_transform(self):
         coord = make_coords()
         coord.transform(make_coords(pos=[1, 2, 3]))


### PR DESCRIPTION
```
>>> import numpy as np
>>> from skrobot.coordinates import Coordinates


>>> T = [[-1, 0, 0, 1],
         [0, -1, 0, 0],
         [0, 0, 1, -1],
         [0, 0, 0, 1]]

>>> c = Coordinates(T)
>>> print(c.translation)
[ 1.  0. -1.]
>>> print(c.rotation)
[[-1.  0.  0.]
 [ 0. -1.  0.]
 [ 0.  0.  1.]]
```