### PR TITLE
Fixed bug due to docstring of rodrigues

### DIFF
--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -929,7 +929,7 @@ def rodrigues(axis, theta=None):
     See: `Rodrigues' rotation formula - Wikipedia
     <https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula>`_.
 
-    See: `Axis–angle representation - Wikipedia
+    See: `Axis-angle representation - Wikipedia
     <https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation>`_.
 
     Parameters


### PR DESCRIPTION
I got an error when trying to import skrobot with python2, so I fixed the dostring.
```
In[1]: import skrobot
File "/home/kosuke/scikit-robot/skrobot/coordinates/math.py", line 932
See: `Axis–angle representation - Wikipedia
^
SyntaxError: Non-ASCII character '\xe2' in file / home/kosuke/scikit-robot/skrobot/coordinates/math.py on line 933, but no encoding declared
see http: // python.org/dev/peps/pep-0263 / for details
```