### PR TITLE
[coordinates/geo] Add rotate_points

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -80,3 +80,15 @@ Quaternion Functions
    skrobot.coordinates.math.rotation_matrix_from_quat
    skrobot.coordinates.math.quaternion_from_axis_angle
    skrobot.coordinates.math.axis_angle_from_quaternion
+
+
+.. module:: skrobot.coordinates.geo
+
+Geometry functions
+------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   skrobot.coordinates.geo.rotate_points

--- a/skrobot/coordinates/__init__.py
+++ b/skrobot/coordinates/__init__.py
@@ -9,6 +9,7 @@ from .geo import _wrap_axis
 from .geo import midcoords
 from .geo import midpoint
 from .geo import orient_coords_to_axis
+from .geo import rotate_points
 
 from .math import matrix2quaternion
 from .math import quaternion2rpy

--- a/tests/skrobot_tests/coordinates_tests/test_geo.py
+++ b/tests/skrobot_tests/coordinates_tests/test_geo.py
@@ -1,10 +1,12 @@
 import unittest
 
+import numpy as np
 from numpy import pi
 from numpy import testing
 
 from skrobot.coordinates.geo import midcoords
 from skrobot.coordinates.geo import orient_coords_to_axis
+from skrobot.coordinates.geo import rotate_points
 from skrobot.coordinates import make_coords
 from skrobot.coordinates.math import matrix2quaternion
 
@@ -49,3 +51,16 @@ class TestGeo(unittest.TestCase):
         testing.assert_array_almost_equal(
             target_coords.rpy_angle()[0],
             [0, 0, pi])
+
+    def test_rotate_points(self):
+        points = np.array([1, 0, 0])
+        rot_points = rotate_points(points, [1, 0, 0], [0, 0, 1])
+        testing.assert_almost_equal(rot_points, [[0, 0, 1]])
+
+        points = np.array([[1, 0, 0]])
+        rot_points = rotate_points(points, [1, 0, 0], [0, 0, 1])
+        testing.assert_almost_equal(rot_points, [[0, 0, 1]])
+
+        points = np.array([[1, 0, 0]])
+        rot_points = rotate_points(points, [0, 0, 1], [0, 0, 1])
+        testing.assert_almost_equal(rot_points, [[1, 0, 0]])


### PR DESCRIPTION
Add `rotate_points` function to rotate given points.
```
import numpy as np

import skrobot
from skrobot.models import Sphere
from skrobot.coordinates import rotate_points


viewer = skrobot.viewers.TrimeshSceneViewer()

points = np.array([[1, 0, 0],
                   [1, 0, 0.1],
                   [1, 0, -0.1],
                   [1, 0.1, 0],
                   [1, 0.1, 0.1],
                   [1, 0.1, -0.1],
                   [1, -0.1, 0],
                   [1, -0.1, 0.1],
                   [1, -0.1, -0.1]])

rotated_points = rotate_points(points, [1, 0, 0], [0, 0, 1])
objs = []

obj = Sphere(1, color=(0, 0, 0, 100))
viewer.add(obj)
objs.append(obj)

for point in points:
    obj = Sphere(0.01, color=(255, 0, 0), pos=point)
    viewer.add(obj)
    objs.append(obj)

for point in rotated_points:
    obj = Sphere(0.01, color=(0, 255, 0), pos=point)
    viewer.add(obj)
    objs.append(obj)
viewer.show()
```

![image](https://user-images.githubusercontent.com/4690682/85371788-cd607400-b56b-11ea-9c57-5971f1626669.png)
