### PR TITLE
Add PointCloudLink

### DIFF
--- a/skrobot/model.py
+++ b/skrobot/model.py
@@ -604,18 +604,20 @@ class Link(CascadedCoords):
 
         Parameters
         ----------
-        mesh : None, trimesh.Trimesh, sequence of trimesh.Trimesh, or str
+        mesh : None, trimesh.Trimesh, sequence of trimesh.Trimesh,
+               trimesh.points.PointCloud or str
             A set of visual meshes for the link in the link frame.
         """
         if not (mesh is None
                 or isinstance(mesh, trimesh.Trimesh)
                 or (isinstance(mesh, collections.Sequence)
                     and all(isinstance(m, trimesh.Trimesh) for m in mesh))
+                or isinstance(mesh, trimesh.points.PointCloud)
                 or isinstance(mesh, str)):
             raise TypeError(
                 'mesh must be None, trimesh.Trimesh, sequence of '
-                'trimesh.Trimesh, or path of mesh file, but got: {}'.format(
-                    type(mesh)))
+                'trimesh.Trimesh, trimesh.points.PointCloud '
+                'or path of mesh file, but got: {}'.format(type(mesh)))
         if isinstance(mesh, str):
             mesh = trimesh.load(mesh)
         self._visual_mesh = mesh

--- a/skrobot/models/__init__.py
+++ b/skrobot/models/__init__.py
@@ -7,6 +7,7 @@ from skrobot.models.primitives import CameraMarker
 from skrobot.models.primitives import Cone
 from skrobot.models.primitives import Cylinder
 from skrobot.models.primitives import MeshLink
+from skrobot.models.primitives import PointCloudLink
 from skrobot.models.primitives import Sphere
 
 from skrobot.models.fetch import Fetch

--- a/skrobot/models/primitives.py
+++ b/skrobot/models/primitives.py
@@ -158,3 +158,16 @@ class MeshLink(model_module.Link):
 
         super(MeshLink, self).__init__(pos=pos, rot=rot, name=name)
         self.visual_mesh = visual_mesh
+
+
+class PointCloudLink(model_module.Link):
+
+    def __init__(self,
+                 visual_mesh=None,
+                 pos=(0, 0, 0), rot=np.eye(3), name=None):
+        if name is None:
+            name = 'pointcloudlink_{}'.format(
+                str(uuid.uuid1()).replace('-', '_'))
+
+        super(PointCloudLink, self).__init__(pos=pos, rot=rot, name=name)
+        self.visual_mesh = visual_mesh


### PR DESCRIPTION
I'm not sure if this is good, but I added PointCloudLink. We can add and delete on the viewer just like a mesh.
We no longer need to use `viewer.scene.add_geometry()` directly for point cloud visualization.
However, the variable name `visual_mesh` becomes uncomfortable...

This is sample point cloud data https://drive.google.com/drive/folders/1a1Jiz781z-c8qRcWVRQ0-_RGYG7Ra67x?usp=sharing
![pointcloudlink](https://user-images.githubusercontent.com/39142679/93641788-dd3b0780-fa37-11ea-89e9-59e4b4ded561.gif)
```
import time

import numpy as np
import skrobot
import trimesh

trimesh_pc = trimesh.PointCloud(np.load('points.npy'), np.load('colors.npy'))
pc = skrobot.models.PointCloudLink(trimesh_pc)

random_points = (np.random.random((100, 3)) - 0.5) * 0.3
random_trimesh_pc = trimesh.points.PointCloud(random_points)
random_pc = skrobot.models.PointCloudLink(random_trimesh_pc)

viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
viewer.add(pc)
viewer.show()
viewer.delete(pc)

for _ in range(3):
    viewer.add(pc)
    time.sleep(1)
    viewer.delete(pc)
    time.sleep(1)
    viewer.add(random_pc)
    time.sleep(1)
    viewer.delete(random_pc)
    time.sleep(1)
```