### PR TITLE
Fixed doc. deg -> rad

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -44,32 +44,32 @@ You have direct access to link and joint information.
 >>> robot_model.l_elbow_flex_joint.joint_angle()
 0.0
 
->>> robot_model.l_elbow_flex_joint.joint_angle(-90.0)
--90.0
+>>> robot_model.l_elbow_flex_joint.joint_angle(-0.5)
+-0.5
 
 >>> robot_model.l_elbow_flex_joint.joint_angle()
--90.0
+-0.5
 
 Inverse Kinematics
 ------------------
 
-First, set initial pose.
+First, set the initial pose. Note that the position of the prismatic joint is in [m] and angles of rotational joints are in [rad].
 
 >>> robot_model.torso_lift_joint.joint_angle(0.05)
->>> robot_model.l_shoulder_pan_joint.joint_angle(60)
->>> robot_model.l_shoulder_lift_joint.joint_angle(74)
->>> robot_model.l_upper_arm_roll_joint.joint_angle(70)
->>> robot_model.l_elbow_flex_joint.joint_angle(-120)
->>> robot_model.l_forearm_roll_joint.joint_angle(20)
->>> robot_model.l_wrist_flex_joint.joint_angle(-30)
->>> robot_model.l_wrist_roll_joint.joint_angle(180)
->>> robot_model.r_shoulder_pan_joint.joint_angle(-60)
->>> robot_model.r_shoulder_lift_joint.joint_angle(74)
->>> robot_model.r_upper_arm_roll_joint.joint_angle(-70)
->>> robot_model.r_elbow_flex_joint.joint_angle(-120)
->>> robot_model.r_forearm_roll_joint.joint_angle(-20)
->>> robot_model.r_wrist_flex_joint.joint_angle(-30)
->>> robot_model.r_wrist_roll_joint.joint_angle(180)
+>>> robot_model.l_shoulder_pan_joint.joint_angle(60 * 3.14/180.0)
+>>> robot_model.l_shoulder_lift_joint.joint_angle(74 * 3.14/180.0)
+>>> robot_model.l_upper_arm_roll_joint.joint_angle(70* 3.14/180.0)
+>>> robot_model.l_elbow_flex_joint.joint_angle(-120 * 3.14/180.0)
+>>> robot_model.l_forearm_roll_joint.joint_angle(20 * 3.14/180.0)
+>>> robot_model.l_wrist_flex_joint.joint_angle(-30 * 3.14/180.0)
+>>> robot_model.l_wrist_roll_joint.joint_angle(180 * 3.14/180.0)
+>>> robot_model.r_shoulder_pan_joint.joint_angle(-60 * 3.14/180.0)
+>>> robot_model.r_shoulder_lift_joint.joint_angle(74 * 3.14/180.0)
+>>> robot_model.r_upper_arm_roll_joint.joint_angle(-70 * 3.14/180.0)
+>>> robot_model.r_elbow_flex_joint.joint_angle(-120 * 3.14/180.0)
+>>> robot_model.r_forearm_roll_joint.joint_angle(-20 * 3.14/180.0)
+>>> robot_model.r_wrist_flex_joint.joint_angle(-30 * 3.14/180.0)
+>>> robot_model.r_wrist_roll_joint.joint_angle(180 * 3.14/180.0
 >>> robot_model.head_pan_joint.joint_angle(0)
 >>> robot_model.head_tilt_joint.joint_angle(0)
 
@@ -90,8 +90,7 @@ Next, set move_target and link_list
 
 Set target_coords.
 
->>> target_coords = rarm_end_coords.copy_worldcoords()
->>> target_coords.translate((0.3, 0, 0), 'local')
+>>> target_coords = skrobot.coordinates.Coordinates([0.5, -0.3, 0.7], [0, 0, 0])
 >>> robot_model.inverse_kinematics(
 ...     target_coords,
 ...     link_list=link_list,

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -69,7 +69,7 @@ First, set the initial pose. Note that the position of the prismatic joint is in
 >>> robot_model.r_elbow_flex_joint.joint_angle(-120 * 3.14/180.0)
 >>> robot_model.r_forearm_roll_joint.joint_angle(-20 * 3.14/180.0)
 >>> robot_model.r_wrist_flex_joint.joint_angle(-30 * 3.14/180.0)
->>> robot_model.r_wrist_roll_joint.joint_angle(180 * 3.14/180.0
+>>> robot_model.r_wrist_roll_joint.joint_angle(180 * 3.14/180.0)
 >>> robot_model.head_pan_joint.joint_angle(0)
 >>> robot_model.head_tilt_joint.joint_angle(0)
 


### PR DESCRIPTION
I corrected unit for angles from deg to rad 

In the examples in the documentation, angles are used with the unit of degree, but in the software internally radian is used. Most critically, the output of `robot_model.l_elbow_flex_joint.joint_angle(-90.0)` is -2.3213 thought it supporsed to be -90.0 if the documentation is right. 

In the succeeding section, after setting the angles in the example, PR2's state becomes like a person tied in a jail: 
![before](https://user-images.githubusercontent.com/38597814/98738377-f1bdcf80-23ea-11eb-81b0-302bfb21f6ba.png)

After fixing them to radian, the state becomes 
![after](https://user-images.githubusercontent.com/38597814/98738417-fe422800-23ea-11eb-8d87-6328e7732056.png)

Also, IK cannot be solved with the target coords in the example. So I fixed it to some solvable value. 
