### PR TITLE
Prevent overwriting existing assoc 

### DIFF
--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -1028,7 +1028,7 @@ class CascadedCoords(Coordinates):
 
         is_invalid_assoc = (child.parent is not None) and (not force)
         if is_invalid_assoc:
-            msg = "child already has a assoc relation with {0} \
+            msg = "child already has a assoc relation with {0}\
                     to overwrite this, please specify force=True".format(
                 child.parent)
             raise RuntimeError(msg)

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -983,9 +983,11 @@ class CascadedCoords(Coordinates):
                                         rot=self.rotation,
                                         hook=self.update)
 
-        if parent is not None:
-            parent.assoc(self)
         self.parent = parent
+        if parent is not None:
+            # Because we must self.parent = parent in this case,
+            # force=True is required.
+            parent.assoc(self, force=True)
 
     @property
     def descendants(self):
@@ -1035,27 +1037,17 @@ class CascadedCoords(Coordinates):
             if relative_coords is None:
                 relative_coords = self.worldcoords().transformation(
                     child.worldcoords())
-            child.obey(self)
+            child.parent = self
             child.newcoords(relative_coords)
             self._descendants.append(child)
             return child
-
-    def obey(self, mother):
-        if self.parent is not None:
-            self.parent.dissoc(self)
-        self.parent = mother
 
     def dissoc(self, child):
         if child in self.descendants:
             c = child.worldcoords().copy_coords()
             self._descendants.remove(child)
-            child.disobey(self)
+            child.parent = None
             child.newcoords(c)
-
-    def disobey(self, mother):
-        if self.parent == mother:
-            self.parent = None
-        return self.parent
 
     def newcoords(self, c, pos=None):
         super(CascadedCoords, self).newcoords(c, pos)

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -1024,8 +1024,8 @@ class CascadedCoords(Coordinates):
                 DeprecationWarning)
             relative_coords = kwargs['c']
 
-        isInvalidAssoc = (child.parent is not None) and (not force)
-        if isInvalidAssoc:
+        is_invalid_assoc = (child.parent is not None) and (not force)
+        if is_invalid_assoc:
             msg = "child already has a assoc relation with {0} \
                     to overwrite this, please specify force=True".format(
                 child.parent)

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -1009,7 +1009,7 @@ class CascadedCoords(Coordinates):
             child coordinate.
         relative_coords : None or Coordinates
             child coordinate's relative coordinate.
-        force : bool  
+        force : bool
             predicate for overwriting the existing assoc-relation
 
         Returns
@@ -1028,8 +1028,8 @@ class CascadedCoords(Coordinates):
         if isInvalidAssoc:
             msg = "child already has a assoc relation with {0} \
                     to overwrite this, please specify force=True".format(
-                        child.parent)
-            raise Exception(msg)
+                child.parent)
+            raise RuntimeError(msg)
 
         if not (child in self.descendants):
             if relative_coords is None:

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -1028,9 +1028,9 @@ class CascadedCoords(Coordinates):
 
         is_invalid_assoc = (child.parent is not None) and (not force)
         if is_invalid_assoc:
-            msg = "child already has a assoc relation with {0}\
-                    to overwrite this, please specify force=True".format(
-                child.parent)
+            msg = "child already has an assoc relation with '{0}'."\
+                " To overwrite this, please specify force=True."\
+                .format(child.parent.name)
             raise RuntimeError(msg)
 
         if not (child in self.descendants):

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -983,15 +983,15 @@ class CascadedCoords(Coordinates):
                                         rot=self.rotation,
                                         hook=self.update)
 
-        self.parent = parent
         if parent is not None:
-            self.parent.assoc(self)
+            parent.assoc(self)
+        self.parent = parent
 
     @property
     def descendants(self):
         return self._descendants
 
-    def assoc(self, child, relative_coords=None,
+    def assoc(self, child, relative_coords=None, force=False,
               **kwargs):
         """Associate child coords to this coordinate.
 
@@ -999,6 +999,9 @@ class CascadedCoords(Coordinates):
         of childcoord in the world coordinate system do not change.
         If `relative_coords` is specified, childcoord is assoced
         at translation and rotation of `relative_coords`.
+        By default, if child is already assoced to some other coords,
+        raise an exception. But if `force` is `True`, you can overwrite
+        the existing assoc relation.
 
         Parameters
         ----------
@@ -1006,6 +1009,8 @@ class CascadedCoords(Coordinates):
             child coordinate.
         relative_coords : None or Coordinates
             child coordinate's relative coordinate.
+        force : bool  
+            predicate for overwriting the existing assoc-relation
 
         Returns
         -------
@@ -1018,6 +1023,14 @@ class CascadedCoords(Coordinates):
                 'Please use `relative_coords` instead',
                 DeprecationWarning)
             relative_coords = kwargs['c']
+
+        isInvalidAssoc = (child.parent is not None) and (not force)
+        if isInvalidAssoc:
+            msg = "child already has a assoc relation with {0} \
+                    to overwrite this, please specify force=True".format(
+                        child.parent)
+            raise Exception(msg)
+
         if not (child in self.descendants):
             if relative_coords is None:
                 relative_coords = self.worldcoords().transformation(

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -374,7 +374,7 @@ class TestCascadedCoordinates(unittest.TestCase):
             [-0.07320508, -0.08660254, 0.05])
 
         c = make_cascoords()
-        with self.assertRaises(Exception):
+        with self.assertRaises(RuntimeError):
             c.assoc(b)
 
     def test_dissoc(self):

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -373,6 +373,10 @@ class TestCascadedCoordinates(unittest.TestCase):
             b.worldpos(),
             [-0.07320508, -0.08660254, 0.05])
 
+        c = make_cascoords()
+        with self.assertRaises(Exception):
+            c.assoc(b)
+
     def test_dissoc(self):
         a = make_cascoords(rot=rotation_matrix(pi / 3, 'x'),
                            pos=[0.1, 0, 0],


### PR DESCRIPTION
In the current implementation, assoc is overwritten when a new parent coords `assoc` the child. I think it is potentially cause for bug, because there is a risk that the user can unconsciously overwrite the existing assoc relation. 

Originally, obey function arrow overwriting, which is the expected roll of this function I guess.
```python
    def obey(self, mother):
        if self.parent is not None:
            self.parent.dissoc(self)
        self.parent = mother
```

To reflect my change, I deleted the obey function. Also, I found that `disobey` function can be removed and simplify the logic. In other words, `disobey` function is called only from `dissoc` and, if `child in self.descendatans`(in [dissoc](https://github.com/iory/scikit-robot/blob/c4349055f2d4b19c0d7fad3c19a13a807cf22154/skrobot/coordinates/base.py#L1035)) then always `self.parent == mother`(in [disobey](https://github.com/iory/scikit-robot/blob/c4349055f2d4b19c0d7fad3c19a13a807cf22154/skrobot/coordinates/base.py#L1042)), thus checking `if self.parent==mother` is meaningless. 
