### PR TITLE
Add cross product

### DIFF
--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -797,6 +797,24 @@ def outer_product_matrix(v):
                      [-v[1], v[0], 0]])
 
 
+def cross_product(a, b):
+    """Return cross product.
+
+    Parameters
+    ----------
+    a : numpy.ndarray
+        3-dimensional vector.
+    b : numpy.ndarray
+        3-dimensional vector.
+
+    Returns
+    -------
+    cross_prod : numpy.ndarray
+        calculated cross product
+    """
+    return np.dot(outer_product_matrix(a), b)
+
+
 def quaternion2rpy(q):
     """Returns Roll-pitch-yaw angles of a given quaternion.
 

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -7,6 +7,7 @@ from numpy import testing
 
 from skrobot.coordinates.math import _check_valid_rotation
 from skrobot.coordinates.math import angle_between_vectors
+from skrobot.coordinates.math import cross_product
 from skrobot.coordinates.math import matrix2quaternion
 from skrobot.coordinates.math import matrix_exponent
 from skrobot.coordinates.math import matrix_log
@@ -194,6 +195,11 @@ class TestMath(unittest.TestCase):
                                    np.array([[0.0, -3.0, 2.0],
                                              [3.0, 0.0, -1.0],
                                              [-2.0, 1.0, 0.0]]))
+
+    def test_cross_product(self):
+        testing.assert_array_equal(
+            cross_product([-1, 2, -3], [1, 2, 3]),
+            [12, 0, -4])
 
     def test_matrix_exponent(self):
         m1 = rotate_matrix(rotate_matrix(rotate_matrix(


### PR DESCRIPTION
```
from datetime import datetime

import numpy as np
from skrobot.coordinates.math import random_translation
from skrobot.coordinates.math import cross_product


N = 10000
for _ in range(N):
    a = random_translation()
    b = random_translation()
    c = np.cross(a, b)
    d = cross_product(a, b)
    if np.allclose(c, d) is False:
        raise


np.random.seed(0)
start = datetime.now()
for _ in range(N):
    a = random_translation()
    b = random_translation()
    c = np.cross(a, b)
end = datetime.now()
print(end - start)
# 0:00:00.361590

np.random.seed(0)
start = datetime.now()
for _ in range(N):
    a = random_translation()
    b = random_translation()
    d = cross_product(a, b)
end = datetime.now()
print(end - start)
# 0:00:00.071820
```
