### PR TITLE
Change hashing target

### DIFF
--- a/skrobot/model.py
+++ b/skrobot/model.py
@@ -645,11 +645,11 @@ class CascadedLink(CascadedCoords):
         relevance_predicate_table = {}
         for joint in self.joint_list:
             for link in self.link_list:
-                key = (joint.name, link.name)
+                key = (joint, link)
                 relevance_predicate_table[key] = False
 
         def inner_recursion(joint, link):
-            key = (joint.name, link.name)
+            key = (joint, link)
             relevance_predicate_table[key] = True
             is_no_childlen = len(link._child_links) == 0
             if is_no_childlen:
@@ -686,7 +686,7 @@ class CascadedLink(CascadedCoords):
         found_ancestor_link = (link is not None)
         assert found_ancestor_link, "input is not connected to the robot"
 
-        key = (joint.name, link.name)
+        key = (joint, link)
         if key in self._relevance_predicate_table:
             return self._relevance_predicate_table[key]
         return False


### PR DESCRIPTION
sorry, for making multiple PRs. In my previous PR https://github.com/iory/scikit-robot/pull/170, I applied hashing to `(joint.name, link.name)`. But, rather want to change it to `(joint, link)`.

For example, in the following example, the pefromance comparison result is 0.09 sec vs 0.15 sec, which means modified one leads to fast read and write of the table.

As stated in [here](https://stackoverflow.com/questions/11324271/what-is-the-default-hash-in-python) the default hash function for the object is computed for the id of the object, thus hashing is faster than for string. 

```python
import time
import skrobot
from skrobot.coordinates import CascadedCoords

robot_model = skrobot.models.urdf.RobotModelFromURDF(
    urdf_file=skrobot.data.pr2_urdfpath())

ts = time.time()
table = {}
for i in range(100):
    for joint in robot_model.joint_list:
        for link in robot_model.link_list:
            key = (joint, link)
            table[key] = False
            table[key]
print(time.time() - ts)

ts = time.time()
table = {}
for i in range(100):
    for joint in robot_model.joint_list:
        for link in robot_model.link_list:
            key = (joint.name, link.name)
            table[key] = False
            table[key]
print(time.time() - ts)
```