### PR TITLE
collision checker between swept sphers and sdf

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -13,3 +13,4 @@ API Reference
    functions
    interfaces
    sdfs
+   planner

--- a/docs/source/reference/planner.rst
+++ b/docs/source/reference/planner.rst
@@ -1,0 +1,30 @@
+Planning
+========
+
+Sdf-swept-sphere-based collision checker
+--------------------------------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   skrobot.planner.SweptSphereSdfCollisionChecker
+
+Swept sphere generater 
+----------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   skrobot.planner.swept_sphere.compute_swept_sphere
+
+Planner utils
+-------------
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   skrobot.planner.utils.set_robot_config
+   skrobot.planner.utils.get_robot_config
+   skrobot.planner.utils.forward_kinematics_multi

--- a/examples/swept_sphere.py
+++ b/examples/swept_sphere.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+import time
+
+import skrobot
+from skrobot.model import Box
+from skrobot.planner import SweptSphereSdfCollisionChecker
+from skrobot.planner.utils import set_robot_config
+
+try:
+    robot_model  # noqa
+except:  # noqa
+    robot_model = skrobot.models.PR2()
+    table = Box(extents=[0.7, 1.0, 0.05], with_sdf=True)
+    table.translate([0.8, 0.0, 0.655])
+    viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
+
+    link_idx_table = {}
+    for link_idx in range(len(robot_model.link_list)):
+        name = robot_model.link_list[link_idx].name
+        link_idx_table[name] = link_idx
+
+coll_link_names = [
+    "r_upper_arm_link",
+    "r_forearm_link",
+    "r_gripper_palm_link",
+    "r_gripper_r_finger_link",
+    "r_gripper_l_finger_link"]
+
+coll_link_list = [robot_model.link_list[link_idx_table[lname]]
+                  for lname in coll_link_names]
+
+move_link_names = [
+    "r_shoulder_pan_link",
+    "r_shoulder_lift_link",
+    "r_upper_arm_roll_link",
+    "r_elbow_flex_link",
+    "r_forearm_roll_link",
+    "r_wrist_flex_link",
+    "r_wrist_roll_link"]
+link_list = [robot_model.link_list[link_idx_table[lname]]
+             for lname in move_link_names]
+joint_list = [link.joint for link in link_list]
+
+sscc = SweptSphereSdfCollisionChecker(table.sdf, robot_model)
+for lname in coll_link_names:
+    link = robot_model.link_list[link_idx_table[lname]]
+    sscc.add_collision_link(link)
+
+with_base = True
+av = [0.4, 0.6] + [-0.7] * 5 + [0.1, 0.0, 0.3]
+set_robot_config(robot_model, joint_list, av, with_base=with_base)
+dists = sscc.update_color()
+sscc.add_coll_spheres_to_viewer(viewer)
+viewer.add(robot_model)
+viewer.add(table)
+viewer.show()
+
+print('==> Press [q] to close window')
+while not viewer.has_exit:
+    time.sleep(0.1)
+    viewer.redraw()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ python-fcl  # for collision check in trimesh module
 pyyaml
 quadprog
 scipy==1.2.1
+scikit-learn
 six
 trimesh>=3.5.20
 sphinx==1.8.2

--- a/skrobot/planner/__init__.py
+++ b/skrobot/planner/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa
+
+from skrobot.planner.collision_checker import SweptSphereSdfCollisionChecker

--- a/skrobot/planner/collision_checker.py
+++ b/skrobot/planner/collision_checker.py
@@ -1,0 +1,288 @@
+import copy
+
+import numpy as np
+import scipy
+import trimesh
+
+from skrobot.coordinates import CascadedCoords
+from skrobot.model.primitives import Sphere
+from skrobot.planner.swept_sphere import compute_swept_sphere
+from skrobot.planner.utils import forward_kinematics_multi
+from skrobot.planner.utils import get_robot_config
+
+
+class SweptSphereSdfCollisionChecker(object):
+    """Collision checker between swept spheres and sdf"""
+
+    def __init__(self, sdf, robot_model):
+        self.sdf = sdf
+        self.robot_model = robot_model
+
+        self.coll_link_name_list = []
+        self.coll_sphere_list = []
+        self.coll_radius_list = []
+        self.coll_coords_list = []
+        self.n_feature = 0
+
+        self.color_normal_sphere = [250, 250, 10, 200]
+        self.color_collision_sphere = [255, 0, 0, 200]
+
+    def add_coll_spheres_to_viewer(self, viewer):
+        """Add collision sheres to viewer
+
+        Parameters
+        ----------
+        viewer : skrobot.viewers._trimesh.TrimeshSceneViewer
+            viewer
+        Returns
+        ----------
+        """
+
+        for s in self.coll_sphere_list:
+            viewer.add(s)
+
+    def add_collision_link(self, coll_link):
+        """Add link for which collision with sdf is checked
+
+        The given `coll_link` will be approximated by swept-spheres
+        and these spheres will be added to collision sphere's list.
+
+        Parameters
+        ----------
+        coll_link : list[skrobot.model.Link]
+            link for which collision with sdf is checked
+        """
+
+        if coll_link.name in self.coll_link_name_list:
+            return
+        self.coll_link_name_list.append(coll_link)
+
+        col_mesh = coll_link.collision_mesh
+        assert type(col_mesh) == trimesh.base.Trimesh
+
+        centers, R = compute_swept_sphere(col_mesh)
+        sphere_list = []
+        coords_list = []
+        for center in centers:
+            link_pos = coll_link.copy_worldcoords()
+            coll_coords = CascadedCoords(
+                pos=link_pos.worldpos(),
+                rot=link_pos.worldrot())
+            coll_coords.translate(center)
+            coll_link.assoc(coll_coords)
+            coords_list.append(coll_coords)
+
+            # add sphere
+            sp = Sphere(radius=R, pos=coll_coords.worldpos(),
+                        color=self.color_normal_sphere)
+            coll_coords.assoc(sp)
+            sphere_list.append(sp)
+
+        self.coll_sphere_list.extend(sphere_list)
+        self.coll_coords_list.extend(coords_list)
+        self.coll_radius_list.extend([R] * len(sphere_list))
+        self.n_feature = len(self.coll_coords_list)
+
+    def update_color(self):  # for debugging
+        """Update the color of links under collision
+
+        This method checks the collision between the collision
+        spheres and registered sdf. If collision spheres are
+        found to be under collision, the color of the spheres
+        will be changed to `color_collision_sphere`.
+
+        Returns
+        -------
+        dists : numpy.array(n_sphere,)
+            array of the signed distances for each sphere against sdf.
+        """
+
+        joint_list = [j for j in self.robot_model.joint_list]
+        angle_vector = get_robot_config(
+            self.robot_model, joint_list, with_base=True)
+
+        dists, _ = self.compute_batch_sd_vals(
+            joint_list, np.array([angle_vector]),
+            with_base=True, with_jacobian=False)
+        idxes_collide = np.where(dists < 0)[0]
+
+        for idx in range(self.n_feature):
+            sphere = self.coll_sphere_list[idx]
+            n_facet = len(sphere._visual_mesh.visual.face_colors)
+
+            color = self.color_collision_sphere if idx in idxes_collide \
+                else self.color_normal_sphere
+            sphere._visual_mesh.visual.face_colors = np.array(
+                [color] * n_facet)
+        return dists
+
+    def compute_batch_sd_vals(self,
+                              joint_list,
+                              angle_vector_seq,
+                              with_base=False,
+                              with_jacobian=False):
+        """Compute sd signed distances of collision spheres
+
+        This method is the core of this class. We assume that this
+        method is mainly called from a trajecotyr optimizer or
+        path planner.
+
+        Let :math:`n_{wp}` be the number of way-points of a trajectory.
+        Let :math:`n_{f}` be the number of collision feature points on
+        the robot links.
+
+        Let :math:`f_{i, j} : \\mathbb{R}^{n_{dof}}
+        \\ni q \\mapsto x \\in \\mathbb{R}^3`
+        be the forward kinematics of collision features point :math:`j`
+        at waypoint :math:`i` where :math:`q` is the angle vector and
+        :math:`n_{dof}` is the dimension of the angle vector.
+
+        Let :math:`c : \\mathbb{R}^3 \\ni x \\mapsto sd \\in \\mathbb{R}`
+        be the signd distance function.
+
+        Then, this fucntion is defined as
+        :math:`F : \\mathbb{R}^{n_{wp} n_{dof}} \\ni \\xi \\mapsto
+        [
+        [f_{1, 1}(q_1), \\ldots, f_{1, n_{f}}(q_1)]^T,
+        \\ldots,
+        [f_{n_{wp}, 1}(q_{n_{wp}}),\\ldots,f_{n_{wp}, n_{f}}(q_{n_{wp}})]^T
+        ]^T
+        \\in \\mathbb{R}^{n_{wp} n_{f}}`
+        where :math:`\\xi = [q_1^T, \\ldots, q_{n_{wp}}^T]^T` be
+        the angle vector sequence of the trajectory.
+        The corresponding jacobian is defined as
+        :math:`\\frac{\\partial F}{\\partial \\xi}`.
+
+        Parameters
+        ----------
+        joint_list : list[skrobot.model.Joint]
+            joint list to be set
+        angle_vector_seq : numpy.ndarray[float](n_wp, n_dof)
+            angle vector sequence.
+        with_base : bool
+            hoge
+        with_jacobian : bool
+            if `True`, jacobian is copmuted at the same time.
+        Returns
+        -------
+        sd_vals : numpy.ndarray[float](n_wp * n_feature,)
+            signed distnaces for all feature points through the trajectory
+        sd_vals_jacobi : numpy.ndarray[float](n_wp * n_feature, n_wp * n_dof)
+            jacobain of sd_vals with respect to DOF (i.e. n_wp * n_dof) of the
+            trajectory
+        """
+
+        P, J = self._coll_batch_forward_kinematics(
+            joint_list, angle_vector_seq,
+            with_base=with_base,
+            with_jacobian=with_jacobian)
+        sd_vals, sd_vals_jacobi = self._compute_batch_sd_vals_internal(P, J)
+        return sd_vals, sd_vals_jacobi
+
+    def _compute_batch_sd_vals_internal(self, pts_batch, jac_batch):
+        """This function must be implemented considering performance
+
+        Parameters
+        ----------
+        pts_batch : numpy.ndarray(n_wp, n_feature, 3)
+            all feature points in a trajectory.
+        jac_batch : Union[numpy.ndarray(n_wp, n_feature, 3, n_dof), None]
+            jacobians for all feature points in a trajectory. If set to
+            None, jacobian for `pts_batch` will not be computed.
+
+        Returns
+        -------
+        sd_vals_batch_flatten_sphere :
+        numpy.ndarray[float](n_wp * n_feature,)
+            signed distnaces for all feature points through the trajectory
+        jac_whole : numpy.ndarray[float](n_wp * n_feature, n_wp * n_dof)
+            jacobain of sd_vals with respect to DOF (i.e. n_wp * n_dof) of the
+            trajectory. If `jac_batch = None`, `jac_whole = None`.
+        """
+
+        with_jacobian = (jac_batch is not None)
+
+        n_wp, n_feature, _ = pts_batch.shape
+        n_total_feature = n_wp * n_feature
+
+        # flattening (n_wp, n_feature, 3) -> (n_wp * n_feature, 3)
+        # is necessary to copmute sdf() without using loop.
+        pts_batch_flatten = pts_batch.reshape((n_total_feature, 3))
+        sd_vals_batch_flatten = self.sdf(pts_batch_flatten)
+
+        # we must convert it to sphere's signed distnace
+        radius_arr_traj = np.array(self.coll_radius_list * n_wp)
+        sd_vals_batch_flatten_sphere = sd_vals_batch_flatten - radius_arr_traj
+
+        if not with_jacobian:
+            return sd_vals_batch_flatten_sphere, None
+
+        _, _, _, n_dof = jac_batch.shape
+        # numerically grad array of sdf
+        eps = 1e-7
+        sd_val_grads_batch_flatten = np.zeros((n_total_feature, 3))
+        for idx in range(3):
+            pts_batch_flatten_plus = copy.copy(pts_batch_flatten)
+            pts_batch_flatten_plus[:, idx] += eps
+            sd_vals_batch_flatten_plus = self.sdf(pts_batch_flatten_plus)
+            diff = sd_vals_batch_flatten_plus - sd_vals_batch_flatten
+            sd_val_grads_batch_flatten[:, idx] = diff / eps
+        sd_val_grads_batch = sd_val_grads_batch_flatten.reshape(
+            n_wp, n_feature, 3)
+
+        # (n_wp, n_feature, 3) x (n_wp, n_feature, 3, n_dof)
+        # => (n_wp, n_feature, n_dof)
+        jac_whole_batch = np.einsum(
+            'ijk,ijkl->ijl', sd_val_grads_batch, jac_batch)
+
+        jac_whole = scipy.linalg.block_diag(*list(jac_whole_batch))
+        return sd_vals_batch_flatten_sphere, jac_whole
+
+    def _coll_batch_forward_kinematics(self,
+                                       joint_list,
+                                       angle_vector_seq,
+                                       with_base,
+                                       with_jacobian):
+        """This function must be implemented considering performance
+
+        Parameters
+        ----------
+        joint_list : list[skrobot.model.Joint]
+            joint list to be considered in the forward kinematics.
+        angle_vector_seq : numpy.ndarray[float](n_wp, n_dof)
+            angle vector sequence.
+        with_base : bool
+            hoge
+        with_jacobian : bool
+            if `True`, jacobian is copmuted at the same time.
+        Returns
+        -------
+        pts_batch : numpy.ndarray(n_wp, n_feature, 3)
+            all feature points in a trajectory.
+        jac_batch : numpy.ndarray(n_wp, n_feature, 3, n_dof)
+            jacobians for all feature points in a trajectory.
+        """
+
+        if isinstance(angle_vector_seq, list):
+            angle_vector_seq = np.array(angle_vector_seq)
+
+        n_wp, n_dof = angle_vector_seq.shape
+        pts_batch = np.zeros((n_wp, self.n_feature, 3))
+
+        if with_jacobian:
+            jac_batch = np.zeros((n_wp, self.n_feature, 3, n_dof))
+        else:
+            jac_batch = None
+
+        for i in range(n_wp):
+            av = angle_vector_seq[i]
+            pts_arr, jac_arr = forward_kinematics_multi(
+                self.robot_model, joint_list, av, self.coll_coords_list,
+                with_rot=False, with_base=with_base,
+                with_jacobian=with_jacobian)
+
+            pts_batch[i, :, :] = pts_arr
+            if with_jacobian:
+                jac_batch[i, :, :, :] = jac_arr
+
+        return pts_batch, jac_batch

--- a/skrobot/planner/swept_sphere.py
+++ b/skrobot/planner/swept_sphere.py
@@ -1,0 +1,135 @@
+import numpy as np
+from sklearn.covariance import EmpiricalCovariance
+
+
+def compute_swept_sphere(collision_mesh,
+                         n_sphere=None,
+                         tol=0.1):
+    """Compute swept spheres approximating a mesh
+
+    Parameters
+    ----------
+    collision_mesh : trimesh.Trimesh
+        mesh which swept spheres are computed for
+    n_sphere : int or None
+        number of sphere to approximate the mesh. If it's set to `None`,
+        the number of sphere is automatically determined.
+    tol : float
+        tolerance determins how much mesh jutting-out from the swept-spheres
+        are accepted. Let `max_jut` be the maximum jut-distance. Then the
+        setting `tol` enforces `max_jut / radius < max_jut`. If some integer
+        is set to `n_sphere`, `tol` does not affects the result.
+
+    Returns
+    -------
+    centers_original_space : numpy.ndarray[float](n_sphere, 3)
+        center of the approximating spheres in the space where the
+        mesh vertices are defined.
+
+    radius : float
+        radius of approximating sphers.
+    """
+
+    verts = collision_mesh.vertices
+
+    # first we compute the principal directions of the vertices.
+    mean = np.mean(verts, axis=0)
+    verts_slided = verts - mean[None, :]
+    cov = EmpiricalCovariance().fit(verts_slided)
+    eig_vals, basis_tf_mat = np.linalg.eig(cov.covariance_)
+    principle_axis = np.argmax(eig_vals)
+
+    # and map to the space spanned by the principle vectors.
+    # Also, compute the inverse map, to re-map them to the original
+    # splace in the end of this function.
+    verts_mapped = verts_slided.dot(basis_tf_mat)
+
+    def inverse_map(verts):
+        return verts.dot(basis_tf_mat.T) + mean[None, :]
+
+    # get the indexes of the place axis
+    if principle_axis == 0:
+        plane_axes = [1, 2]
+    elif principle_axis == 1:
+        plane_axes = [2, 0]
+    else:
+        plane_axes = [0, 1]
+
+    # then compute the bounding-circle for vertices projected
+    # to the plane.
+    def determine_radius(verts_2d_projected):
+        X, Y = verts_2d_projected.T
+        radius_vec = np.sqrt(X**2 + Y**2)
+        radius = np.max(radius_vec)
+        return radius
+
+    margin_factor = 1.01
+    radius = determine_radius(verts_mapped[:, plane_axes]) * margin_factor
+
+    # compute the maximum and minimum heights (h_center_max, h_center_min)
+    # of the sphere centers. Here, hight is defined in the principle direction.
+    squared_radius_arr = np.sum(verts_mapped[:, plane_axes] ** 2, axis=1)
+    h_center_arr = verts_mapped[:, principle_axis]
+
+    h_vert_max = np.max(verts_mapped[:, principle_axis])
+    h_vert_min = np.min(verts_mapped[:, principle_axis])
+
+    def get_h_center_max():
+        def cond_all_inside_positive(h_center_max):
+            sphere_heights = h_center_max +\
+                np.sqrt(radius**2 - squared_radius_arr)
+            return np.all(sphere_heights > h_center_arr)
+        # get first index that satisfies the condition
+        h_cand_list = np.linspace(0, h_vert_max, 30)
+        idx = np.where([cond_all_inside_positive(h)
+                        for h in h_cand_list])[0][0]
+        h_center_max = h_cand_list[idx]
+        return h_center_max
+
+    def get_h_center_min():
+        def cond_all_inside_negative(h_center_min):
+            sphere_heights = h_center_min - \
+                np.sqrt(radius**2 - squared_radius_arr)
+            return np.all(h_center_arr > sphere_heights)
+        # get first index that satisfies the condition
+        h_cand_list = np.linspace(0, h_vert_min, 30)
+        idx = np.where([cond_all_inside_negative(h)
+                        for h in h_cand_list])[0][0]
+        h_center_min = h_cand_list[idx]
+        return h_center_min
+
+    h_center_max = get_h_center_max()
+    h_center_min = get_h_center_min()
+
+    # using h_center_min and h_center_max, generate center points in
+    # the mapped space.
+    def compute_center_pts_mapped_space(n_sphere):
+        h_centers = np.linspace(h_center_min, h_center_max, n_sphere)
+        centers = np.zeros((n_sphere, 3))
+        centers[:, principle_axis] = h_centers
+        return centers
+
+    auto_determine_n_sphere = (n_sphere is None)
+    if auto_determine_n_sphere:
+        n_sphere = 1
+        while True:  # iterate until the approximation satisfies tolerance
+            centers_pts_mapped_space =\
+                compute_center_pts_mapped_space(n_sphere)
+            dists_foreach_sphere = np.array([
+                np.sqrt(np.sum((verts_mapped - c[None, :])**2, axis=1))
+                for c in centers_pts_mapped_space])
+            # verts distance to the approximating spheres
+            # if this distance is positive value, the vertex is jutting-out
+            # from the swept-sphere.
+            jut_dists = np.min(dists_foreach_sphere, axis=0) - radius
+            max_jut = np.max(jut_dists)
+            err_ratio = max_jut / radius
+            if err_ratio < tol:
+                break
+            n_sphere += 1
+    else:
+        centers_pts_mapped_space = compute_center_pts_mapped_space(n_sphere)
+
+    # map all centers to the original space
+    centers_original_space = inverse_map(centers_pts_mapped_space)
+    return centers_original_space, radius

--- a/skrobot/planner/utils.py
+++ b/skrobot/planner/utils.py
@@ -1,0 +1,193 @@
+import numpy as np
+
+from skrobot.coordinates import CascadedCoords
+from skrobot.coordinates import Coordinates
+from skrobot.coordinates.math import rpy_angle
+from skrobot.coordinates.math import rpy_matrix
+
+
+def set_robot_config(robot_model, joint_list, av, with_base=False):
+    """A utility function for setting robot state
+
+    Parameters
+    ----------
+    robot_model : skrobot.model.CascadedLink
+        robot model
+    joint_list : list[skrobot.model.Joint]
+        joint list to be set
+    av : numpy.ndarray[float](n_dof,)
+        angle vector which has n_dof dims.
+    with_base : bool
+        If `with_base=False`, `n_dof` is the number of joints `n_joint`,
+        but if `with_base=True`, `n_dof = n_joint + 3`.
+    """
+
+    if with_base:
+        assert len(joint_list) + 3 == len(av)
+    else:
+        assert len(joint_list) == len(av)
+
+    if with_base:
+        av_joint, av_base = av[:-3], av[-3:]
+        x, y, theta = av_base
+        co = Coordinates(pos=[x, y, 0.0], rot=rpy_matrix(theta, 0.0, 0.0))
+        robot_model.newcoords(co)
+    else:
+        av_joint = av
+
+    for joint, angle in zip(joint_list, av_joint):
+        joint.joint_angle(angle)
+
+
+def get_robot_config(robot_model, joint_list, with_base=False):
+    """A utility function for getting robot state
+
+    Parameters
+    ----------
+    robot_model : skrobot.model.CascadedLink
+        robot model
+    joint_list : list[Joint]
+        joint list of which you want to know the angles
+    with_base : bool
+        If set to `True`, base position is also computed.
+
+    Returns
+    -------
+    av_whole (or av_joint) : numpy.array(n_dof,)
+        angle vector. If `with_base=False`, `n_dof` is the number of
+        joints `n_joint`, but if `with_base=True`, `n_dof = n_joint + 3`.
+    """
+    av_joint = np.array([j.joint_angle() for j in joint_list])
+    if with_base:
+        x, y, _ = robot_model.translation
+        rpy = rpy_angle(robot_model.rotation)[0]
+        theta = rpy[0]
+        av_whole = np.hstack((av_joint, [x, y, theta]))
+        return av_whole
+    else:
+        return av_joint
+
+
+def forward_kinematics_multi(robot_model,
+                             joint_list,
+                             av,
+                             move_target_list,
+                             with_rot,
+                             with_base,
+                             with_jacobian):
+    """Compute fk for multiple feature points
+
+    Parameters
+    ----------
+    robot_model : skrobot.model.CascadedLink
+        robot model.
+    joint_list : list[skrobot.model.Joint]
+        joint to be controlled
+    av : numpy.ndarray(n_dof,)
+        angle vector.
+    move_target_list : list[skrobot.coordinates.CascadedCoords]
+        the list has `n_feature` elements. Each element is the
+        coordinate of the features points.
+    with_rot : bool
+        If set to `True`, 7(3 + 4) dim pose-fk is also computed.
+        Otherwise, 3 dim point-fk is computed.
+    with_base : bool
+        If `with_base=False`, `n_dof` is the number of joints `n_joint`,
+        but if `with_base=True`, `n_dof = n_joint + 3`.
+
+    Returns
+    -------
+    pose_arr : numpy.ndarray(n_feature, dim_pose)
+        array of pose of each feature points.
+        `dim_pose=7' if `with_rot=True`. Otherwise, `dim_pose=3`.
+    jac_arr : numpy.ndarray(n_feature, dim_pose, n_dof)
+        array of jacobian of each feature points.
+
+    """
+
+    set_robot_config(robot_model, joint_list, av, with_base)
+    n_feature = len(move_target_list)
+    n_dof = len(av)
+    dim_pose = 3 + (4 if with_rot else 0)
+
+    pose_arr = np.zeros((n_feature, dim_pose))
+    if with_jacobian:
+        jac_arr = np.zeros((n_feature, dim_pose, n_dof))
+    else:
+        jac_arr = None
+
+    for i in range(n_feature):
+        pose, jac = _forward_kinematics(
+            robot_model, joint_list, move_target_list[i],
+            with_rot, with_base, with_jacobian)
+        pose_arr[i, :] = pose
+        if with_jacobian:
+            jac_arr[i, :, :] = jac
+    return pose_arr, jac_arr
+
+
+def _forward_kinematics(robot_model,
+                        joint_list,
+                        move_target,
+                        with_rot,
+                        with_base,
+                        with_jacobian):
+
+    link_list = [joint.child_link for joint in joint_list]
+
+    ef_pos_wrt_world = move_target.worldpos()
+    ef_quat_wrt_world = move_target.worldcoords().quaternion
+    world_coordinate = CascadedCoords()
+
+    def quaternion_kinematic_matrix(q):
+        # dq/dt = 0.5 * mat * omega
+        q1, q2, q3, q4 = q
+        mat = np.array([
+            [-q2, -q3, -q4],
+            [q1, q4, -q3],
+            [-q4, q1, q2],
+            [q3, -q2, q1]])
+        return mat * 0.5
+
+    def compute_jacobian_wrt_world():
+        J_joint = robot_model.calc_jacobian_from_link_list(
+            [move_target],
+            link_list,
+            transform_coords=world_coordinate,
+            rotation_axis=with_rot)
+
+        if with_rot:
+            kine_mat = quaternion_kinematic_matrix(ef_quat_wrt_world)
+            J_joint_rot_geometric = J_joint[3:, :]  # "geometric" jacobian
+            J_joint_quat = kine_mat.dot(J_joint_rot_geometric)
+            J_joint = np.vstack((J_joint[:3, :], J_joint_quat))
+
+        if with_base:  # cat base jacobian if base is considered
+            # please follow computation carefully
+            base_pos_wrt_world = robot_model.worldpos()
+            ef_pos_wrt_world = move_target.worldpos()
+            ef_pos_wrt_base = ef_pos_wrt_world - base_pos_wrt_world
+            x, y = ef_pos_wrt_base[0], ef_pos_wrt_base[1]
+            J_base_pos = np.array([[1, 0, -y], [0, 1, x], [0, 0, 0]])
+
+            if with_rot:
+                J_base_quat_xy = np.zeros((4, 2))
+                rot_axis = np.array([0, 0, 1.0])
+                J_base_quat_theta = kine_mat.dot(rot_axis).reshape(4, 1)
+                J_base_quat = np.hstack((J_base_quat_xy, J_base_quat_theta))
+                J_base = np.vstack((J_base_pos, J_base_quat))
+            else:
+                J_base = J_base_pos
+            J_whole = np.hstack((J_joint, J_base))
+        else:
+            J_whole = J_joint
+        return J_whole
+
+    pose = np.hstack((ef_pos_wrt_world, ef_quat_wrt_world)) if with_rot \
+        else ef_pos_wrt_world
+
+    if with_jacobian:
+        J = compute_jacobian_wrt_world()
+        return pose, J
+    else:
+        return pose, None

--- a/tests/skrobot_tests/planner_tests/test_collision_checker.py
+++ b/tests/skrobot_tests/planner_tests/test_collision_checker.py
@@ -1,0 +1,120 @@
+import copy
+import unittest
+
+import numpy as np
+from numpy import testing
+
+import skrobot
+from skrobot.model.primitives import Box
+from skrobot.planner import SweptSphereSdfCollisionChecker
+from skrobot.planner.utils import set_robot_config
+
+
+def jacobian_test_util(func, x0, decimal=5):
+    f0, jac = func(x0)
+    n_dim = len(x0)
+
+    eps = 1e-7
+    jac_numerical = np.zeros(jac.shape)
+    for idx in range(n_dim):
+        x1 = copy.copy(x0)
+        x1[idx] += eps
+        f1, _ = func(x1)
+        jac_numerical[:, idx] = (f1 - f0) / eps
+
+    testing.assert_almost_equal(jac, jac_numerical, decimal=decimal)
+
+
+class TestCollisionChecker(unittest.TestCase):
+
+    @classmethod
+    def setup_class(cls):
+        robot_model = skrobot.models.PR2()
+        robot_model.init_pose()
+
+        table = Box(extents=[0.7, 1.0, 0.05], with_sdf=True)
+        table.translate([0.8, 0.0, 0.655])
+
+        link_idx_table = {}
+        for link_idx in range(len(robot_model.link_list)):
+            name = robot_model.link_list[link_idx].name
+            link_idx_table[name] = link_idx
+
+        coll_link_names = ["r_upper_arm_link", "r_forearm_link",
+                           "r_gripper_palm_link", "r_gripper_r_finger_link",
+                           "r_gripper_l_finger_link"]
+
+        coll_link_list = [robot_model.link_list[link_idx_table[lname]]
+                          for lname in coll_link_names]
+
+        link_names = ["r_shoulder_pan_link", "r_shoulder_lift_link",
+                      "r_upper_arm_roll_link", "r_elbow_flex_link",
+                      "r_forearm_roll_link", "r_wrist_flex_link",
+                      "r_wrist_roll_link"]
+
+        link_list = [robot_model.link_list[link_idx_table[lname]]
+                     for lname in link_names]
+        joint_list = [l.joint for l in link_list]
+
+        coll_checker = SweptSphereSdfCollisionChecker(table.sdf, robot_model)
+        for link in coll_link_list:
+            coll_checker.add_collision_link(link)
+
+        cls.robot_model = robot_model
+        cls.coll_checker = coll_checker
+        cls.joint_list = joint_list
+
+    def test_update_color(self):
+        robot_model = self.robot_model
+        av = np.array([0.4, 0.6] + [-0.7] * 5)
+        av_with_base = np.hstack((av, [0.1, 0.0, 0.3]))
+        joint_list = self.joint_list
+        set_robot_config(robot_model, joint_list, av_with_base, with_base=True)
+
+        dists_ground_truth = np.array([
+            0.15608007, 0.06519901, -0.01225516, -0.04206324, -0.01748433,
+            -0.01476751, -0.01205069, -0.00933387, -0.00681298, -0.03081892,
+            -0.02670986, 0.02851278, 0.01134911])
+        dists = self.coll_checker.update_color()
+        testing.assert_almost_equal(dists, dists_ground_truth)
+
+        idxes_colliding = np.where(dists < 0)[0]
+        color_collide = self.coll_checker.color_collision_sphere
+        for idx in idxes_colliding:
+            sphere = self.coll_checker.coll_sphere_list[idx]
+            color_actual = sphere._visual_mesh.visual.face_colors[0]
+            testing.assert_equal(color_actual, color_collide)
+
+    def test_coll_batch_forward_kinematics(self):
+        robot_model = self.robot_model
+        av = np.array([0.4, 0.6] + [-0.7] * 5)
+        av_with_base = np.hstack((av, [0.1, 0.0, 0.3]))
+        joint_list = self.joint_list
+        set_robot_config(robot_model, joint_list, av_with_base, with_base=True)
+
+        n_wp = 1
+        n_feature = self.coll_checker.n_feature
+
+        def collision_fk(av, with_base):
+            # this function wraps _coll_batch_forward_kinematics so that it's
+            # output will be scipy-style (f, jac)
+            n_dof = len(av)
+            f_tmp, jac_tmp = self.coll_checker._coll_batch_forward_kinematics(
+                joint_list, [av], with_base=with_base, with_jacobian=True)
+            f = f_tmp.flatten()
+            jac = jac_tmp.reshape((n_wp * n_feature * 3, n_dof))
+            return f, jac
+
+        jacobian_test_util(lambda av: collision_fk(av, False), av)
+        jacobian_test_util(lambda av: collision_fk(av, True), av_with_base)
+
+    def test_compute_batch_sd_vals(self):
+        robot_model = self.robot_model
+        joint_list = self.joint_list
+        av = np.array([0.4, 0.6] + [-0.7] * 5)
+        set_robot_config(robot_model, joint_list, av)
+
+        def func(av):
+            return self.coll_checker.compute_batch_sd_vals(
+                joint_list, [av], with_jacobian=True)
+        jacobian_test_util(func, av)

--- a/tests/skrobot_tests/planner_tests/test_swept_sphere.py
+++ b/tests/skrobot_tests/planner_tests/test_swept_sphere.py
@@ -1,0 +1,42 @@
+import unittest
+
+import numpy as np
+import trimesh
+
+import skrobot
+from skrobot.planner.swept_sphere import compute_swept_sphere
+
+
+class TestSweptSphere(unittest.TestCase):
+
+    @classmethod
+    def setup_class(cls):
+        robot_model = skrobot.models.PR2()
+        cls.mesh1 = robot_model.r_gripper_palm_link._visual_mesh[0]
+
+        objfile_path = skrobot.data.bunny_objpath()
+        bunnymesh = trimesh.load_mesh(objfile_path)
+        cls.mesh2 = bunnymesh
+
+    def test_copmute_swept_sphere(self):
+
+        def approximation_accuracy_test(mesh, tol):
+            center_pts, radius = compute_swept_sphere(mesh, tol=tol)
+
+            def swept_sphere_sdf(pts):
+                dists_list = []
+                for c in center_pts:
+                    dists = np.sqrt(np.sum((pts - c[None, :])**2, axis=1))
+                    dists_list.append(dists)
+                dists_arr = np.array(dists_list)
+                # union sdf of all spheres
+                signed_dists = np.min(dists_arr, axis=0) - radius
+                return signed_dists
+
+            jut_arr = swept_sphere_sdf(mesh.vertices)
+            max_jut = np.max(jut_arr)
+            self.assertLess(max_jut / radius, tol)
+
+        tol = 1e-3
+        approximation_accuracy_test(self.mesh1, tol)
+        approximation_accuracy_test(self.mesh2, tol)

--- a/tests/skrobot_tests/planner_tests/test_utils.py
+++ b/tests/skrobot_tests/planner_tests/test_utils.py
@@ -1,0 +1,125 @@
+import copy
+import unittest
+
+import numpy as np
+from numpy import testing
+
+import skrobot
+from skrobot.planner.utils import forward_kinematics_multi
+from skrobot.planner.utils import get_robot_config
+from skrobot.planner.utils import set_robot_config
+
+
+def jacobian_test_util(func, x0, decimal=5):
+    # test jacobian by comparing the resulting and numerical jacobian
+    f0, jac = func(x0)
+    n_dim = len(x0)
+
+    eps = 1e-7
+    jac_numerical = np.zeros(jac.shape)
+    for idx in range(n_dim):
+        x1 = copy.copy(x0)
+        x1[idx] += eps
+        f1, _ = func(x1)
+        jac_numerical[:, idx] = (f1 - f0) / eps
+    testing.assert_almost_equal(jac, jac_numerical, decimal=decimal)
+
+
+class TestPlannerUtils(unittest.TestCase):
+
+    @classmethod
+    def setup_class(cls):
+        robot_model = skrobot.models.PR2()
+
+        link_idx_table = {}
+        for link_idx in range(len(robot_model.link_list)):
+            name = robot_model.link_list[link_idx].name
+            link_idx_table[name] = link_idx
+
+        link_names = ["r_shoulder_pan_link", "r_shoulder_lift_link",
+                      "r_upper_arm_roll_link", "r_elbow_flex_link",
+                      "r_forearm_roll_link", "r_wrist_flex_link",
+                      "r_wrist_roll_link"]
+
+        link_list = [robot_model.link_list[link_idx_table[lname]]
+                     for lname in link_names]
+        joint_list = [l.joint for l in link_list]
+
+        cls.robot_model = robot_model
+        cls.link_list = link_list
+        cls.joint_list = joint_list
+
+        av = np.array([0.4, 0.6] + [-0.7] * 5)
+        cls.av = np.array([0.4, 0.6] + [-0.7] * 5)
+        cls.av_with_base = np.hstack((av, [0.1, 0.0, 0.3]))
+
+    def test_set_and_get_robot_config(self):
+        robot_model = self.robot_model
+        joint_list = self.joint_list
+        av = self.av
+        av_with_base = self.av_with_base
+
+        with self.assertRaises(AssertionError):
+            set_robot_config(robot_model, joint_list, av, with_base=True)
+        set_robot_config(robot_model, joint_list, av, with_base=False)
+
+        with self.assertRaises(AssertionError):
+            set_robot_config(robot_model, joint_list,
+                             av_with_base, with_base=False)
+        set_robot_config(robot_model, joint_list, av_with_base, with_base=True)
+
+        testing.assert_equal(
+            av,
+            get_robot_config(robot_model, joint_list, with_base=False)
+        )
+        testing.assert_equal(
+            av_with_base,
+            get_robot_config(robot_model, joint_list, with_base=True)
+        )
+
+    def test_forward_kinematics_multi(self):
+        robot_model = self.robot_model
+        link_list = self.link_list
+        joint_list = self.joint_list
+        av_init = self.av
+        av_with_base_init = self.av_with_base
+
+        move_target_list = link_list
+        n_feature = len(move_target_list)
+
+        def fk_fun_simple(av, with_base, with_rot, with_jacobian):
+            pose_arr, jac_arr = forward_kinematics_multi(
+                robot_model, joint_list, av, move_target_list,
+                with_rot, with_base, with_jacobian)
+            return pose_arr, jac_arr
+
+        # checking returning types and shapes:
+        for with_base, av in [(False, av_init), (True, av_with_base_init)]:
+            for with_rot, n_pose in [(False, 3), (True, 3 + 4)]:
+                for with_jacobian in [False, True]:
+                    p, jac = fk_fun_simple(
+                        av, with_base, with_rot, with_jacobian)
+                    self.assertEqual(p.shape, (n_feature, n_pose))
+                    n_dof = len(av)
+                    if with_jacobian:
+                        self.assertEqual(jac.shape, (n_feature, n_pose, n_dof))
+                    else:
+                        self.assertEqual(jac, None)
+
+        def fk_jac_test(av, with_base, with_rot):
+            n_dof = len(av)
+            pose_arr, jac_arr = fk_fun_simple(av, with_base, with_rot, True)
+            pose_flatten = pose_arr.flatten()  # (pose_dim * n_feature)
+            pose_dim = 7 if with_rot else 3
+            jac_flatten = jac_arr.reshape(n_feature * pose_dim, n_dof)
+            return pose_flatten, jac_flatten
+
+        # checking jacobian
+        jacobian_test_util(
+            lambda av: fk_jac_test(av, False, False), av_init)
+        jacobian_test_util(
+            lambda av: fk_jac_test(av, False, True), av_init)
+        jacobian_test_util(
+            lambda av: fk_jac_test(av, True, False), av_with_base_init)
+        jacobian_test_util(
+            lambda av: fk_jac_test(av, True, True), av_with_base_init)


### PR DESCRIPTION
I implemented sdf-swept-sphere collision checker. This function is assumed to be called from a motion planner. But I think, now is the good time to make a PR. To understand swept-sphere collision checking, Figure 3 of [this paper](https://ieeexplore.ieee.org/abstract/document/8263622/) will be helpful. 

### added feature
1. compute swept-spheres approximating a link. 
2. collision detection using the swept-sphere and sdf.
3. Given joint angles, compute signed distance for each features (collision swept-sphers) and corresponding jacobain (it is a key to trajectory optimization)

Also, I wrote test for all important functions and added a demo of swept-sphere collision checking. 

@iory I finished this PR. I will kindly ask you to review this. (I will fix the dirty commit log after changing following the review)

If you run `example/swept_sphere.py` you can get the following images. You can see that each mesh in the right arm is approximated by spheres. The after checking the collision, the spheres under collision is turned to red. 

![col2](https://user-images.githubusercontent.com/38597814/102262636-ba48c280-3f56-11eb-8732-f7a6684235ba.png)
![col3](https://user-images.githubusercontent.com/38597814/102262645-bc128600-3f56-11eb-9be4-798b17426934.png)
