### PR TITLE
Remove child_reverse

### DIFF
--- a/skrobot/model/joint.py
+++ b/skrobot/model/joint.py
@@ -302,11 +302,11 @@ class FixedJoint(Joint):
 
 
 def calc_jacobian_rotational(jacobian, row, column, joint, paxis, child_link,
-                             world_default_coords, child_reverse,
+                             world_default_coords,
                              move_target, transform_coords, rotation_axis,
                              translation_axis):
     j_rot = calc_jacobian_default_rotate_vector(
-        paxis, world_default_coords, child_reverse, transform_coords)
+        paxis, world_default_coords, transform_coords)
     p_diff = np.matmul(transform_coords.worldrot().T,
                        (move_target.worldpos() - child_link.worldpos()))
     j_translation = cross_product(j_rot, p_diff)
@@ -321,11 +321,11 @@ def calc_jacobian_rotational(jacobian, row, column, joint, paxis, child_link,
 
 def calc_jacobian_linear(jacobian, row, column,
                          joint, paxis, child_link,
-                         world_default_coords, child_reverse,
+                         world_default_coords,
                          move_target, transform_coords,
                          rotation_axis, translation_axis):
     j_trans = calc_jacobian_default_rotate_vector(
-        paxis, world_default_coords, child_reverse, transform_coords)
+        paxis, world_default_coords, transform_coords)
     j_rot = np.array([0, 0, 0])
     j_trans = calc_dif_with_axis(j_trans, translation_axis)
     jacobian[row:row + len(j_trans), column] = j_trans
@@ -337,13 +337,9 @@ def calc_jacobian_linear(jacobian, row, column,
 
 
 def calc_jacobian_default_rotate_vector(
-        paxis, world_default_coords, child_reverse,
+        paxis, world_default_coords,
         transform_coords):
-    if child_reverse:
-        sign = -1.0
-    else:
-        sign = 1.0
-    v = sign * normalize_vector(world_default_coords.rotate_vector(paxis))
+    v = normalize_vector(world_default_coords.rotate_vector(paxis))
     return np.dot(transform_coords.worldrot().T, v)
 
 
@@ -469,22 +465,22 @@ class OmniWheelJoint(Joint):
     def calc_jacobian(self,
                       jacobian, row, column,
                       joint, paxis, child_link,
-                      world_default_coords, child_reverse,
+                      world_default_coords,
                       move_target, transform_coords,
                       rotation_axis, translation_axis):
         calc_jacobian_linear(jacobian, row, column + 0,
                              joint, [1, 0, 0], child_link,
-                             world_default_coords, child_reverse,
+                             world_default_coords,
                              move_target, transform_coords,
                              rotation_axis, translation_axis)
         calc_jacobian_linear(jacobian, row, column + 1,
                              joint, [0, 1, 0], child_link,
-                             world_default_coords, child_reverse,
+                             world_default_coords,
                              move_target, transform_coords,
                              rotation_axis, translation_axis)
         calc_jacobian_rotational(jacobian, row, column + 2,
                                  joint, [0, 0, 1], child_link,
-                                 world_default_coords, child_reverse,
+                                 world_default_coords,
                                  move_target, transform_coords,
                                  rotation_axis, translation_axis)
         return jacobian

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -1499,30 +1499,9 @@ class CascadedLink(CascadedCoords):
                      rotation_axes,
                      translation_axes):
                 if ul in link_list:
-                    length = len(link_list)
-                    ll = link_list.index(ul)
                     joint = ul.joint
+
                     if self._is_relevant(joint, move_target):
-                        def find_parent(parent_link, link_list):
-                            if parent_link is None or parent_link in link_list:
-                                return parent_link
-                            else:
-                                return find_parent(parent_link.parent_link,
-                                                   link_list)
-
-                        if not isinstance(joint.child_link, Link):
-                            child_reverse = False
-                        elif ((ll + 1 < length)
-                              and not joint.child_link == find_parent(
-                                  link_list[ll + 1].parent_link, link_list)):
-                            child_reverse = True
-                        elif ((ll + 1 == length)
-                              and (not joint.child_link == find_parent(
-                                  move_target.parent, link_list))):
-                            child_reverse = True
-                        else:
-                            child_reverse = False
-
                         if joint.joint_dof <= 1:
                             paxis = _wrap_axis(joint.axis)
                         else:
@@ -1541,7 +1520,6 @@ class CascadedLink(CascadedCoords):
                             paxis,
                             child_link,
                             world_default_coords,
-                            child_reverse,
                             move_target,
                             transform_coord,
                             rotation_axis,


### PR DESCRIPTION
I removed child_reverse, because it's not used anywhere, and causes bag in jacobian computation when the move_target is not an end-coords.