### PR TITLE
SQP-basd Trajectory optimization

### DIFF
--- a/docs/source/reference/planner.rst
+++ b/docs/source/reference/planner.rst
@@ -2,13 +2,22 @@ Planning
 ========
 
 Sdf-swept-sphere-based collision checker
---------------------------------------------
+----------------------------------------
 
 .. autosummary::
    :toctree: generated/
    :nosignatures:
 
    skrobot.planner.SweptSphereSdfCollisionChecker
+
+SQP-based trajectory planner
+----------------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   skrobot.planner.sqp_plan_trajectory
 
 Swept sphere generater 
 ----------------------
@@ -25,6 +34,7 @@ Planner utils
    :toctree: generated/
    :nosignatures:
 
+   skrobot.planner.utils.scipinize
    skrobot.planner.utils.set_robot_config
    skrobot.planner.utils.get_robot_config
    skrobot.planner.utils.forward_kinematics_multi

--- a/examples/collision_free_trajectory.py
+++ b/examples/collision_free_trajectory.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+import time
+
+import numpy as np
+
+import skrobot
+from skrobot.model.primitives import Axis
+from skrobot.model.primitives import Box
+from skrobot.planner import sqp_plan_trajectory
+from skrobot.planner import SweptSphereSdfCollisionChecker
+from skrobot.planner.utils import get_robot_config
+from skrobot.planner.utils import set_robot_config
+
+# initialization stuff
+np.random.seed(0)
+robot_model = skrobot.models.PR2()
+robot_model.init_pose()
+
+box_center = np.array([0.9, -0.2, 0.9])
+box = Box(extents=[0.7, 0.5, 0.6], with_sdf=True)
+box.translate(box_center)
+
+link_list = [
+    robot_model.r_shoulder_pan_link, robot_model.r_shoulder_lift_link,
+    robot_model.r_upper_arm_roll_link, robot_model.r_elbow_flex_link,
+    robot_model.r_forearm_roll_link, robot_model.r_wrist_flex_link,
+    robot_model.r_wrist_roll_link]
+joint_list = [link.joint for link in link_list]
+
+coll_link_list = [
+    robot_model.r_upper_arm_link, robot_model.r_forearm_link,
+    robot_model.r_gripper_palm_link, robot_model.r_gripper_r_finger_link,
+    robot_model.r_gripper_l_finger_link]
+
+# obtain av_start (please try both with_base=True, FalseA)
+with_base = True
+av_start = np.array([0.564, 0.35, -0.74, -0.7, -0.7, -0.17, -0.63])
+if with_base:
+    av_start = np.hstack([av_start, [0, 0, 0]])
+
+# solve inverse kinematics to obtain av_goal
+coef = 3.1415 / 180.0
+joint_angles = [coef * e for e in [-60, 74, -70, -120, -20, -30, 180]]
+set_robot_config(robot_model, joint_list, joint_angles)
+
+rarm_end_coords = skrobot.coordinates.CascadedCoords(
+    parent=robot_model.r_gripper_tool_frame,
+    name='rarm_end_coords')
+robot_model.inverse_kinematics(
+    target_coords=skrobot.coordinates.Coordinates([0.8, -0.6, 0.8], [0, 0, 0]),
+    link_list=link_list,
+    move_target=robot_model.rarm_end_coords, rotation_axis=True)
+av_goal = get_robot_config(robot_model, joint_list, with_base=with_base)
+
+# collision checker setup
+sscc = SweptSphereSdfCollisionChecker(lambda X: box.sdf(X), robot_model)
+for link in coll_link_list:
+    sscc.add_collision_link(link)
+
+# motion planning
+ts = time.time()
+av_seq = sqp_plan_trajectory(
+    sscc, av_start, av_goal, joint_list, 10,
+    safety_margin=1e-2, with_base=with_base)
+print("solving time : {0} sec".format(time.time() - ts))
+
+# visualizatoin
+print("show trajectory")
+viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(641, 480))
+viewer.add(robot_model)
+viewer.add(box)
+viewer.add(Axis(pos=[0.8, -0.6, 0.8]))
+sscc.add_coll_spheres_to_viewer(viewer)
+viewer.show()
+for av in av_seq:
+    set_robot_config(robot_model, joint_list, av, with_base=with_base)
+    sscc.update_color()
+    viewer.redraw()
+    time.sleep(1.0)
+
+print('==> Press [q] to close window')
+while not viewer.has_exit:
+    time.sleep(0.1)
+    viewer.redraw()

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ six
 trimesh>=3.5.20
 sphinx==1.8.2
 sphinx_rtd_theme
+repoze.lru;python_version<"3.2"

--- a/skrobot/planner/__init__.py
+++ b/skrobot/planner/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa
 
 from skrobot.planner.collision_checker import SweptSphereSdfCollisionChecker
+from skrobot.planner.sqp_based import sqp_plan_trajectory

--- a/skrobot/planner/collision_checker.py
+++ b/skrobot/planner/collision_checker.py
@@ -93,7 +93,7 @@ class SweptSphereSdfCollisionChecker(object):
 
         Returns
         -------
-        dists : numpy.array(n_sphere,)
+        dists : numpy.ndarray(n_sphere,)
             array of the signed distances for each sphere against sdf.
         """
 
@@ -186,7 +186,7 @@ class SweptSphereSdfCollisionChecker(object):
         ----------
         pts_batch : numpy.ndarray(n_wp, n_feature, 3)
             all feature points in a trajectory.
-        jac_batch : Union[numpy.ndarray(n_wp, n_feature, 3, n_dof), None]
+        jac_batch : numpy.ndarray(n_wp, n_feature, 3, n_dof) or None
             jacobians for all feature points in a trajectory. If set to
             None, jacobian for `pts_batch` will not be computed.
 

--- a/skrobot/planner/sqp_based.py
+++ b/skrobot/planner/sqp_based.py
@@ -1,0 +1,174 @@
+import numpy as np
+import scipy
+
+try:
+    # in python3
+    from functools import lru_cache
+except ImportError:
+    # in python2
+    from repoze.lru import lru_cache
+
+from skrobot.planner.utils import scipinize
+
+
+def sqp_plan_trajectory(collision_checker,
+                        av_start,
+                        av_goal,
+                        joint_list,
+                        n_wp,
+                        safety_margin=1e-2,
+                        with_base=False,
+                        weights=None,
+                        initial_trajectory=None,
+                        slsqp_option=None
+                        ):
+    """Gradient based trajectory optimization using scipy's SLSQP.
+
+    Collision constraint is considered in an inequality constraits.
+    Terminal constraint (start and end) is considered as an
+    equality constraint.
+
+    Parameters
+    ----------
+    av_start : numpy.ndarray(n_dof,)
+        joint angle vector at start point
+    joint_list : list[skrobot.model.Link]
+        link list to be controlled (similar to inverse_kinematics function)
+    n_wp : int
+        number of waypoints
+    safety_margin : float
+        safety margin in collision checking
+    with_base: bool
+        If `with_base=False`, `n_dof` is the number of joints `n_joint`,
+        but if `with_base=True`, `n_dof = len(joint_list) + 3`.
+    weights : numpy.ndarray(n_dof,) or  None
+        cost to move of each joint. For example,
+        if you set weights=numpy.ndarray([1.0, 0.1, 0.1]) for a
+        3 DOF manipulator, moving the first joint is with
+        high cost compared to others. If set to `None` it's automatically
+        determined.
+    initial_trajectory : numpy.ndarray(n_wp, n_dof) or None
+        initial solution in the trajectory optimization specifeid by a
+        angle vector sequence. If None, initial trajectory is
+        automatically generated.
+    slsqp_option: dict or None
+        option of slsqp. Please see `options` in
+        https://docs.scipy.org/doc/scipy/reference/optimize.minimize-slsqp.html
+        for the detail. If set to `None`, a default values is used.
+    Returns
+    ------------
+    planned_trajectory : numpy.ndarray(n_wp, n_dof)
+        planned trajectory.
+    """
+
+    # common stuff
+    joint_limit_list = [[j.min_angle, j.max_angle] for j in joint_list]
+    if with_base:
+        joint_limit_list += [[-np.inf, np.inf]] * 3
+
+    # determine default weight
+    if weights is None:
+        weights = [1.0] * len(joint_list)
+        if with_base:
+            weights += [3.0] * 3  # base should be difficult to move
+    weights = tuple(weights)  # to use cache
+
+    # create initial solution for the optimization problem
+    if initial_trajectory is None:
+        regular_interval = (av_goal - av_start) / (n_wp - 1)
+        initial_trajectory = np.array(
+            [av_start + i * regular_interval for i in range(n_wp)])
+
+    def collision_ineq_fun(av_seq):
+        with_jacobian = True
+        sd_vals, sd_val_jac = collision_checker.compute_batch_sd_vals(
+            joint_list, av_seq,
+            with_base=with_base, with_jacobian=with_jacobian)
+        sd_vals_margined = sd_vals - safety_margin
+        return sd_vals_margined, sd_val_jac
+
+    optimal_trajectory = _sqp_based_trajectory_optimization(
+        initial_trajectory,
+        collision_ineq_fun,
+        joint_limit_list,
+        weights,
+        slsqp_option)
+    return optimal_trajectory
+
+
+def _sqp_based_trajectory_optimization(
+        av_seq_init,
+        collision_ineq_fun,
+        joint_limit_list,
+        weights,
+        slsqp_option=None):
+
+    if slsqp_option is None:
+        slsqp_option = {'ftol': 1e-4, 'disp': True, 'maxiter': 100}
+    n_wp, n_dof = av_seq_init.shape
+    A = construct_smoothcost_fullmat(n_wp, n_dof, weights=weights)
+
+    def fun_objective(x):
+        f = (0.5 * A.dot(x).dot(x)).item() / n_wp
+        grad = A.dot(x) / n_wp
+        return f, grad
+
+    def fun_ineq(xi):
+        av_seq = xi.reshape(n_wp, n_dof)
+        return collision_ineq_fun(av_seq)
+
+    def fun_eq(xi):
+        # terminal constraint
+        Q = xi.reshape(n_wp, n_dof)
+        q_start = av_seq_init[0]
+        q_end = av_seq_init[-1]
+        f = np.hstack((q_start - Q[0], q_end - Q[-1]))
+        grad_ = np.zeros((n_dof * 2, n_dof * n_wp))
+        grad_[:n_dof, :n_dof] = - np.eye(n_dof)
+        grad_[-n_dof:, -n_dof:] = - np.eye(n_dof)
+        return f, grad_
+
+    eq_const_scipy, eq_const_jac_scipy = scipinize(fun_eq)
+    eq_dict = {'type': 'eq', 'fun': eq_const_scipy,
+               'jac': eq_const_jac_scipy}
+    ineq_const_scipy, ineq_const_jac_scipy = scipinize(fun_ineq)
+    ineq_dict = {'type': 'ineq', 'fun': ineq_const_scipy,
+                 'jac': ineq_const_jac_scipy}
+    f, jac = scipinize(fun_objective)
+
+    tmp = np.array(joint_limit_list)
+    lower_limit, uppre_limit = tmp[:, 0], tmp[:, 1]
+
+    bounds = list(zip(lower_limit, uppre_limit)) * n_wp
+
+    xi_init = av_seq_init.reshape((n_dof * n_wp, ))
+    res = scipy.optimize.minimize(
+        f, xi_init, method='SLSQP', jac=jac,
+        bounds=bounds,
+        constraints=[eq_dict, ineq_dict],
+        options=slsqp_option)
+    traj_opt = res.x.reshape(n_wp, n_dof)
+    return traj_opt
+
+
+@lru_cache(maxsize=1000)
+def construct_smoothcost_fullmat(n_wp, n_dof, weights):
+    """Compute A of eq. (17) of IJRR-version (2013) of CHOMP"""
+
+    def construct_smoothcost_mat(n_wp):
+        # In CHOMP (2013), squared sum of velocity is computed.
+        # In this implementation we compute squared sum of acceralation
+        # if you set acc_block * 0.0, vel_block * 1.0, then the trajectory
+        # cost is same as the CHOMP one.
+        acc_block = np.array([[1, -2, 1], [-2, 4, -2], [1, -2, 1]])
+        vel_block = np.array([[1, -1], [-1, 1]])
+        A_ = np.zeros((n_wp, n_wp))
+        for i in [1 + i for i in range(n_wp - 2)]:
+            A_[i - 1:i + 2, i - 1:i + 2] += acc_block * 1.0
+            A_[i - 1:i + 1, i - 1:i + 1] += vel_block * 0.0  # do nothing
+        return A_
+
+    w_mat = np.diag(weights)
+    A_ = construct_smoothcost_mat(n_wp)
+    A = np.kron(A_, w_mat**2)
+    return A

--- a/skrobot/planner/utils.py
+++ b/skrobot/planner/utils.py
@@ -6,6 +6,39 @@ from skrobot.coordinates.math import rpy_angle
 from skrobot.coordinates.math import rpy_matrix
 
 
+def scipinize(fun):
+    """Scipinize a function returning both f and jac
+
+    For the detail this issue may help:
+    https://github.com/scipy/scipy/issues/12692
+
+    Parameters
+    ----------
+    fun: function
+        function maps numpy.ndarray(n_dim,) to tuple[numpy.ndarray(m_dim,),
+        numpy.ndarray(m_dim, n_dim)], where the returned tuples is
+        composed of function value(vector) and the corresponding jacobian.
+    Returns
+    -------
+    fun_scipinized : function
+        function maps numpy.ndarray(n_dim,) to a value numpy.ndarray(m_dim,).
+    fun_scipinized_jac : function
+        function maps numpy.ndarray(n_dim,) to
+        jacobian numpy.ndarray(m_dim, n_dim).
+    """
+
+    closure_member = {'jac_cache': None}
+
+    def fun_scipinized(x):
+        f, jac = fun(x)
+        closure_member['jac_cache'] = jac
+        return f
+
+    def fun_scipinized_jac(x):
+        return closure_member['jac_cache']
+    return fun_scipinized, fun_scipinized_jac
+
+
 def set_robot_config(robot_model, joint_list, av, with_base=False):
     """A utility function for setting robot state
 
@@ -53,7 +86,7 @@ def get_robot_config(robot_model, joint_list, with_base=False):
 
     Returns
     -------
-    av_whole (or av_joint) : numpy.array(n_dof,)
+    av_whole (or av_joint) : numpy.ndarray(n_dof,)
         angle vector. If `with_base=False`, `n_dof` is the number of
         joints `n_joint`, but if `with_base=True`, `n_dof = n_joint + 3`.
     """

--- a/tests/skrobot_tests/planner_tests/test_sqp_based_planner.py
+++ b/tests/skrobot_tests/planner_tests/test_sqp_based_planner.py
@@ -1,0 +1,89 @@
+import unittest
+
+import numpy as np
+from numpy import testing
+
+import skrobot
+from skrobot.model.primitives import Box
+from skrobot.planner import sqp_plan_trajectory
+from skrobot.planner import SweptSphereSdfCollisionChecker
+from skrobot.planner.utils import get_robot_config
+from skrobot.planner.utils import set_robot_config
+
+
+class Test_sqp_based_planner(unittest.TestCase):
+
+    @classmethod
+    def setup_class(cls):
+        robot_model = skrobot.models.PR2()
+        robot_model.init_pose()
+
+        # setting up box sdf
+        box_center = np.array([0.9, -0.2, 0.9])
+        box = Box(extents=[0.7, 0.5, 0.6], with_sdf=True)
+        box.translate(box_center)
+
+        # defining control joints
+        link_list = [
+            robot_model.r_shoulder_pan_link, robot_model.r_shoulder_lift_link,
+            robot_model.r_upper_arm_roll_link, robot_model.r_elbow_flex_link,
+            robot_model.r_forearm_roll_link, robot_model.r_wrist_flex_link,
+            robot_model.r_wrist_roll_link]
+        joint_list = [link.joint for link in link_list]
+
+        # defining collision links
+        coll_link_list = [
+            robot_model.r_upper_arm_link, robot_model.r_forearm_link,
+            robot_model.r_gripper_palm_link,
+            robot_model.r_gripper_r_finger_link,
+            robot_model.r_gripper_l_finger_link]
+
+        # collision checker setup
+        sscc = SweptSphereSdfCollisionChecker(
+            lambda X: box.sdf(X), robot_model)
+        for link in coll_link_list:
+            sscc.add_collision_link(link)
+
+        # by solving inverse kinematics, setting up av_goal
+        coef = 3.1415 / 180.0
+        joint_angles = [coef * e for e in [-60, 74, -70, -120, -20, -30, 180]]
+        set_robot_config(robot_model, joint_list, joint_angles)
+
+        robot_model.inverse_kinematics(
+            target_coords=skrobot.coordinates.Coordinates(
+                [0.8, -0.6, 0.8], [0, 0, 0]),
+            link_list=link_list,
+            move_target=robot_model.rarm_end_coords, rotation_axis=True)
+        av_goal = get_robot_config(robot_model, joint_list, with_base=False)
+
+        cls.joint_list = joint_list
+        cls.av_start = np.array([0.564, 0.35, -0.74, -0.7, -0.7, -0.17, -0.63])
+        cls.av_goal = av_goal
+        cls.sscc = sscc
+
+    def test_sqp_plan_trajectory(self):
+        _av_start = self.av_start
+        _av_goal = self.av_goal
+        joint_list = self.joint_list
+        sscc = self.sscc
+        n_wp = 10
+
+        for with_base in [False, True]:
+            if with_base:
+                av_start = np.hstack((_av_start, [0, 0, 0]))
+                av_goal = np.hstack((_av_goal, [0, 0, 0]))
+            else:
+                av_start, av_goal = _av_start, _av_goal
+
+            av_seq = sqp_plan_trajectory(
+                sscc, av_start, av_goal, joint_list, n_wp,
+                safety_margin=1e-2, with_base=with_base)
+            # check equality (terminal) constraint
+            testing.assert_almost_equal(av_seq[0], av_start)
+            testing.assert_almost_equal(av_seq[-1], av_goal)
+
+            # check inequality constraint,
+            # meaning that in any waypoint, rarm does not collide
+            batch_dists, _ = sscc.compute_batch_sd_vals(
+                joint_list, av_seq, with_base=with_base, with_jacobian=False)
+            self.assertTrue(np.all(batch_dists > -1e-4))


### PR DESCRIPTION
### feature
SQP-based trajectory optimization. The cost of a trajecotory is a CHOMP-type one (quadratic cost), but this implementation is different from CHOMP. CHOMP use an objective-function that is the sum of trajectory cost and collision cost and then minimize it by grad-based method. On the other hand, in this implementation, collision cost is directly considered as an inequality constrain.

Please try `example/collision_free_trajectory.py`. Assuming my previous PR https://github.com/iory/scikit-robot/pull/173 works correctly, this GIF shows that there is no collision between the sphere and the object throughout the trajectory. 

![out](https://user-images.githubusercontent.com/38597814/102545254-5ad6e800-40f9-11eb-9f13-94469c31a953.gif)

### warning 
Note that grad-based trajecotyr optimizer can be easily got stuck into a local optima. If you make the box tinier, then the trajectory will tend to jump over the object. So, please consider that this optimization based method can be mainly applied to an easy problem. 

For difficult problem, sampling based solver based initialization is necessary. But, current FK solving speed of scikit-robot, it will take several minutes, So it's not practical. 

### TODO
finnished!
- [x] implementation
- [x] example
- [x] test 
- [x] documentation
- [x] clean up