### PR TITLE
[EXPERIMENTAL] tinyfk backend 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install APT On Linux
       run: |
         sudo apt-get update -qq -y
-        sudo apt-get install -qq -y libspatialindex-dev freeglut3-dev
+        sudo apt-get install -qq -y libspatialindex-dev freeglut3-dev libtinyxml-dev
     - name: Install Pytest
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/examples/collision_free_trajectory.py
+++ b/examples/collision_free_trajectory.py
@@ -6,8 +6,8 @@ import numpy as np
 import skrobot
 from skrobot.model.primitives import Axis
 from skrobot.model.primitives import Box
-from skrobot.planner import sqp_plan_trajectory
-from skrobot.planner import SweptSphereSdfCollisionChecker
+from skrobot.planner import tinyfk_sqp_plan_trajectory
+from skrobot.planner import TinyfkSweptSphereSdfCollisionChecker
 from skrobot.planner.utils import get_robot_config
 from skrobot.planner.utils import set_robot_config
 
@@ -53,13 +53,13 @@ robot_model.inverse_kinematics(
 av_goal = get_robot_config(robot_model, joint_list, with_base=with_base)
 
 # collision checker setup
-sscc = SweptSphereSdfCollisionChecker(lambda X: box.sdf(X), robot_model)
+sscc = TinyfkSweptSphereSdfCollisionChecker(lambda X: box.sdf(X), robot_model)
 for link in coll_link_list:
     sscc.add_collision_link(link)
 
 # motion planning
 ts = time.time()
-av_seq = sqp_plan_trajectory(
+av_seq = tinyfk_sqp_plan_trajectory(
     sscc, av_start, av_goal, joint_list, 10,
     safety_margin=1e-2, with_base=with_base)
 print("solving time : {0} sec".format(time.time() - ts))

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ trimesh>=3.5.20
 sphinx==1.8.2
 sphinx_rtd_theme
 repoze.lru;python_version<"3.2"
+tinyfk>=0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ trimesh>=3.5.20
 sphinx==1.8.2
 sphinx_rtd_theme
 repoze.lru;python_version<"3.2"
-tinyfk>=0.2.3
+tinyfk>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ trimesh>=3.5.20
 sphinx==1.8.2
 sphinx_rtd_theme
 repoze.lru;python_version<"3.2"
-tinyfk>=0.3.0
+tinyfk>=0.3.2

--- a/skrobot/planner/__init__.py
+++ b/skrobot/planner/__init__.py
@@ -2,3 +2,6 @@
 
 from skrobot.planner.collision_checker import SweptSphereSdfCollisionChecker
 from skrobot.planner.sqp_based import sqp_plan_trajectory
+
+from skrobot.planner.tinyfk_collision_checker import TinyfkSweptSphereSdfCollisionChecker
+from skrobot.planner.tinyfk_sqp_based import tinyfk_sqp_plan_trajectory

--- a/skrobot/planner/collision_checker.py
+++ b/skrobot/planner/collision_checker.py
@@ -82,6 +82,7 @@ class SweptSphereSdfCollisionChecker(object):
         self.coll_coords_list.extend(coords_list)
         self.coll_radius_list.extend([R] * len(sphere_list))
         self.n_feature = len(self.coll_coords_list)
+        return centers, coords_list, sphere_list, R
 
     def update_color(self):  # for debugging
         """Update the color of links under collision

--- a/skrobot/planner/tinyfk_collision_checker.py
+++ b/skrobot/planner/tinyfk_collision_checker.py
@@ -1,0 +1,73 @@
+import tinyfk
+
+from skrobot.planner import SweptSphereSdfCollisionChecker
+
+
+class TinyfkSweptSphereSdfCollisionChecker(SweptSphereSdfCollisionChecker):
+    """Collision checker using tinyfk as a backend"""
+
+    def __init__(self, sdf, robot_model):
+        super(TinyfkSweptSphereSdfCollisionChecker, self).__init__(
+            sdf, robot_model)
+        self.fksolver = tinyfk.RobotModel(robot_model.urdf_path)
+        self.coll_sphere_id_list = []
+
+    def add_collision_link(self, coll_link):
+        center_list, _, sphere_list, _ =\
+            super(TinyfkSweptSphereSdfCollisionChecker, self).\
+            add_collision_link(coll_link)
+        coll_link_id = self.fksolver.get_link_ids([coll_link.name])[0]
+        sphere_name_list = [s.name for s in sphere_list]
+        for name, center in zip(sphere_name_list, center_list):
+            self.fksolver.add_new_link(name, coll_link_id, center)
+
+        sphere_ids = self.fksolver.get_link_ids(sphere_name_list)
+        self.coll_sphere_id_list.extend(sphere_ids)
+
+    def compute_batch_sd_vals(
+            self,
+            joint_list,
+            angle_vector_seq,
+            with_base=False,
+            with_jacobian=False):
+        """Mocking compute_batch_sd_vals of the super class
+
+        get_joint_ids comes with some overhead, which is critical
+        in the cpp based trajectory planner. So, Do not call this,
+        and instead, call _compute_batchsd_vals in path-planning
+        applications.
+        """
+        joint_name_list = [j.name for j in joint_list]
+        joint_ids = self.fksolver.get_joint_ids(joint_name_list)
+        return self._compute_batch_sd_vals(
+            joint_ids,
+            angle_vector_seq,
+            with_base=with_base,
+            with_jacobian=with_jacobian)
+
+    def _compute_batch_sd_vals(
+            self,
+            joint_ids,
+            angle_vector_seq,
+            with_base=False,
+            with_jacobian=False):
+        """This will be called from the optimization
+
+        As python doesn't supprot multiple dispatch,
+        we define _compute_batchsd_vals whcih takes
+        different type of arguments.
+        """
+
+        n_wp, n_dof = angle_vector_seq.shape
+        with_rot = False
+        P_tmp, J_tmp = self.fksolver.solve_forward_kinematics(
+            angle_vector_seq, self.coll_sphere_id_list, joint_ids,
+            with_rot, with_base, with_jacobian)
+        # because pybind can handle only 2-dim matrix, we must reshape it
+        P = P_tmp.reshape(n_wp, self.n_feature, 3)
+        if with_jacobian:
+            J = J_tmp.reshape(n_wp, self.n_feature, 3, n_dof)
+        else:
+            J = None
+        sd_vals, sd_vals_jacobi = self._compute_batch_sd_vals_internal(P, J)
+        return sd_vals, sd_vals_jacobi

--- a/skrobot/planner/tinyfk_sqp_based.py
+++ b/skrobot/planner/tinyfk_sqp_based.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from skrobot.planner.sqp_based import _sqp_based_trajectory_optimization
+
+
+def tinyfk_sqp_plan_trajectory(collision_checker,
+                               av_start,
+                               av_goal,
+                               joint_list,
+                               n_wp,
+                               safety_margin=1e-2,
+                               with_base=False,
+                               weights=None,
+                               initial_trajectory=None,
+                               slsqp_option=None
+                               ):
+    # common stuff
+    joint_limit_list = [[j.min_angle, j.max_angle] for j in joint_list]
+    if with_base:
+        joint_limit_list += [[-np.inf, np.inf]] * 3
+
+    # determine default weight
+    if weights is None:
+        weights = [1.0] * len(joint_list)
+        if with_base:
+            weights += [3.0] * 3  # base should be difficult to move
+    weights = tuple(weights)  # to use cache
+
+    # create initial solution for the optimization problem
+    if initial_trajectory is None:
+        regular_interval = (av_goal - av_start) / (n_wp - 1)
+        initial_trajectory = np.array(
+            [av_start + i * regular_interval for i in range(n_wp)])
+
+    joint_name_list = [j.name for j in joint_list]
+    joint_ids = collision_checker.fksolver.get_joint_ids(joint_name_list)
+
+    def collision_ineq_fun(av_seq):
+        with_jacobian = True
+        sd_vals, sd_val_jac = collision_checker._compute_batch_sd_vals(
+            joint_ids, av_seq,
+            with_base=with_base, with_jacobian=with_jacobian)
+        sd_vals_margined = sd_vals - safety_margin
+        return sd_vals_margined, sd_val_jac
+
+    optimal_trajectory = _sqp_based_trajectory_optimization(
+        initial_trajectory,
+        collision_ineq_fun,
+        joint_limit_list,
+        weights,
+        slsqp_option)
+    return optimal_trajectory


### PR DESCRIPTION
### feature
An experimental branch using [tinyfk](https://github.com/HiroIshida/tinyfk) as a backend of collision checker. Currently, the API of the tinyfk is still not fixed, so I want to keep it experimental.

Using tinyfk makes the solving speed aboud 50 times faster in `example/collision_free_trajectory.py` compared to my previous PR https://github.com/iory/scikit-robot/pull/181. (If `with_base=True` solving time is 0.20 sec, if `with_base=False` solving time is 0.04 sec)

### how to use 
```
git clone -b tinyfk https://github.com/HiroIshida/scikit-robot.git
cd scikit-robot 
pip install . --user
```

### dependency on libtinyxml
Because tinyfk is using a shared library dependency with `tinyxml` thus, to use tinyfk you must install the dependency via: 
```
sudo apt install libtinyxml-dev
```  
But most roboticist probably already has it as long as they use ROS. 