### PR TITLE
Refactor sdf transform

### DIFF
--- a/skrobot/coordinates/__init__.py
+++ b/skrobot/coordinates/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import CascadedCoords
 from .base import Coordinates
+from .base import Transform
 from .base import make_coords
 from .base import make_cascoords
 

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -90,26 +90,45 @@ class Transform(object):
         self.translation = np.array(translation)
         self.rotation = rotation
 
-    def __call__(self, pts):
-        """Apply this transform to point/points
+    def transform_vector(self, vec):
+        """Apply this transform to vector/vectors
 
         Parameters
         ----------
-        pts : numpy.ndarray(3,) or numpy.ndarray(n_points, 3)
-            point/points to be transformed
+        vec : numpy.ndarray(3,) or numpy.ndarray(n_points, 3)
+            vector/vectors to be transformed
 
         Returns
         -------
-        pts_transformed : numpy.ndarray(3,) or numpy.ndarray(n_points, 3)
+        vec_transformed : numpy.ndarray(3,) or numpy.ndarray(n_points, 3)
             transformed points
         """
-        assert pts.ndim < 3, "pts must be either 1 or 2 dimensional."
-        if pts.ndim == 1:
-            return self.rotation.dot(pts.T) + self.translation
-        if pts.ndim == 2:
-            return self.rotation.dot(pts.T).T + self.translation[None, :]
+        assert vec.ndim < 3, "vec must be either 1 or 2 dimensional."
+        if vec.ndim == 1:
+            return self.rotation.dot(vec.T) + self.translation
+        if vec.ndim == 2:
+            return self.rotation.dot(vec.T).T + self.translation[None, :]
 
-    def get_inverse(self):
+    def rotate_vector(self, vec):
+        """Rotate 3-dimensional vector using rotation of this Transform
+
+        Parameters
+        ----------
+        vec : numpy.ndarray(3,) or numpy.ndarray(3, n_points)
+            vector (or vectors) to be roated
+
+        Returns
+        -------
+        vec_transformed : numpy.ndarray(3,), numpy.ndarray(3, n_points)
+            rotated vector (or vectors)
+        """
+        assert vec.ndim < 3, "vec must be either 1 or 2 dimensional."
+        if vec.ndim == 1:
+            return self.rotation.dot(vec.T)
+        if vec.ndim == 2:
+            return self.rotation.dot(vec.T).T
+
+    def inverse_transformation(self):
         """Return inverse transform
 
         Returns

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -110,7 +110,7 @@ class SignedDistanceFunction(object):
         """
         tf_world_to_local = self.coords.get_transform().get_inverse()
         tf_local_to_sdf = self.sdf_to_obj_transform.get_inverse()
-        tf_world_to_sdf = tf_world_to_local.__mull__(tf_local_to_sdf)
+        tf_world_to_sdf = tf_world_to_local * tf_local_to_sdf
         points_sdf = tf_world_to_sdf(points_obj)
         return points_sdf
 
@@ -129,7 +129,7 @@ class SignedDistanceFunction(object):
         """
         tf_local_to_world = self.coords.get_transform()
         tf_sdf_to_local = self.sdf_to_obj_transform
-        tf_sdf_to_world = tf_sdf_to_local.__mull__(tf_local_to_world)
+        tf_sdf_to_world = tf_sdf_to_local * tf_local_to_world
         points_obj = tf_sdf_to_world(points_sdf)
         return points_obj
 

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -108,10 +108,11 @@ class SignedDistanceFunction(object):
         points_sdf : numpy.ndarray[float](n_point, 3)
             2 dim point array w.r.t. a sdf-specific coordinate.
         """
-        tf_world_to_local = self.coords.get_transform().get_inverse()
-        tf_local_to_sdf = self.sdf_to_obj_transform.get_inverse()
+        tf_world_to_local =\
+            self.coords.get_transform().inverse_transformation()
+        tf_local_to_sdf = self.sdf_to_obj_transform.inverse_transformation()
         tf_world_to_sdf = tf_world_to_local * tf_local_to_sdf
-        points_sdf = tf_world_to_sdf(points_obj)
+        points_sdf = tf_world_to_sdf.transform_vector(points_obj)
         return points_sdf
 
     def _transform_pts_sdf_to_obj(self, points_sdf):
@@ -130,7 +131,7 @@ class SignedDistanceFunction(object):
         tf_local_to_world = self.coords.get_transform()
         tf_sdf_to_local = self.sdf_to_obj_transform
         tf_sdf_to_world = tf_sdf_to_local * tf_local_to_world
-        points_obj = tf_sdf_to_world(points_sdf)
+        points_obj = tf_sdf_to_world.transform_vector(points_sdf)
         return points_obj
 
 

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -15,7 +15,7 @@ from skrobot.coordinates import Transform
 
 class TestTransform(unittest.TestCase):
 
-    def test_transform_vector(self):
+    def test_transform_vector_and_rotate_vector(self):
         # see test_transform_vector for these values
         pos = [0.13264493, 0.05263172, 0.93042636]
         q = [-0.20692513, 0.50841015, 0.82812527, 0.1136206]
@@ -24,18 +24,16 @@ class TestTransform(unittest.TestCase):
 
         pt_original = np.array([0.2813606, 0.97762403, 0.83617263])
         pt_transformed = tf.transform_vector(pt_original)
-        testing.assert_almost_equal(pt_transformed, np.array(
-            [0.70004566, 1.05660075, 0.29465928]))
+        pt_ground_truth = coords.transform_vector(pt_original)
+        testing.assert_equal(pt_transformed, pt_ground_truth)
+
+        pt_transformed = tf.rotate_vector(pt_original)
+        pt_ground_truth = coords.rotate_vector(pt_original)
+        testing.assert_equal(pt_transformed, pt_ground_truth)
 
         tf.transform_vector(np.zeros((100, 3)))  # ok
         with self.assertRaises(AssertionError):
             tf.transform_vector(np.zeros((100, 100, 3)))  # ng
-
-    def test_rotate_vector(self):
-        rot = rpy_matrix(0.1, 0.2, 0.3)
-        tf = Transform([1, 1, 1], rot)
-        pt = np.array([2, 2, 2])
-        testing.assert_array_equal(tf.rotate_vector(pt), rot.dot(pt))
 
         tf.rotate_vector(np.zeros((100, 3)))  # ok
         with self.assertRaises(AssertionError):

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -13,9 +13,9 @@ from skrobot.coordinates.math import rpy_matrix
 from skrobot.coordinates import Transform
 
 
-class testTransform(unittest.TestCase):
+class TestTransform(unittest.TestCase):
 
-    def test__call__(self):
+    def test_transform_vector(self):
         # see test_transform_vector for these values
         pos = [0.13264493, 0.05263172, 0.93042636]
         q = [-0.20692513, 0.50841015, 0.82812527, 0.1136206]
@@ -23,13 +23,23 @@ class testTransform(unittest.TestCase):
         tf = coords.get_transform()
 
         pt_original = np.array([0.2813606, 0.97762403, 0.83617263])
-        pt_transformed = tf(pt_original)
+        pt_transformed = tf.transform_vector(pt_original)
         testing.assert_almost_equal(pt_transformed, np.array(
             [0.70004566, 1.05660075, 0.29465928]))
 
-        tf(np.zeros((100, 3)))  # ok
+        tf.transform_vector(np.zeros((100, 3)))  # ok
         with self.assertRaises(AssertionError):
-            tf(np.zeros((100, 100, 3)))  # ng
+            tf.transform_vector(np.zeros((100, 100, 3)))  # ng
+
+    def test_rotate_vector(self):
+        rot = rpy_matrix(0.1, 0.2, 0.3)
+        tf = Transform([1, 1, 1], rot)
+        pt = np.array([2, 2, 2])
+        testing.assert_array_equal(tf.rotate_vector(pt), rot.dot(pt))
+
+        tf.rotate_vector(np.zeros((100, 3)))  # ok
+        with self.assertRaises(AssertionError):
+            tf.rotate_vector(np.zeros((100, 100, 3)))  # ng
 
     def test__mull__(self):
         trans12 = np.array([0, 0, 1])
@@ -47,12 +57,12 @@ class testTransform(unittest.TestCase):
             tf13.translation, rot23.dot(trans12) + trans23)
         testing.assert_almost_equal(tf13.rotation, rot23.dot(rot12))
 
-    def test_get_inverse(self):
+    def test_inverse_transformation(self):
         # this also checks __mull__
         trans = np.array([1, 1, 1])
         rot = rpy_matrix(pi / 2.0, pi / 3.0, pi / 5.0)
         tf = Transform(trans, rot)
-        tf_inv = tf.get_inverse()
+        tf_inv = tf.inverse_transformation()
 
         tf_id = tf * tf_inv
         testing.assert_almost_equal(tf_id.translation, np.zeros(3))


### PR DESCRIPTION
From my experience, `copy_worldcoords()` tend to be a bottleneck. However, in the sdf computation, we use to have to call `copy_worldcoords()` In _transform_pts_sdf_to_obj in `SignedDistanceFunction`, because there is no other way to compute such a transform. see: https://github.com/iory/scikit-robot/blob/ef5adf308bebf6aef82d69e7e836189e6eeb620c/skrobot/sdf/signed_distance_function.py#L128

So, the motivation of this PR is to speed-up the sdf computation by avoiding `copy_worldcoords()`. To this end, I implemented `Transform` class, and **detached** transform computation from the coordinatspeede class. This not only enabled avoiding `copy_worldcoords` but also remove other wastefull process like  `quaternio2matrix`. 


After this change, we gain the speedup: 0.056 [sec] -> 0.027 [sec], this change affects a lot in tinyfk-based optimization.  From the profiler output, you will notice that in the original implementation, just computing the transformation takes as same as the main computation of the sdf `signed_distance()`. But  after this change, most of the computational load is took by `signed_distance()`. 

benchmark demo code
```python
import numpy as np
import skrobot
from skrobot.model import MeshLink

m = MeshLink(visual_mesh=skrobot.data.bunny_objpath(), with_sdf=True)
m.translate([0, 0.1, 0])
pts = np.random.randn(100, 3)

from pyinstrument import Profiler
profiler = Profiler()
profiler.start()
for i in range(100):
    m.sdf(pts)
profiler.stop()
print(profiler.output_text(unicode=True, color=True, show_all=True))
```



Before this change
```
0.056 <module>  sdf_slow.py:1
└─ 0.056 __call__  skrobot/sdf/signed_distance_function.py:41
   ├─ 0.031 _signed_distance  skrobot/sdf/signed_distance_function.py:285
   │  └─ 0.031 __call__  scipy/interpolate/interpolate.py:2445
   │     ├─ 0.021 _evaluate_linear  scipy/interpolate/interpolate.py:2494
   │     │  ├─ 0.017 [self]  
   │     │  ├─ 0.003 where  <__array_function__ internals>:2
   │     │  │  └─ 0.003 implement_array_function  <built-in>:0
   │     │  └─ 0.001 asarray  numpy/core/_asarray.py:14
   │     ├─ 0.009 _find_indices  scipy/interpolate/interpolate.py:2515
   │     │  ├─ 0.005 [self]  
   │     │  ├─ 0.003 searchsorted  <__array_function__ internals>:2
   │     │  │  ├─ 0.002 searchsorted  numpy/core/fromnumeric.py:1276
   │     │  │  │  ├─ 0.001 _wrapfunc  numpy/core/fromnumeric.py:52
   │     │  │  │  │  └─ 0.001 ndarray.searchsorted  <built-in>:0
   │     │  │  │  └─ 0.001 [self]  
   │     │  │  └─ 0.001 [self]  
   │     │  └─ 0.001 zeros  <built-in>:0
   │     └─ 0.001 [self]  
   └─ 0.025 _transform_pts_obj_to_sdf  skrobot/sdf/signed_distance_function.py:98
      ├─ 0.013 transform  skrobot/coordinates/base.py:524
      │  └─ 0.013 transform_coords  skrobot/coordinates/base.py:28
      │     ├─ 0.008 rotation  skrobot/coordinates/base.py:153
      │     │  ├─ 0.007 quaternion2matrix  skrobot/coordinates/math.py:633
      │     │  │  ├─ 0.005 allclose  <__array_function__ internals>:2
      │     │  │  │  └─ 0.005 allclose  numpy/core/numeric.py:2121
      │     │  │  │     ├─ 0.004 isclose  <__array_function__ internals>:2
      │     │  │  │     │  └─ 0.004 isclose  numpy/core/numeric.py:2197
      │     │  │  │     │     ├─ 0.002 within_tol  numpy/core/numeric.py:2274
      │     │  │  │     │     │  └─ 0.002 __exit__  numpy/core/_ufunc_config.py:438
      │     │  │  │     │     │     └─ 0.002 seterr  numpy/core/_ufunc_config.py:32
      │     │  │  │     │     │        ├─ 0.001 seterrobj  <built-in>:0
      │     │  │  │     │     │        └─ 0.001 geterr  numpy/core/_ufunc_config.py:132
      │     │  │  │     │     ├─ 0.001 [self]  
      │     │  │  │     │     └─ 0.001 all  <__array_function__ internals>:2
      │     │  │  │     │        └─ 0.001 all  numpy/core/fromnumeric.py:2337
      │     │  │  │     │           └─ 0.001 _wrapreduction  numpy/core/fromnumeric.py:70
      │     │  │  │     │              └─ 0.001 _all  numpy/core/_methods.py:56
      │     │  │  │     │                 └─ 0.001 ufunc.reduce  <built-in>:0
      │     │  │  │     └─ 0.001 all  <__array_function__ internals>:2
      │     │  │  │        └─ 0.001 all  numpy/core/fromnumeric.py:2337
      │     │  │  │           └─ 0.001 _wrapreduction  numpy/core/fromnumeric.py:70
      │     │  │  └─ 0.002 [self]  
      │     │  └─ 0.001 norm  <__array_function__ internals>:2
      │     │     └─ 0.001 norm  numpy/linalg/linalg.py:2363
      │     │        └─ 0.001 asarray  numpy/core/_asarray.py:14
      │     ├─ 0.003 quaternion_multiply  skrobot/coordinates/math.py:1088
      │     │  ├─ 0.002 [self]  
      │     │  └─ 0.001 array  <built-in>:0
      │     ├─ 0.001 quaternion_normalize  skrobot/coordinates/math.py:1349
      │     │  └─ 0.001 quaternion_norm  skrobot/coordinates/math.py:1316
      │     └─ 0.001 translation  skrobot/coordinates/base.py:211
      │        └─ 0.001 _check_valid_translation  skrobot/coordinates/math.py:108
      │           └─ 0.001 issubdtype  numpy/core/numerictypes.py:360
      ├─ 0.010 copy_worldcoords  skrobot/coordinates/base.py:874
      │  ├─ 0.009 coords  skrobot/coordinates/base.py:865
      │  │  └─ 0.009 copy_coords  skrobot/coordinates/base.py:860
      │  │     └─ 0.009 __init__  skrobot/coordinates/base.py:99
      │  │        ├─ 0.008 rotation  skrobot/coordinates/base.py:153
      │  │        │  ├─ 0.005 matrix2quaternion  skrobot/coordinates/math.py:582
      │  │        │  │  ├─ 0.004 isclose  <__array_function__ internals>:2
      │  │        │  │  │  ├─ 0.003 isclose  numpy/core/numeric.py:2197
      │  │        │  │  │  │  ├─ 0.002 within_tol  numpy/core/numeric.py:2274
      │  │        │  │  │  │  │  ├─ 0.001 abs  <built-in>:0
      │  │        │  │  │  │  │  └─ 0.001 [self]  
      │  │        │  │  │  │  └─ 0.001 all  <__array_function__ internals>:2
      │  │        │  │  │  │     └─ 0.001 all  numpy/core/fromnumeric.py:2337
      │  │        │  │  │  └─ 0.001 [self]  
      │  │        │  │  └─ 0.001 [self]  
      │  │        │  ├─ 0.002 _check_valid_rotation  skrobot/coordinates/math.py:88
      │  │        │  │  └─ 0.002 det  <__array_function__ internals>:2
      │  │        │  │     ├─ 0.001 [self]  
      │  │        │  │     └─ 0.001 det  numpy/linalg/linalg.py:2105
      │  │        │  └─ 0.001 [self]  
      │  │        └─ 0.001 array  <built-in>:0
      │  └─ 0.001 [self]  
      └─ 0.002 inverse_transform_vector  skrobot/coordinates/base.py:342
         └─ 0.002 array  <built-in>:0
```

After this change: 
```
0.027 <module>  sdf_slow.py:1
└─ 0.027 __call__  skrobot/sdf/signed_distance_function.py:41
   ├─ 0.025 _signed_distance  skrobot/sdf/signed_distance_function.py:287
   │  └─ 0.025 __call__  scipy/interpolate/interpolate.py:2445
   │     ├─ 0.019 _evaluate_linear  scipy/interpolate/interpolate.py:2494
   │     │  ├─ 0.016 [self]  
   │     │  └─ 0.003 where  <__array_function__ internals>:2
   │     │     ├─ 0.002 implement_array_function  <built-in>:0
   │     │     └─ 0.001 [self]  
   │     ├─ 0.005 _find_indices  scipy/interpolate/interpolate.py:2515
   │     │  ├─ 0.004 [self]  
   │     │  └─ 0.001 list.append  <built-in>:0
   │     └─ 0.001 [self]  
   └─ 0.002 _transform_pts_obj_to_sdf  skrobot/sdf/signed_distance_function.py:98
      ├─ 0.001 __call__  skrobot/coordinates/base.py:95
      └─ 0.001 get_transform  skrobot/coordinates/base.py:198
         └─ 0.001 worldpos  skrobot/coordinates/base.py:1282
```
