### PR TITLE
Make matrix2quaternion faster

### DIFF
--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import math
 from math import acos
 from math import asin
 from math import atan2
@@ -600,34 +601,32 @@ def matrix2quaternion(m):
     array([1., 0., 0., 0.])
     """
     m = np.array(m, dtype=np.float64)
-    q0_2 = (1 + m[0, 0] + m[1, 1] + m[2, 2]) / 4.0
-    q1_2 = (1 + m[0, 0] - m[1, 1] - m[2, 2]) / 4.0
-    q2_2 = (1 - m[0, 0] + m[1, 1] - m[2, 2]) / 4.0
-    q3_2 = (1 - m[0, 0] - m[1, 1] + m[2, 2]) / 4.0
-    mq_2 = max(q0_2, q1_2, q2_2, q3_2)
-    if np.isclose(mq_2, q0_2):
-        q0 = np.sqrt(q0_2)
-        q1 = ((m[2, 1] - m[1, 2]) / (4.0 * q0))
-        q2 = ((m[0, 2] - m[2, 0]) / (4.0 * q0))
-        q3 = ((m[1, 0] - m[0, 1]) / (4.0 * q0))
-    elif np.isclose(mq_2, q1_2):
-        q1 = np.sqrt(q1_2)
-        q0 = ((m[2, 1] - m[1, 2]) / (4.0 * q1))
-        q2 = ((m[1, 0] + m[0, 1]) / (4.0 * q1))
-        q3 = ((m[0, 2] + m[2, 0]) / (4.0 * q1))
-    elif np.isclose(mq_2, q2_2):
-        q2 = np.sqrt(q2_2)
-        q0 = ((m[0, 2] - m[2, 0]) / (4.0 * q2))
-        q1 = ((m[1, 0] + m[0, 1]) / (4.0 * q2))
-        q3 = ((m[1, 2] + m[2, 1]) / (4.0 * q2))
-    elif np.isclose(mq_2, q3_2):
-        q3 = np.sqrt(q3_2)
-        q0 = ((m[1, 0] - m[0, 1]) / (4.0 * q3))
-        q1 = ((m[0, 2] + m[2, 0]) / (4.0 * q3))
-        q2 = ((m[1, 2] + m[2, 1]) / (4.0 * q3))
+    tr = m[0, 0] + m[1, 1] + m[2, 2]
+    if tr > 0:
+        S = math.sqrt(tr + 1.0) * 2
+        qw = 0.25 * S
+        qx = (m[2, 1] - m[1, 2]) / S
+        qy = (m[0, 2] - m[2, 0]) / S
+        qz = (m[1, 0] - m[0, 1]) / S
+    elif (m[0, 0] > m[1, 1]) and (m[0, 0] > m[2, 2]):
+        S = math.sqrt(1. + m[0, 0] - m[1, 1] - m[2, 2]) * 2
+        qw = (m[2, 1] - m[1, 2]) / S
+        qx = 0.25 * S
+        qy = (m[0, 1] + m[1, 0]) / S
+        qz = (m[0, 2] + m[2, 0]) / S
+    elif m[1, 1] > m[2, 2]:
+        S = math.sqrt(1. + m[1, 1] - m[0, 0] - m[2, 2]) * 2
+        qw = (m[0, 2] - m[2, 0]) / S
+        qx = (m[0, 1] + m[1, 0]) / S
+        qy = 0.25 * S
+        qz = (m[1, 2] + m[2, 1]) / S
     else:
-        raise ValueError('matrix {} is invalid'.format(m))
-    return np.array([q0, q1, q2, q3])
+        S = math.sqrt(1. + m[2, 2] - m[0, 0] - m[1, 1]) * 2
+        qw = (m[1, 0] - m[0, 1]) / S
+        qx = (m[0, 2] + m[2, 0]) / S
+        qy = (m[1, 2] + m[2, 1]) / S
+        qz = 0.25 * S
+    return np.array([qw, qx, qy, qz])
 
 
 def quaternion2matrix(q, normalize=False):


### PR DESCRIPTION
In current `matrix2quaternion` is slow.

```
import contextlib
import math

import numpy as np

import skrobot
from datetime import datetime
from skrobot.coordinates.math import random_rotation


@contextlib.contextmanager
def measure(name, log_enable=True):
    import time
    s = time.time()
    yield
    e = time.time()
    if log_enable:
        print("{}: {:.4f}sec".format(name, e - s))


def matrix2quaternion(m):
    m = np.array(m, dtype=np.float64)
    qw_2 = (1 + m[0, 0] + m[1, 1] + m[2, 2]) / 4.0
    qx_2 = (1 + m[0, 0] - m[1, 1] - m[2, 2]) / 4.0
    qy_2 = (1 - m[0, 0] + m[1, 1] - m[2, 2]) / 4.0
    qz_2 = (1 - m[0, 0] - m[1, 1] + m[2, 2]) / 4.0
    mq_2 = max(qw_2, qx_2, qy_2, qz_2)
    e = 0.000001
    if np.isclose(mq_2, qw_2):
        qw = np.sqrt(qw_2)
        qx = ((m[2, 1] - m[1, 2]) / (4.0 * qw))
        qy = ((m[0, 2] - m[2, 0]) / (4.0 * qw))
        qz = ((m[1, 0] - m[0, 1]) / (4.0 * qw))
    elif np.isclose(mq_2, qx_2):
        qx = np.sqrt(qx_2)
        qw = ((m[2, 1] - m[1, 2]) / (4.0 * qx))
        qy = ((m[1, 0] + m[0, 1]) / (4.0 * qx))
        qz = ((m[0, 2] + m[2, 0]) / (4.0 * qx))
    elif np.isclose(mq_2, qy_2):
        qy = np.sqrt(qy_2)
        qw = ((m[0, 2] - m[2, 0]) / (4.0 * qy))
        qx = ((m[1, 0] + m[0, 1]) / (4.0 * qy))
        qz = ((m[1, 2] + m[2, 1]) / (4.0 * qy))
    elif np.isclose(mq_2, qz_2):
        qz = np.sqrt(qz_2)
        qw = ((m[1, 0] - m[0, 1]) / (4.0 * qz))
        qx = ((m[0, 2] + m[2, 0]) / (4.0 * qz))
        qy = ((m[1, 2] + m[2, 1]) / (4.0 * qz))
    else:
        raise ValueError('matrix {} is invalid'.format(m))
    return np.array([qw, qx, qy, qz])


def new_matrx2quaternion(m):
    """Returns quaternion of given rotation matrix.

    Parameters
    ----------
    m : list or numpy.ndarray
        3x3 rotation matrix

    Returns
    -------
    quaternion : numpy.ndarray
        quaternion [w, x, y, z] order

    Examples
    --------
    >>> import numpy
    >>> from skrobot.coordinates.math import matrix2quaternion
    >>> matrix2quaternion(np.eye(3))
    array([1., 0., 0., 0.])
    """
    m = np.array(m, dtype=np.float64)
    tr = m[0, 0] + m[1, 1] + m[2, 2]
    if tr > 0:
        S = math.sqrt(tr + 1.0) * 2
        qw = 0.25 * S
        qx = (m[2, 1] - m[1, 2]) / S
        qy = (m[0, 2] - m[2, 0]) / S
        qz = (m[1, 0] - m[0, 1]) / S
    elif (m[0, 0] > m[1, 1]) and (m[0, 0] > m[2, 2]):
        S = math.sqrt(1. + m[0, 0] - m[1, 1] - m[2, 2]) * 2
        qw = (m[2, 1] - m[1, 2]) / S
        qx = 0.25 * S
        qy = (m[0, 1] + m[1, 0]) / S
        qz = (m[0, 2] + m[2, 0]) / S
    elif m[1, 1] > m[2, 2]:
        S = math.sqrt(1. + m[1, 1] - m[0, 0] - m[2, 2]) * 2
        qw = (m[0, 2] - m[2, 0]) / S
        qx = (m[0, 1] + m[1, 0]) / S
        qy = 0.25 * S
        qz = (m[1, 2] + m[2, 1]) / S
    else:
        S = math.sqrt(1. + m[2, 2] - m[0, 0] - m[1, 1]) * 2
        qw = (m[1, 0] - m[0, 1]) / S
        qx = (m[0, 2] + m[2, 0]) / S
        qy = (m[1, 2] + m[2, 1]) / S
        qz = 0.25 * S
    return np.array([qw, qx, qy, qz])


Ns = [1, 10, 100, 1000, 10000, 100000]
for N in Ns:
    print(N)
    np.random.seed(0)
    with measure('matrix2quaternion'):
        for _ in range(N):
            rot = random_rotation()
            a = matrix2quaternion(rot)

    np.random.seed(0)
    with measure('new_matrx2quaternion'):
        for _ in range(N):
            rot = random_rotation()
            a = new_matrx2quaternion(rot)
```
The results are as follows.
```
1
matrix2quaternion: 0.0004sec
new_matrx2quaternion: 0.0001sec
10
matrix2quaternion: 0.0021sec
new_matrx2quaternion: 0.0011sec
100
matrix2quaternion: 0.0237sec
new_matrx2quaternion: 0.0120sec
1000
matrix2quaternion: 0.2462sec
new_matrx2quaternion: 0.1205sec
10000
matrix2quaternion: 2.2720sec
new_matrx2quaternion: 1.1287sec
100000
matrix2quaternion: 27.0925sec
new_matrx2quaternion: 11.8058sec
```