### PR TITLE
Improve performance of normalize_vector

### DIFF
--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -575,9 +575,10 @@ def normalize_vector(v, ord=2):
     array([0., 0., 0.])
     """
     v = np.array(v, dtype=np.float64)
-    if np.allclose(v, 0) is True:
+    norm = np.linalg.norm(v, ord=ord)
+    if norm == 0:
         return v
-    return v / np.linalg.norm(v, ord=ord)
+    return v / norm
 
 
 def matrix2quaternion(m):


### PR DESCRIPTION
In current `normalize_vector` is slow because it internally use `np.allclose`.
```
import contextlib
import time

import numpy as np

from skrobot.coordinates.math import random_translation


@contextlib.contextmanager
def measure(name, log_enable=True):
    import time
    s = time.time()
    yield
    e = time.time()
    if log_enable:
        print("{}: {:.4f}sec".format(name, e - s))


def normalize_vector(v, ord=2):
    v = np.array(v, dtype=np.float64)
    if np.allclose(v, 0) is True:
        return v
    return v / np.linalg.norm(v, ord=ord)


def new_normalize_vector(v, ord=2):
    v = np.array(v, dtype=np.float64)
    norm = np.linalg.norm(v, ord=ord)
    if norm == 0:
        return v
    return v / norm


Ns = [1, 10, 100, 1000, 10000, 100000]
for N in Ns:
    print(N)
    np.random.seed(0)
    with measure('normalize_vector'):
        for _ in range(N):
            trans = random_translation()
            a = normalize_vector(trans)

    np.random.seed(0)
    with measure('new_normalize_vector'):
        for _ in range(N):
            trans = random_translation()
            a = new_normalize_vector(trans)
```
```
1
normalize_vector: 0.0003sec
new_normalize_vector: 0.0000sec
10
normalize_vector: 0.0004sec
new_normalize_vector: 0.0001sec
100
normalize_vector: 0.0038sec
new_normalize_vector: 0.0009sec
1000
normalize_vector: 0.0373sec
new_normalize_vector: 0.0075sec
10000
normalize_vector: 0.4089sec
new_normalize_vector: 0.0872sec
100000
normalize_vector: 4.6471sec
new_normalize_vector: 0.9667sec
```