### PR TITLE
Add initialization of predicate table for RobotModel

### DIFF
--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -1636,6 +1636,9 @@ class RobotModel(CascadedLink):
             self.__dict__[joint.name] = joint
         self.urdf_path = None
 
+        self._relevance_predicate_table = \
+            self._compute_relevance_predicate_table()
+
     def reset_pose(self):
         raise NotImplementedError()
 

--- a/tests/skrobot_tests/model_tests/test_robot_model.py
+++ b/tests/skrobot_tests/model_tests/test_robot_model.py
@@ -148,6 +148,9 @@ class TestRobotModel(unittest.TestCase):
         for move_target in [fetch.rarm_end_coords] + link_list:
             compare(move_target)
 
+        # check initialization of limb of RobotModel
+        fetch.rarm.calc_jacobian_from_link_list(fetch.rarm.end_coords)
+
     def test_calc_inverse_kinematics_nspace_from_link_list(self):
         kuka = self.kuka
         kuka.calc_inverse_kinematics_nspace_from_link_list(


### PR DESCRIPTION
An initialized `RobotModel` class without urdf don't call `_compute_relevance_predicate_table()`.
This PR fixes the problem.