### PR TITLE
urdf geometry as member of Link class 

### DIFF
--- a/skrobot/model/link.py
+++ b/skrobot/model/link.py
@@ -4,6 +4,7 @@ import numpy as np
 import trimesh
 
 from skrobot.coordinates import CascadedCoords
+from skrobot.model.utils import _meshes_from_urdf_visuals
 
 
 class Link(CascadedCoords):
@@ -12,6 +13,7 @@ class Link(CascadedCoords):
                  inertia_tensor=None,
                  collision_mesh=None,
                  visual_mesh=None,
+                 urdf_link=None,
                  *args, **kwargs):
         super(Link, self).__init__(*args, **kwargs)
         self.centroid = centroid
@@ -22,6 +24,15 @@ class Link(CascadedCoords):
             inertia_tensor = np.eye(3)
         self._collision_mesh = collision_mesh
         self._visual_mesh = visual_mesh
+        self.urdf_link = urdf_link
+
+    @classmethod
+    def from_urdf_link(cls, urdf_link):
+        return cls(
+            name=urdf_link.name,
+            collision_mesh=urdf_link.collision_mesh,
+            visual_mesh=_meshes_from_urdf_visuals(urdf_link.visuals),
+            urdf_link=urdf_link)
 
     @property
     def parent_link(self):

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -29,7 +29,6 @@ from skrobot.model.joint import joint_angle_limit_weight
 from skrobot.model.joint import LinearJoint
 from skrobot.model.joint import RotationalJoint
 from skrobot.model.link import Link
-from skrobot.model.utils import _meshes_from_urdf_visuals
 from skrobot.optimizer import solve_qp
 from skrobot.utils.listify import listify
 from skrobot.utils import urdf
@@ -1666,9 +1665,7 @@ class RobotModel(CascadedLink):
 
         links = []
         for urdf_link in self.urdf_robot_model.links:
-            link = Link(name=urdf_link.name)
-            link.collision_mesh = urdf_link.collision_mesh
-            link.visual_mesh = _meshes_from_urdf_visuals(urdf_link.visuals)
+            link = Link.from_urdf_link(urdf_link)
             links.append(link)
         link_maps = {l.name: l for l in links}
 

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -1,7 +1,6 @@
 import io
 import itertools
 from logging import getLogger
-import warnings
 
 import numpy as np
 import numpy.linalg as LA
@@ -30,6 +29,7 @@ from skrobot.model.joint import joint_angle_limit_weight
 from skrobot.model.joint import LinearJoint
 from skrobot.model.joint import RotationalJoint
 from skrobot.model.link import Link
+from skrobot.model.utils import _meshes_from_urdf_visuals
 from skrobot.optimizer import solve_qp
 from skrobot.utils.listify import listify
 from skrobot.utils import urdf
@@ -1650,53 +1650,6 @@ class RobotModel(CascadedLink):
     def init_pose(self):
         return self.angle_vector(np.zeros_like(self.angle_vector()))
 
-    def _meshes_from_urdf_visuals(self, visuals):
-        meshes = []
-        for visual in visuals:
-            meshes.extend(self._meshes_from_urdf_visual(visual))
-        return meshes
-
-    def _meshes_from_urdf_visual(self, visual):
-        if not isinstance(visual, urdf.Visual):
-            raise TypeError('visual must be urdf.Visual, but got: {}'
-                            .format(type(visual)))
-
-        meshes = []
-        for mesh in visual.geometry.meshes:
-            mesh = mesh.copy()
-
-            # rescale
-            if visual.geometry.mesh is not None:
-                if visual.geometry.mesh.scale is not None:
-                    mesh.vertices = mesh.vertices * visual.geometry.mesh.scale
-
-            # TextureVisuals is usually slow to render
-            if not isinstance(mesh.visual, trimesh.visual.ColorVisuals):
-                mesh.visual = mesh.visual.to_color()
-                if mesh.visual.vertex_colors.ndim == 1:
-                    mesh.visual.vertex_colors = \
-                        mesh.visual.vertex_colors[None].repeat(
-                            mesh.vertices.shape[0], axis=0
-                        )
-
-            # If color or texture is not specified in mesh file,
-            # use information specified in URDF.
-            if (
-                (mesh.visual.face_colors
-                 == trimesh.visual.DEFAULT_COLOR).all()
-                and visual.material
-            ):
-                if visual.material.texture is not None:
-                    warnings.warn(
-                        'texture specified in URDF is not supported'
-                    )
-                elif visual.material.color is not None:
-                    mesh.visual.face_colors = visual.material.color
-
-            mesh.apply_transform(visual.origin)
-            meshes.append(mesh)
-        return meshes
-
     def load_urdf(self, urdf):
         f = io.StringIO()
         f.write(urdf)
@@ -1715,8 +1668,7 @@ class RobotModel(CascadedLink):
         for urdf_link in self.urdf_robot_model.links:
             link = Link(name=urdf_link.name)
             link.collision_mesh = urdf_link.collision_mesh
-            link.visual_mesh = self._meshes_from_urdf_visuals(
-                urdf_link.visuals)
+            link.visual_mesh = _meshes_from_urdf_visuals(urdf_link.visuals)
             links.append(link)
         link_maps = {l.name: l for l in links}
 

--- a/skrobot/model/utils.py
+++ b/skrobot/model/utils.py
@@ -1,0 +1,54 @@
+import warnings
+
+import trimesh
+
+from skrobot.utils import urdf
+
+
+def _meshes_from_urdf_visuals(visuals):
+    meshes = []
+    for visual in visuals:
+        meshes.extend(_meshes_from_urdf_visual(visual))
+    return meshes
+
+
+def _meshes_from_urdf_visual(visual):
+    if not isinstance(visual, urdf.Visual):
+        raise TypeError('visual must be urdf.Visual, but got: {}'
+                        .format(type(visual)))
+
+    meshes = []
+    for mesh in visual.geometry.meshes:
+        mesh = mesh.copy()
+
+        # rescale
+        if visual.geometry.mesh is not None:
+            if visual.geometry.mesh.scale is not None:
+                mesh.vertices = mesh.vertices * visual.geometry.mesh.scale
+
+        # TextureVisuals is usually slow to render
+        if not isinstance(mesh.visual, trimesh.visual.ColorVisuals):
+            mesh.visual = mesh.visual.to_color()
+            if mesh.visual.vertex_colors.ndim == 1:
+                mesh.visual.vertex_colors = \
+                    mesh.visual.vertex_colors[None].repeat(
+                        mesh.vertices.shape[0], axis=0
+                    )
+
+        # If color or texture is not specified in mesh file,
+        # use information specified in URDF.
+        if (
+            (mesh.visual.face_colors
+             == trimesh.visual.DEFAULT_COLOR).all()
+            and visual.material
+        ):
+            if visual.material.texture is not None:
+                warnings.warn(
+                    'texture specified in URDF is not supported'
+                )
+            elif visual.material.color is not None:
+                mesh.visual.face_colors = visual.material.color
+
+        mesh.apply_transform(visual.origin)
+        meshes.append(mesh)
+    return meshes


### PR DESCRIPTION
In the original implementation, the information of the geometry is summarized into the trime's mesh. However, in many application, "raw" data for the geometry such as filename of the mesh and shape and origin of the Box is required. For example, when we construct the sdf from the existing robot model, we need to access filename of the STL to construct GridSDF or size and origin for the BoxSDF. Another example is when we try to use visualizer other than trimesh, we need to access these information. 

To fix this problem, I added `urdf_link` as a member of `Link`. I thought it is cleaner to do this by adding a new constructor `from_urdf_link` defined as a `classmethod`. Also, I find that `_meshes_from_urdf_visuals` which is necessary for the constructor, is member function of `RobotModel` but no attributes of member functions are used inside the function, so I decided to separate it from the `robot_model.py` and put it in `utils.py`. 

After this change, one can access to the attribute like `size` and `filename` as follows: 
```python
import skrobot
import skrobot.utils.urdf as urdf

fetch = skrobot.models.Fetch()

base_link = fetch.__dict__["base_link"]
col = base_link.urdf_link.collisions[0]
geo = col.geometry.geometry
assert isinstance(geo, urdf.Mesh)

# access something need to reconstruct the collision object
mesh_origin = col.origin
filename = geo.filename

gripper_finger_link = fetch.__dict__["r_gripper_finger_link"]
col = gripper_finger_link.urdf_link.collisions[0]
geo = col.geometry.geometry
assert isinstance(geo, urdf.Box)

# access something need to reconstruct the collision object
box_origin = col.origin
box_size = geo.size
```