### PR TITLE
Add CylinderSDF 

### DIFF
--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -8,6 +8,7 @@ from skrobot.coordinates.base import CascadedCoords
 from skrobot.coordinates.base import Coordinates
 from skrobot.model import Link
 from skrobot.sdf import BoxSDF
+from skrobot.sdf import CylinderSDF
 from skrobot.sdf import GridSDF
 from skrobot.sdf import SphereSDF
 
@@ -114,7 +115,7 @@ class Cylinder(Link):
     def __init__(self, radius, height,
                  sections=32,
                  vertex_colors=None, face_colors=None,
-                 pos=(0, 0, 0), rot=np.eye(3), name=None):
+                 pos=(0, 0, 0), rot=np.eye(3), name=None, with_sdf=False):
         if name is None:
             name = 'cylinder_{}'.format(str(uuid.uuid1()).replace('-', '_'))
 
@@ -126,6 +127,13 @@ class Cylinder(Link):
             vertex_colors=vertex_colors,
             face_colors=face_colors,
         )
+
+        if with_sdf:
+            sdf = CylinderSDF(np.zeros(3), height, radius)
+            self.assoc(sdf.coords)
+            self.sdf = sdf
+        else:
+            self.sdf = None
 
 
 class Sphere(Link):

--- a/skrobot/sdf/__init__.py
+++ b/skrobot/sdf/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 
 from .signed_distance_function import BoxSDF
+from .signed_distance_function import CylinderSDF
 from .signed_distance_function import GridSDF
 from .signed_distance_function import SignedDistanceFunction
 from .signed_distance_function import SphereSDF


### PR DESCRIPTION
I added CylinderSDF which is the cylinder version of the SDF. Also, I enabled `with_sdf` option of `primitives.Cylinder`. Now, all geometric type of the urdf format (i.e. mesh, sphere, cylinder, box) can be converted to sdf. 

So, by integrating this PR to my previous PR https://github.com/iory/scikit-robot/pull/199, "Any" type of urdf can be converted to sdf. 



Example: 
```python
import skrobot
from skrobot.model import Sphere
from skrobot.model import Cylinder

c = Cylinder(radius=0.5, height=1.0, with_sdf=True)
pts, sd_vals = c.sdf.surface_points()
viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
viewer.add(c)
viewer.show()
for pt in pts:
    sp = Sphere(radius=0.01, pos=pt, color=[255, 0, 0, 200])
    viewer.add(sp)
```
![sdf](https://user-images.githubusercontent.com/38597814/103370264-b77dce00-4b0f-11eb-9042-b57b64eaf951.png)