### PR TITLE
[sdf] Improve loading sdf time

### DIFF
--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -482,15 +482,8 @@ class GridSDF(SignedDistanceFunction):
 
             # resolution of the grid cells in original mesh coords
             resolution = float(f.readline())
-            sdf_data = np.zeros(dims)
-
-            # loop through file, getting each value
-            count = 0
-            for k in range(nz):
-                for j in range(ny):
-                    for i in range(nx):
-                        sdf_data[i][j][k] = float(f.readline())
-                        count += 1
+            sdf_data = np.fromstring(f.read(), dtype=float, sep='\n').reshape(
+                *dims).transpose(2, 1, 0)
         return GridSDF(sdf_data, origin, resolution)
 
     @staticmethod


### PR DESCRIPTION
```
from datetime import datetime

import skrobot
from skrobot.model import Sphere
from skrobot.sdf import UnionSDF

fetch = skrobot.models.Fetch()
fetch.reset_manip_pose()

start = datetime.now()
union = UnionSDF.from_robot_model(fetch)
end = datetime.now()
print(end - start)
```

With this PR
```
0:00:00.237056
```
Without this PR
```
0:00:01.199379
```