### PR TITLE
Enable option for wait

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         ]
     },
     extras_require={
-        'all': ['pybullet>=2.1.9, <3.0.8'],
+        'all': ['pybullet>=2.1.9;python_version>="3.0"',
+                'pybullet>=2.1.9, <=3.0.8;python_version<"3.0"'],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,6 @@ setup(
         ]
     },
     extras_require={
-        'all': ['pybullet>=2.1.9'],
+        'all': ['pybullet>=2.1.9, <3.0.8'],
     },
 )


### PR DESCRIPTION
Wait for goal only if optional argument `wait` is set to be `True`, otherwise break just after sending the command. 
Simply adding this features to the original code would increase the complexity of the code by introducing additional `if` statement, thus, I removed some if statement just by returning as soon as some condition is not satisfied.  