### PR TITLE
Restrict pybullet version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         ]
     },
     extras_require={
-        'all': ['pybullet>=2.1.9, <3.0.8'],
+        'all': ['pybullet>=2.1.9;python_version>="3.0"',
+                'pybullet>=2.1.9, <=3.0.8;python_version<"3.0"'],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,6 @@ setup(
         ]
     },
     extras_require={
-        'all': ['pybullet>=2.1.9'],
+        'all': ['pybullet>=2.1.9, <3.0.8'],
     },
 )


### PR DESCRIPTION
Currently, after release v3.0.9 of pybullet, the pybullet module seems to be broken in python 2.7. https://pypi.org/project/pybullet/#history
So I restrict the version to be under v.3.0.8. 

This probably fix the test error in https://github.com/iory/scikit-robot/pull/230

It is a temporally fix. But I'm not sure, the author of bullet3 will fix this issue, because v.3.0.9 is release March 9, and already one month passed, but this issue is not fixed. It may related the fact that Bullet author **removed the issue page** for some reason in the [repo](https://github.com/bulletphysics/bullet3) 