### PR TITLE
Import planner in __init__

### DIFF
--- a/skrobot/__init__.py
+++ b/skrobot/__init__.py
@@ -11,6 +11,7 @@ from skrobot import data
 from skrobot import interpolator
 from skrobot import optimizer
 from skrobot import optimizers
+from skrobot import planner
 from skrobot import interfaces
 from skrobot import model
 from skrobot import models


### PR DESCRIPTION
it is better to include planner inside `__init__` for consistency. 

More personally, to call python module from julia's [pyCall](https://github.com/JuliaPy/PyCall.jl), any module should seems to be imported in the `__init__` in the top directory.  