### PR TITLE
Change viewer update rate to 1.0Hz

### DIFF
--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -34,7 +34,7 @@ class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
         self._links = collections.OrderedDict()
 
         self._redraw = True
-        pyglet.clock.schedule_interval(self.on_update, 1 / 30)
+        pyglet.clock.schedule_interval(self.on_update, 1.0)
 
         self.scene = trimesh.Scene()
         self._kwargs = dict(

--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -27,14 +27,14 @@ def _redraw_all_windows():
 
 class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
 
-    def __init__(self, resolution=None):
+    def __init__(self, resolution=None, update_interval=1.0):
         if resolution is None:
             resolution = (640, 480)
 
         self._links = collections.OrderedDict()
 
         self._redraw = True
-        pyglet.clock.schedule_interval(self.on_update, 1.0)
+        pyglet.clock.schedule_interval(self.on_update, update_interval)
 
         self.scene = trimesh.Scene()
         self._kwargs = dict(


### PR DESCRIPTION
When I use `TrimeshSceneViewer`, CPU usage is over 300% even when I don't click viewer.

![cpu_dt_0](https://user-images.githubusercontent.com/19769486/147492362-df47c0f8-4ef2-465d-a303-326dc0b74a22.png)

After I change the duration from `1 / 30` to `1.0 / 30`, CPU usage is still high.

![cpu_dt_003](https://user-images.githubusercontent.com/19769486/147492460-eb48f131-b014-4244-b521-00c8ce77775d.png)

After I change the duration from `1 / 30` to `1.0`, CPU usage is low when I don't click viewer.

![cpu_dt_1](https://user-images.githubusercontent.com/19769486/147492481-2d9328a5-2420-4e5e-81aa-03560d5cb213.png)

Setting the duration to 1.0 did not seem to decrease the responsiveness of the viewer to clicks. (I am sorry if I misunderstand `pyglet.clock.schedule_interval`)

Test code (trimesh_scene_viewer.py)

```python
#!/usr/bin/env python

import time
import skrobot

viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
plane = skrobot.model.Box(
    extents=(2, 2, 0.01), face_colors=(0.75, 0.75, 0.75)
)
viewer.add(plane)
viewer.show()

print('==> Press [q] to close window')
while not viewer.has_exit:
    time.sleep(1)
```