### PR TITLE
feat(primitives): add acceser to primitive properties

### DIFF
--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -156,6 +156,10 @@ class Sphere(Link):
             self.assoc(sdf.coords)
             self.sdf = sdf
 
+    @property
+    def radius(self) -> float:
+        return self.visual_mesh.metadata["radius"]
+
 
 class Annulus(Link):
 


### PR DESCRIPTION
@iory 
I am considering to add accessor to the primitive properties (e.g. height, radius, urdf_path) as the commit. 

I think there are two design choices: a) access by self.visual_meshdata["some_property"] and b) setting property in the constructor. Personally, I would choose (a) because it can avoid data duplication with self.visual_mesh.metadata. Which  do you think is better ? 


### two example
example of (a)
```python
@property
def radius(self) -> float:
    return self.visual_mesh.metadata["radius"]
```

example of (b)
```python
self._radius = radius
```
and 
```python
@property
def radius(self) -> float:
    return self._radius
```