### PR TITLE
fix(urdf): handle when transmission element is broken

### DIFF
--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -1826,8 +1826,8 @@ class Transmission(URDFType):
         'name': (str, True),
     }
     _ELEMENTS = {
-        'joints': (TransmissionJoint, True, True),
-        'actuators': (Actuator, True, True),
+        'joints': (TransmissionJoint, False, True),
+        'actuators': (Actuator, False, True),
     }
     _TAG = 'transmission'
 
@@ -1905,7 +1905,7 @@ class Transmission(URDFType):
     @classmethod
     def _from_xml(cls, node, path):
         kwargs = cls._parse(node, path)
-        kwargs['trans_type'] = node.find('type').text
+        kwargs["trans_type"] = node.attrib.get('type')
         return Transmission(**kwargs)
 
     def _to_xml(self, parent, path):


### PR DESCRIPTION
## CAUTION (before merge)
Currently `skbuild=0.16.0` is broken. So, I force the version of the skbuild to be lower than 0.16. 
 Please remove `TMP` commit a https://github.com/scikit-build/scikit-build/issues/788 is fixed. 

## description

### use `attrib` instead of `find`
According to http://wiki.ros.org/urdf/XML/Transmission, the correct way to specify the type of the transmission is like 
```xml
<transmission name="simple_trans">
  <type>transmission_interface/SimpleTransmission</type>
...
```
However, urdf file from the pr2_description `rosrun xacro xacro `rospack find pr2_description`/robots/pr2.urdf.xacro > pr2.urdf                                                                                                                                 
` writes
```xml
<transmission name="l_gripper_trans" type="pr2_mechanism_model/PR2GripperTransmission">
...
```
Therefore original implementation that get the type of the transmission by node.find("type") fails to find the type in the latter case. Rather, we should use `node.attrib` instead. 

### handle when transmission attribute is broken
In the original implementation attributes of Transmission is set to be required by
```python
_ELEMENTS = {
        'joints': (TransmissionJoint, True, True),
        'actuators': (Actuator, True, True),
}
```
However, in my experience, many urdf files lacks attribute for Transmission element. So   