### PR TITLE
fix: use lower pyglet version for legacy python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open('requirements.txt') as f:
 
 # Python 2.7 and 3.4 support has been dropped from packages
 # version lock those packages here so install succeeds
-if (sys.version_info.major, sys.version_info.minor) <= (3, 4):
+if (sys.version_info.major, sys.version_info.minor) <= (3, 7):
     # packages that no longer support old Python
     lock = [('pyglet', '1.4.10'), ('cvxopt', '1.2.7')]
     for name, version in lock:


### PR DESCRIPTION
Newly released pyglet drop suports for version < 3.8. So we must update setup.py
https://github.com/pyglet/pyglet/blob/3c4bf64bfe4790f78b30bca755228f20878f4211/pyglet/__init__.py#L50