### PR TITLE
Fix sdf coordinate when created with primitive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open('requirements.txt') as f:
 
 # Python 2.7 and 3.4 support has been dropped from packages
 # version lock those packages here so install succeeds
-if (sys.version_info.major, sys.version_info.minor) <= (3, 4):
+if (sys.version_info.major, sys.version_info.minor) <= (3, 7):
     # packages that no longer support old Python
     lock = [('pyglet', '1.4.10'), ('cvxopt', '1.2.7')]
     for name, version in lock:

--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -64,7 +64,7 @@ class Box(Link):
         self._extents = extents
         if with_sdf:
             sdf = BoxSDF(np.zeros(3), extents)
-            self.assoc(sdf.coords)
+            self.assoc(sdf.coords, relative_coords="local")
             self.sdf = sdf
 
 
@@ -131,7 +131,7 @@ class Cylinder(Link):
                                        visual_mesh=mesh)
         if with_sdf:
             sdf = CylinderSDF(np.zeros(3), height, radius)
-            self.assoc(sdf.coords)
+            self.assoc(sdf.coords, relative_coords="local")
             self.sdf = sdf
 
 
@@ -153,7 +153,7 @@ class Sphere(Link):
 
         if with_sdf:
             sdf = SphereSDF(np.zeros(3), radius)
-            self.assoc(sdf.coords)
+            self.assoc(sdf.coords, relative_coords="local")
             self.sdf = sdf
 
 
@@ -199,7 +199,7 @@ class MeshLink(Link):
         if with_sdf:
             sdf = trimesh2sdf(self._collision_mesh, dim_grid=dim_grid,
                               padding_grid=padding_grid)
-            self.assoc(sdf.coords)
+            self.assoc(sdf.coords, relative_coords="local")
             self.sdf = sdf
 
 

--- a/tests/skrobot_tests/model_tests/test_primitives.py
+++ b/tests/skrobot_tests/model_tests/test_primitives.py
@@ -30,8 +30,9 @@ class TestBox(unittest.TestCase):
         skrobot.model.Box(extents=(1, 1, 1), with_sdf=True)
 
     def test_init_with_sdf(self):
-        b = skrobot.model.Box(extents=(1, 1, 1), with_sdf=True)
-        booleans, _ = b.sdf.on_surface(b.visual_mesh.vertices)
+        pos = np.ones(3)
+        b = skrobot.model.Box(extents=(1, 1, 1), pos=pos, with_sdf=True)
+        booleans, _ = b.sdf.on_surface(b.visual_mesh.vertices + pos)
         is_all_vertices_on_surface = np.all(booleans)
         self.assertTrue(is_all_vertices_on_surface)
 
@@ -54,8 +55,9 @@ class TestSphere(unittest.TestCase):
         skrobot.model.Sphere(radius=1)
 
     def test_init_with_sdf(self):
-        s = skrobot.model.Sphere(radius=1.0, with_sdf=True)
-        booleans, _ = s.sdf.on_surface(s.visual_mesh.vertices)
+        pos = np.ones(3)
+        s = skrobot.model.Sphere(radius=1.0, pos=pos, with_sdf=True)
+        booleans, _ = s.sdf.on_surface(s.visual_mesh.vertices + pos)
         is_all_vertices_on_surface = np.all(booleans)
         self.assertTrue(is_all_vertices_on_surface)
 
@@ -82,14 +84,17 @@ class TestMeshLink(unittest.TestCase):
         if osp.exists(sdf_cache_dir):
             shutil.rmtree(sdf_cache_dir)
 
-        # test for trimesh.base.Trimeh
+        # test: input is trimesh
         bunny_obj_path = skrobot.data.bunny_objpath()
         m = skrobot.model.MeshLink(
             trimesh.load(bunny_obj_path), with_sdf=True, dim_grid=50)
 
+        # test: input is mesh path
+        pos = np.ones(3)
         bunny_obj_path = skrobot.data.bunny_objpath()
-        m = skrobot.model.MeshLink(bunny_obj_path, with_sdf=True, dim_grid=50)
+        m = skrobot.model.MeshLink(
+            bunny_obj_path, pos=pos, with_sdf=True, dim_grid=50)
 
-        booleans, _ = m.sdf.on_surface(m.visual_mesh.vertices)
+        booleans, _ = m.sdf.on_surface(m.visual_mesh.vertices + pos)
         is_all_vertices_on_surface = np.all(booleans)
         self.assertTrue(is_all_vertices_on_surface)


### PR DESCRIPTION
## CAUSION
This PR depends on the bug fix. Need rebasing after the following PR merged.
https://github.com/iory/scikit-robot/pull/259

## Description
When sdf is created with primitive, it's coords must be equal to that of the primitive, but it doesn't. So I fixed this by associng relatinv to `local`. 

Also, because the test didn't find this bug, I updated the test also.