### PR TITLE
Install cvxopt and python-fcl only if wheel found

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cached-property
-cvxopt
 future
 gdown
 lxml

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,11 @@ if (sys.version_info.major, sys.version_info.minor) <= (3, 7):
     # If not found, give up installing.
     td = tempfile.mkdtemp()
     cvxopt_version = "1.2.6"
-    cmd = "pip3 download cvxopt=={}"\
-          "--only-binary :all: -d {}".format(cvxopt_version, td)
-    ret = subprocess.call(cmd, shell=True)
-    if ret == 0:
+    cmd_download_wheel = "pip3 download cvxopt=={}"\
+        "--only-binary :all: -d {}".format(cvxopt_version, td)
+    return_code = subprocess.call(cmd_download_wheel, shell=True)
+    wheel_found = (return_code == 0)
+    if wheel_found:
         lock.append(('cvxopt', cvxopt_version))
 
     for name, version in lock:

--- a/setup.py
+++ b/setup.py
@@ -53,13 +53,13 @@ if (sys.version_info.major, sys.version_info.minor) <= (3, 7):
 
     # try cvxopt wheel found for this platform
     # If not found, give up installing.
-    with tempfile.TemporaryDirectory() as td:
-        cvxopt_version = "1.2.7"
-        cmd = "pip3 download cvxopt=={}"\
-              "--only-binary :all: -d {}".format(cvxopt_version, td)
-        ret = subprocess.call(cmd, shell=True)
-        if ret == 0:
-            lock.append(('cvxopt', cvxopt_version))
+    td = tempfile.mkdtemp()
+    cvxopt_version = "1.2.7"
+    cmd = "pip3 download cvxopt=={}"\
+          "--only-binary :all: -d {}".format(cvxopt_version, td)
+    ret = subprocess.call(cmd, shell=True)
+    if ret == 0:
+        lock.append(('cvxopt', cvxopt_version))
 
     for name, version in lock:
         # remove version-free requirements

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import platform
 import shlex
 import subprocess
 import sys
+import tempfile
 
 from setuptools import find_packages
 from setuptools import setup
@@ -48,7 +49,18 @@ with open('requirements.txt') as f:
 # version lock those packages here so install succeeds
 if (sys.version_info.major, sys.version_info.minor) <= (3, 7):
     # packages that no longer support old Python
-    lock = [('pyglet', '1.4.10'), ('cvxopt', '1.2.7')]
+    lock = [('pyglet', '1.4.10')]
+
+    # try cvxopt wheel found for this platform
+    # If not found, give up installing. 
+    with tempfile.TemporaryDirectory() as td:
+        cvxopt_version = "1.2.7"
+        cmd = "pip3 download cvxopt=={}"\
+              "--only-binary :all: -d {}".format(cvxopt_version, td)
+        ret = subprocess.call(cmd, shell=True)
+        if ret == 0:
+            lock.append(('cvxopt', cvxopt_version))
+
     for name, version in lock:
         # remove version-free requirements
         install_requires.remove(name)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if (sys.version_info.major, sys.version_info.minor) <= (3, 7):
     # try cvxopt wheel found for this platform
     # If not found, give up installing.
     td = tempfile.mkdtemp()
-    cvxopt_version = "1.2.7"
+    cvxopt_version = "1.2.6"
     cmd = "pip3 download cvxopt=={}"\
           "--only-binary :all: -d {}".format(cvxopt_version, td)
     ret = subprocess.call(cmd, shell=True)

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if (sys.version_info.major, sys.version_info.minor) <= (3, 7):
     lock = [('pyglet', '1.4.10')]
 
     # try cvxopt wheel found for this platform
-    # If not found, give up installing. 
+    # If not found, give up installing.
     with tempfile.TemporaryDirectory() as td:
         cvxopt_version = "1.2.7"
         cmd = "pip3 download cvxopt=={}"\

--- a/skrobot/optimizer.py
+++ b/skrobot/optimizer.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from skrobot.optimizers.cvxopt_solver import solve_qp as cvxopt_solve_qp
-from skrobot.optimizers.quadprog_solver import solve_qp as quadprog_solve_qp
+from skrobot.optimizers import cvxopt_solver
+from skrobot.optimizers import quadprog_solver
 
 
 def solve_qp(P, q, G, h, A=None, b=None, solver='cvxopt', sym_proj=False):
@@ -42,7 +42,7 @@ def solve_qp(P, q, G, h, A=None, b=None, solver='cvxopt', sym_proj=False):
         If the QP is not feasible.
     """
     if solver == 'cvxopt':
-        return cvxopt_solve_qp(P, q, G, h, A, b, sym_proj=sym_proj)
+        return cvxopt_solver(P, q, G, h, A, b, sym_proj=sym_proj)
     elif solver == 'quadprog':
-        return quadprog_solve_qp(P, q, G, h, A, b, sym_proj=sym_proj)
+        return quadprog_solver(P, q, G, h, A, b, sym_proj=sym_proj)
     raise ValueError('QP solver {} not supported'.format(solver))

--- a/skrobot/optimizers/__init__.py
+++ b/skrobot/optimizers/__init__.py
@@ -1,10 +1,13 @@
 def dummy_func(*args, **kwargs):
-    message = "cvxopt is not installed. please install cvxopt by 'pip install cvxopt' if wheel is avilable for your platform"
+    message = "cvxopt is not installed. "\
+              "Please install cvxopt by 'pip install cvxopt' "\
+              "if wheel is released for your platform."
     raise ModuleNotFoundError(message)
+
 
 try:
     from skrobot.optimizers import cvxopt_solver  # NOQA
     from skrobot.optimizers import quadprog_solver  # NOQA
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     cvxopt_solver = dummy_func
     quadprog_solver = dummy_func

--- a/skrobot/optimizers/__init__.py
+++ b/skrobot/optimizers/__init__.py
@@ -1,2 +1,10 @@
-from skrobot.optimizers import cvxopt_solver  # NOQA
-from skrobot.optimizers import quadprog_solver  # NOQA
+def dummy_func(*args, **kwargs):
+    message = "cvxopt is not installed. please install cvxopt by 'pip install cvxopt' if wheel is avilable for your platform"
+    raise ModuleNotFoundError(message)
+
+try:
+    from skrobot.optimizers import cvxopt_solver  # NOQA
+    from skrobot.optimizers import quadprog_solver  # NOQA
+except ImportError:
+    cvxopt_solver = dummy_func
+    quadprog_solver = dummy_func

--- a/skrobot/optimizers/__init__.py
+++ b/skrobot/optimizers/__init__.py
@@ -2,12 +2,12 @@ def dummy_func(*args, **kwargs):
     message = "cvxopt is not installed. "\
               "Please install cvxopt by 'pip install cvxopt' "\
               "if wheel is released for your platform."
-    raise ModuleNotFoundError(message)
+    raise ImportError(message)
 
 
 try:
     from skrobot.optimizers import cvxopt_solver  # NOQA
     from skrobot.optimizers import quadprog_solver  # NOQA
-except (ImportError, ModuleNotFoundError):
+except ImportError:
     cvxopt_solver = dummy_func
     quadprog_solver = dummy_func


### PR DESCRIPTION
## install cvxopt and python-fcl only when wheel found
`cvxopt`' and `python-fcl` wheel is available only on x86_64 on linux. https://pypi.org/project/cvxopt/#files 
https://pypi.org/project/python-fcl/#files

And for other platform, source build will automatically run. However it requires rather heavy dependencies, and must run additional `apt get` like commands to install `lapack`, `blas`, `liboctomap` etc..., which is cumbersome

So I changed the `setup.py` so that it installes cvxopt and python-fcl only when wheel found.  


## downgrade the locked cvxopt version
https://github.com/iory/scikit-robot/pull/240
In this commit, cvxopt version is set to 1.2.7, but 1.2.7 wheel is not released for linux python2.7. So I decided to downgrade it to 1.2.6.  
Also, I removed cvxopt from requirement.txt

## personal opinion
cvxopt is used only in https://github.com/iory/scikit-robot/blob/c7e52ee0796752180ebe6a76fde1c6cb9ae5dbb8/skrobot/model/robot_model.py#L1375 
If no one is using this feature, removing this feature and cvxopt dependency maybe a good idea