### PR TITLE
feat: make coordinates picklable

### DIFF
--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -1516,6 +1516,20 @@ class CascadedCoords(Coordinates):
                              'get type=={}'.format(type(c)))
         self._parent = c
 
+    def __getstate__(self):
+        # NOTE: python3 can serialize instance method as member
+        # but python2 cannot. So we need to write custom serialization.
+        assert self._worldcoords._hook == self.update
+        d = self.__dict__.copy()
+        worldcoords = d["_worldcoords"]
+        worldcoords._hook = None
+        return d
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+        assert self._worldcoords._hook is None  # as we set in __getstate__
+        self._worldcoords._hook = self.update  # register again
+
 
 def coordinates_p(x):
     """Return whether an object is an instance of a class or of a subclass"""

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -224,12 +224,12 @@ class Coordinates(object):
             name = ''
         self.name = name
         self.parent = None
-        self._hook = hook if hook else lambda: None
+        self._hook = hook
 
     @contextlib.contextmanager
     def disable_hook(self):
         hook = self._hook
-        self._hook = lambda: None
+        self._hook = None
         try:
             yield
         finally:
@@ -269,7 +269,8 @@ class Coordinates(object):
                [ 0.00000000e+00,  1.00000000e+00,  0.00000000e+00],
                [-1.00000000e+00,  0.00000000e+00,  2.22044605e-16]])
         """
-        self._hook()
+        if self._hook is not None:
+            self._hook()
         return self._rotation
 
     @rotation.setter
@@ -325,7 +326,8 @@ class Coordinates(object):
         >>> c.translation
         array([0.1, 0.2, 0.3])
         """
-        self._hook()
+        if self._hook is not None:
+            self._hook()
         return self._translation
 
     @translation.setter
@@ -1049,7 +1051,8 @@ class Coordinates(object):
 
     def worldcoords(self):
         """Return thisself"""
-        self._hook()
+        if self._hook is not None:
+            self._hook()
         return self
 
     def copy_worldcoords(self):

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 
 import numpy as np
@@ -85,6 +86,13 @@ class TestCoordinates(unittest.TestCase):
         testing.assert_array_equal(coord.translation, [1, 0, -1])
         testing.assert_almost_equal(coord.rotation,
                                     [[-1, 0, 0], [0, -1, 0], [0, 0, 1]])
+
+    def test_pickling(self):
+        coords = make_coords()
+        coords.translate([1, 2, 3])
+        coords_again = pickle.loads(pickle.dumps(coords))
+        testing.assert_almost_equal(
+            coords.translation, coords_again.translation)
 
     def test_x_axis(self):
         coord = make_coords()
@@ -408,6 +416,23 @@ class TestCoordinates(unittest.TestCase):
 
 
 class TestCascadedCoordinates(unittest.TestCase):
+
+    def test_pickling(self):
+        a = make_cascoords(pos=[0.1, 0, 0])
+        b = make_cascoords(pos=[0, 0, 0.1])
+        c = make_cascoords(pos=[0, 0, -0.1])
+        a.assoc(b, relative_coords="local")
+        a.assoc(c, relative_coords="local")
+
+        a_again = pickle.loads(pickle.dumps(a))
+        assert len(a_again.descendants) == 2
+        b_again = a_again.descendants[0]
+        c_again = a_again.descendants[1]
+        assert id(b_again.parent) == id(a_again)
+        assert id(c_again.parent) == id(a_again)
+        testing.assert_almost_equal(a_again.translation, a.translation)
+        testing.assert_almost_equal(b_again.translation, b.translation)
+        testing.assert_almost_equal(c_again.translation, c.translation)
 
     def test_changed(self):
         a = make_cascoords(rot=rotation_matrix(pi / 3, 'x'),

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -425,14 +425,22 @@ class TestCascadedCoordinates(unittest.TestCase):
         a.assoc(c, relative_coords="local")
 
         a_again = pickle.loads(pickle.dumps(a))
+
+        # see __getstate__ and __setstate__ implementation
+        assert a_again._worldcoords._hook == a_again.update
+
+        # test properly dumped and loaded
         assert len(a_again.descendants) == 2
         b_again = a_again.descendants[0]
         c_again = a_again.descendants[1]
         assert id(b_again.parent) == id(a_again)
         assert id(c_again.parent) == id(a_again)
-        testing.assert_almost_equal(a_again.translation, a.translation)
-        testing.assert_almost_equal(b_again.translation, b.translation)
-        testing.assert_almost_equal(c_again.translation, c.translation)
+        testing.assert_almost_equal(
+            a_again.translation, a.translation)
+        testing.assert_almost_equal(
+            b_again.translation, b.translation)
+        testing.assert_almost_equal(
+            c_again.translation, c.translation)
 
     def test_changed(self):
         a = make_cascoords(rot=rotation_matrix(pi / 3, 'x'),


### PR DESCRIPTION
## what's this
After this change, coordinate can be serializable by pickle. If no _hook is set. I think _hook is set only if coordinates are connected to joint in the current implementation. 

(dill is alternative, but dill is at most over 10x slower than pickle. and probably people want to use the module in standard library)


before this change 
```python3
import pickle
from skrobot.coordinates import make_coords

co = make_coords()
pickle.dumps(co)
```
```
Traceback (most recent call last):
  File "tmp.py", line 5, in <module>
    pickle.dumps(co)
AttributeError: Can't pickle local object 'Coordinates.__init__.<locals>.<lambda>'
```

After this change: 
the following code runs without error
```python
import pickle
from skrobot.coordinates import make_coords
from skrobot.model import Axis, Box, Cylinder

whatever = [make_coords(), Box([1, 1, 1], with_sdf=True), Cylinder(1, 1, with_sdf=True)]
pickle.dumps(whatever)
```
## detail
-  avoid setting `lambda : None` because lambda function cannot be pickled. Instead I decided to set `None`.　https://github.com/iory/scikit-robot/pull/267/commits/e7ae2a5499a829a2e02d788a141dbeaae39152b3

- python2 cannot pickle instancemethod. However,  `self._woorldcoords._hook` of cascoords is `self.udpate` method, and python2 pickle fails to pickle this. So, for compatibility with python2, so, I override the __getstate__ and __setstate__ so that `setl._worldscooreds._hook` is temporaly set to None when pickling and recover to `self._update` when unpickling. https://github.com/iory/scikit-robot/pull/267/commits/128e4d99641bb28f7c3864135a2b5ae635c54d26 As for custom pickling/unpickling, I used https://stackoverflow.com/a/11802295/7624196 as reference