### PR TITLE
fix: pickling coordinates should not change the original object

### DIFF
--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -427,6 +427,7 @@ class TestCascadedCoordinates(unittest.TestCase):
         a_again = pickle.loads(pickle.dumps(a))
 
         # see __getstate__ and __setstate__ implementation
+        assert a._worldcoords._hook == a.update  # original must be unchanged
         assert a_again._worldcoords._hook == a_again.update
 
         # test properly dumped and loaded


### PR DESCRIPTION
## what's this
This fixes the bug introduced in https://github.com/iory/scikit-robot/pull/267
In the original implementation, self._worlcoords is shallow copied, thus the changing the copied _hook also change the original _hook. Because of this, for example, the following error occurred. This PR fix this. 

```python
import pickle
from skrobot.coordinates import make_cascoords

co = make_cascoords()
pickle.dumps(co)
pickle.dumps(co)
```
```
Traceback (most recent call last):
  File "dill_example.py", line 6, in <module>
    pickle.dumps(co)
  File "/home/h-ishida/python/scikit-robot/skrobot/coordinates/base.py", line 1522, in __getstate__
    assert self._worldcoords._hook == self.update
AssertionError
```

## note
To that end, I used deepcopy instead of shallow copy inside. However, deepcopy makes pickling raw cascaded coords object 2x slower. Thus, the custom pickling procedure is called only if python major version is < 3. 
