### PR TITLE
perf: fast analytical primitive serialization

### DIFF
--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -1534,7 +1534,7 @@ class CascadedCoords(Coordinates):
             # of CascadedCoords.
             self._worldcoords._hook = None
             d["_worldcoords"] = copy.deepcopy(self._worldcoords)
-            d["_worldcoords"].__setattr__("_hook", None)
+            d["_worldcoords"].__setattr__("_hook", "invalidated")
 
             # recover the original _hook
             self._worldcoords._hook = self.update
@@ -1546,9 +1546,9 @@ class CascadedCoords(Coordinates):
         if is_python3:
             return
         else:
-            assert self._worldcoords._hook is None  # as we set in __getstate__
-            self._worldcoords._hook = self.update  # register again
-            assert self._worldcoords._hook == self.update
+            if self._worldcoords._hook == "invalidated":
+                self._worldcoords._hook = self.update  # register again
+                assert self._worldcoords._hook == self.update
 
 
 def coordinates_p(x):

--- a/tests/skrobot_tests/model_tests/test_primitives.py
+++ b/tests/skrobot_tests/model_tests/test_primitives.py
@@ -13,7 +13,9 @@ from skrobot.data import get_cache_dir
 class TestAxis(unittest.TestCase):
 
     def test_init(self):
-        skrobot.model.Axis()
+        prim = skrobot.model.Axis()
+        assert prim._visual_mesh is not None
+        assert prim._collision_mesh is None
 
     def from_coords(self):
         coords = skrobot.coordinates.Coordinates()
@@ -27,8 +29,9 @@ class TestAxis(unittest.TestCase):
 class TestBox(unittest.TestCase):
 
     def test_init(self):
-        skrobot.model.Box(extents=(1, 1, 1))
-        skrobot.model.Box(extents=(1, 1, 1), with_sdf=True)
+        prim = skrobot.model.Box(extents=(1, 1, 1))
+        assert prim._visual_mesh is not None
+        assert prim._collision_mesh is not None
 
     def test_init_with_sdf(self):
         pos = np.ones(3)
@@ -41,19 +44,25 @@ class TestBox(unittest.TestCase):
 class TestCone(unittest.TestCase):
 
     def test_init(self):
-        skrobot.model.Cone(radius=0.5, height=1)
+        prim = skrobot.model.Cone(radius=0.5, height=1)
+        assert prim._visual_mesh is not None
+        assert prim._collision_mesh is not None
 
 
 class TestCylinder(unittest.TestCase):
 
     def test_init(self):
-        skrobot.model.Cylinder(radius=0.5, height=1)
+        prim = skrobot.model.Cylinder(radius=0.5, height=1)
+        assert prim._visual_mesh is not None
+        assert prim._collision_mesh is not None
 
 
 class TestSphere(unittest.TestCase):
 
     def test_init(self):
-        skrobot.model.Sphere(radius=1)
+        prim = skrobot.model.Sphere(radius=1)
+        assert prim._visual_mesh is not None
+        assert prim._collision_mesh is not None
 
     def test_init_with_sdf(self):
         pos = np.ones(3)
@@ -66,7 +75,9 @@ class TestSphere(unittest.TestCase):
 class TestAnnulus(unittest.TestCase):
 
     def test_init(self):
-        skrobot.model.Annulus(r_min=0.2, r_max=0.5, height=1)
+        prim = skrobot.model.Annulus(r_min=0.2, r_max=0.5, height=1)
+        assert prim._visual_mesh is not None
+        assert prim._collision_mesh is not None
 
 
 class TestLineString(unittest.TestCase):


### PR DESCRIPTION
This PR enables fast analytical primitive serialization when initializing primitive wiht `light_serialize = True` option. 

For  example, we can instantiate the primitive for light serialization as
```python3
Axis(light_serialize=True)
Box([1, 1, 1], light_serialize=True)
```


As the following comparison results indicate, there seems to be a spatio-temporal trade off for most primitives. However, for example network based application, the size-efficiency is often important. 

Performance comparison result
```
type: Axis
size: normal => 29406616 ls => 291385 (100.92x smaller)
time: normal => 1.8521513938903809 ls => 1.7980108261108398 (1.03x faster)
type: Box
size: normal => 1346205 ls => 308403 (4.37x smaller)
time: normal => 0.12005162239074707 ls => 0.1479053497314453 (0.81x faster)
type: CameraMarker
size: normal => 30207846 ls => 420599 (71.82x smaller)
time: normal => 2.5991079807281494 ls => 2.299029588699341 (1.13x faster)
type: Cone
size: normal => 3184484 ls => 301413 (10.57x smaller)
time: normal => 0.1319873332977295 ls => 0.3681962490081787 (0.36x faster)
type: Cylinder
size: normal => 5488820 ls => 301421 (18.21x smaller)
time: normal => 0.05330038070678711 ls => 0.438122034072876 (0.12x faster)
type: Sphere
size: normal => 46938525 ls => 287392 (163.33x smaller)
time: normal => 0.14972734451293945 ls => 0.7795138359069824 (0.19x faster)
type: Annulus
size: normal => 5458809 ls => 308415 (17.7x smaller)
time: normal => 0.12433838844299316 ls => 0.38243699073791504 (0.33x faster)
```

Script used in comparison
```python3
import pickle
import time
import copy
import skrobot

n_sample = 1000

primitives = [
    skrobot.model.Axis(),
    skrobot.model.Box([1., 1., 1.]),
    skrobot.model.CameraMarker(),
    skrobot.model.Cone(1., 1.),
    skrobot.model.Cylinder(1., 1.),
    skrobot.model.Sphere(1.),
    skrobot.model.Annulus(1., 1., 1.)]


for p in primitives:
    lst = [copy.deepcopy(p) for _ in range(n_sample)]

    lst_ls = [copy.deepcopy(p) for _ in range(n_sample)]
    for e in lst_ls:
        e._light_serialize = True
    print("type: {}".format(type(p).__name__))

    # spatial perforamance
    size = len(pickle.dumps(lst))
    size_ls = len(pickle.dumps(lst_ls))
    x_better = round(size / size_ls, 2)
    print("size: normal => {} ls => {} ({}x smaller)".format(size, size_ls, x_better))

    # temporal perforamance
    ts = time.time()
    pickle.loads(pickle.dumps(lst))
    elapsed = time.time() - ts

    ts = time.time()
    pickle.loads(pickle.dumps(lst_ls))
    elapsed_ls = time.time() - ts

    x_better = round(elapsed / elapsed_ls, 2)
    print("time: normal => {} ls => {} ({}x faster)".format(elapsed, elapsed_ls, x_better))
```