### PR TITLE
chore: relax pybullet version of python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,8 +92,5 @@ setup(
             "visualize-urdf=skrobot.apps.visualize_urdf:main"
         ]
     },
-    extras_require={
-        'all': ['pybullet>=2.1.9;python_version>="3.0"',
-                'pybullet>=2.1.9, <=3.0.8;python_version<"3.0"'],
-    },
+    extras_require={'all': ['pybullet>=2.1.9']},
 )


### PR DESCRIPTION
### this PR is ready for review
The pybullet's broken binary issue mentioned in 
https://github.com/iory/scikit-robot/pull/231
seems to be fixed already (as the test of this CI pass)

Because under the restriction < 3.0.7, pybullet must be build from the source, and it takes too much time. After this PR, installation for python2 becomes much faster. (as the CI result shows)