### PR TITLE
fix/ci: use ubuntu 20.04 to run test for older python versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   formatting:
     name: Check Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -29,7 +29,7 @@ jobs:
 
   requirements-formatting:
     name: Check Requirements Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Check Formatting
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.6]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -66,7 +66,7 @@ jobs:
   pypi:
     name: Release To PyPi
     needs: [formatting, requirements-formatting, tests]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   formatting:
     name: Check Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -35,7 +35,7 @@ jobs:
 
   requirements-formatting:
     name: Check Requirements Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Check Formatting
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.6]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This PR fix the CI fail.

see: the issue below
https://github.com/actions/setup-python/issues/561