### PR TITLE
[viewer] Enable changing color for list visual mesh

### DIFF
--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -121,14 +121,23 @@ class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
             # TODO(someone) fix this at trimesh's scene.
             if (isinstance(mesh, list) or isinstance(mesh, tuple)) \
                and len(mesh) > 0:
-                mesh = trimesh.util.concatenate(mesh)
-            self.scene.add_geometry(
-                geometry=mesh,
-                node_name=link_id,
-                geom_name=link_id,
-                transform=transform,
-            )
-            self._links[link_id] = link
+                for m in mesh:
+                    link_mesh_id = link_id + str(id(m))
+                    self.scene.add_geometry(
+                        geometry=m,
+                        node_name=link_mesh_id,
+                        geom_name=link_mesh_id,
+                        transform=transform,
+                    )
+                    self._links[link_mesh_id] = link
+            else:
+                self.scene.add_geometry(
+                    geometry=mesh,
+                    node_name=link_id,
+                    geom_name=link_id,
+                    transform=transform,
+                )
+                self._links[link_id] = link
 
         for child_link in link._child_links:
             self._add_link(child_link)


### PR DESCRIPTION
Since visual_mesh is a list, it does not change even if you change the color of mesh, so I changed it to change.

```
from skrobot.viewers import TrimeshSceneViewer
from skrobot.models import PR2
import numpy as np



v = TrimeshSceneViewer()
r = PR2()
v.add(r)
v.show()

color = [255, 0, 0, 200]
for link in r.link_lists(r.r_wrist_roll_link, r.r_shoulder_lift_link):
    if isinstance(link._visual_mesh, list):
        if len(link._visual_mesh) == 0:
            continue
        m = link._visual_mesh[0]
    else:
        m = link._visual_mesh
    n_facet = len(m.visual.face_colors)
    m.visual.face_colors =  np.array([color] * n_facet)
```
![image](https://github.com/iory/scikit-robot/assets/4690682/8ba876b5-5076-41e1-9776-b709c9a91a3d)

