### PR TITLE
fix: force pyglet < 2.0 for all python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [2.7, 3.6, 3.8]
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy>=1.16.0
 ordered_set
 pillow
 pycollada!=0.7  # required for robot model using collada
-pyglet
+pyglet<2.0
 pysdfgen>=0.1.5
 python-fcl  # for collision check in trimesh module
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import os
 import platform
+import re
 import shlex
 import subprocess
 import sys
@@ -44,14 +45,29 @@ with open('requirements.txt') as f:
         req = line.split('#')[0].strip()
         install_requires.append(req)
 
+
+def remove_from_requirements(install_requires, remove_req):
+    # If remove_req is "pyglet", requirement name with or without
+    # version specification will be removed.
+    # For example, either "pyglet" or "pyglet<2.0", "pyglet==1.4" will
+    # be removed.
+    delete_requirement = []
+    for req in install_requires:
+        req_without_version = re.split("[<>=]", req)[0]
+        if req_without_version == remove_req:
+            delete_requirement.append(req)
+    assert len(delete_requirement) == 1, "expect only one match"
+    install_requires.remove(delete_requirement.pop())
+
+
 # Python 2.7 and 3.4 support has been dropped from packages
 # version lock those packages here so install succeeds
 if (sys.version_info.major, sys.version_info.minor) <= (3, 7):
     # packages that no longer support old Python
     lock = [('pyglet', '1.4.10'), ('cvxopt', '1.2.7')]
     for name, version in lock:
-        # remove version-free requirements
-        install_requires.remove(name)
+        remove_from_requirements(install_requires, name)
+
         # add working version locked requirements
         install_requires.append('{}=={}'.format(name, version))
 

--- a/tests/skrobot_tests/planner_tests/test_utils.py
+++ b/tests/skrobot_tests/planner_tests/test_utils.py
@@ -68,11 +68,11 @@ class TestPlannerUtils(unittest.TestCase):
                              av_with_base, with_base=False)
         set_robot_config(robot_model, joint_list, av_with_base, with_base=True)
 
-        testing.assert_equal(
+        testing.assert_almost_equal(
             av,
             get_robot_config(robot_model, joint_list, with_base=False)
         )
-        testing.assert_equal(
+        testing.assert_almost_equal(
             av_with_base,
             get_robot_config(robot_model, joint_list, with_base=True)
         )


### PR DESCRIPTION
After the commit https://github.com/mikedh/trimesh/commit/5c4ace850d01efba7f03108a4aa51abff567307a in trimesh on Novemver last year, pyglet version was changed to be fixed to <2. Thus, we need to update requirements.

This PR fixes this issue, and at the same time added python3.8 in the CI to detect such error beforehand. Also, I tweaked the test https://github.com/iory/scikit-robot/pull/284/commits/2857691a61940011b102327f5409f4a489fdbf21 because without this the test for 3.8 fails

@iory could you release new version after merge this?

### note
The reason why the issue happening only these few days is that, trimesh recently made change  to raise error when pyglet version is not <2.0 at the timing of bump up to version 3.20.0

