### PR TITLE
feat: simplify mesh in loading time

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then,
 pip install scikit-robot
 ```
 
-If you would like to use `Pybullet Interface`,
+If you would like to use `Pybullet Interface` and `open3d` for mesh simplification,
 
 ```bash
 pip install scikit-robot[all]

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,12 @@ if uname == 'Darwin':
     # python-fcl could not install.
     install_requires.remove('python-fcl')
 
+
+extra_all_requires = ['pybullet>=2.1.9']
+if (sys.version_info.major > 2):
+    extra_all_requires.append('open3d')
+
+
 setup(
     name='scikit-robot',
     version=version,
@@ -108,5 +114,5 @@ setup(
             "visualize-urdf=skrobot.apps.visualize_urdf:main"
         ]
     },
-    extras_require={'all': ['pybullet>=2.1.9', 'open3d']},
+    extras_require={'all': extra_all_requires},
 )

--- a/setup.py
+++ b/setup.py
@@ -108,5 +108,5 @@ setup(
             "visualize-urdf=skrobot.apps.visualize_urdf:main"
         ]
     },
-    extras_require={'all': ['pybullet>=2.1.9']},
+    extras_require={'all': ['pybullet>=2.1.9', 'open3d']},
 )

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -5,6 +5,7 @@ import contextlib
 import copy
 import os
 import pickle
+import sys
 import time
 
 from skrobot.data import get_cache_dir
@@ -189,6 +190,7 @@ def load_meshes(filename):
         else:
             meshes = _load_meshes(filename)
 
+            assert sys.version_info.major > 2, "supported only for python3.x"
             try:
                 import open3d  # noqa
             except ImportError:

--- a/tests/skrobot_tests/test_urdf.py
+++ b/tests/skrobot_tests/test_urdf.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 from skrobot.data import fetch_urdfpath
@@ -11,6 +12,9 @@ class TestURDF(unittest.TestCase):
         RobotModelFromURDF(urdf_file=fetch_urdfpath())
 
     def test_load_urdfmodel_with_simplification(self):
+        if(sys.version_info.major < 3):
+            return  # this feature is supported only for python3.x
+
         # create cache and load
         with mesh_simplify_factor(0.1):
             RobotModelFromURDF(urdf_file=fetch_urdfpath())

--- a/tests/skrobot_tests/test_urdf.py
+++ b/tests/skrobot_tests/test_urdf.py
@@ -1,0 +1,20 @@
+import unittest
+
+from skrobot.data import fetch_urdfpath
+from skrobot.models.urdf import RobotModelFromURDF
+from skrobot.utils.urdf import mesh_simplify_factor
+
+
+class TestURDF(unittest.TestCase):
+
+    def test_load_urdfmodel(self):
+        RobotModelFromURDF(urdf_file=fetch_urdfpath())
+
+    def test_load_urdfmodel_with_simplification(self):
+        # create cache and load
+        with mesh_simplify_factor(0.1):
+            RobotModelFromURDF(urdf_file=fetch_urdfpath())
+
+        # load using existing cache
+        with mesh_simplify_factor(0.1):
+            RobotModelFromURDF(urdf_file=fetch_urdfpath())


### PR DESCRIPTION
Fix https://github.com/iory/scikit-robot/issues/253
@708yamaguchi 

## what's this
By this PR, you can configure the mesh simplification ratio by using `mesh_simplify_factor` context manager.
If `mesh_simplify_factor` is specified, the simplified mesh with specified factor is computed and cached. So, at the first time, it takes a little bit longer than normal to load urdf. But, after the second time it's so quick. 

By this PR, both urdf loading time and visualization time (trimesh visualizer is slow ..) can be greatly reduced. 

## example
For example, originally, **visualizing fetch model takes about 15 seconds, but by setting the factor to 0.2, then it takes only 2 seconds on my laptop**. see below example 
```python3
import skrobot
from skrobot.utils.urdf import mesh_simplify_factor
with mesh_simplify_factor(0.2):
    robot_model = skrobot.models.urdf.RobotModelFromURDF(urdf_file=skrobot.data.fetch_urdfpath())
viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
viewer.add(robot_model)
viewer.show()
```

## note
this feature cannot be used from python2.x because pickling doesn't work well. Also, installation of open2d for python2.x is bit cumbersome.