### PR TITLE
fix: reformat for flake8 version > 5.0

### DIFF
--- a/skrobot/coordinates/dual_quaternion.py
+++ b/skrobot/coordinates/dual_quaternion.py
@@ -303,7 +303,7 @@ class DualQuaternion(object):
         return dqt.normalized
 
     def enforce_positive_q_rot_w(self):
-        assert(self.norm[0] > 1e-8)
+        assert self.norm[0] > 1e-8
         q_rot_w = self.qr.w
         if q_rot_w < 0.0:
             self.dq = -self.dq

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -927,8 +927,7 @@ class CascadedLink(CascadedCoords):
                              len(target_coords)))
             return False
 
-        if not(len(additional_jacobi)
-               == len(additional_vel)):
+        if len(additional_jacobi) != len(additional_vel):
             logger.error('list length differ : additional_jacobi {}, '
                          'additional_vel {}'.format(
                              len(additional_jacobi), len(additional_vel)))

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -177,7 +177,7 @@ class SignedDistanceFunction(object):
         return points_obj, dists
 
     def _transform_pts_obj_to_sdf(self, points_obj):
-        """Transform points from to an object coordinate to a sdf-specific coordinate.
+        """Transform points from to an object coords to a sdf-specific coords.
 
         Parameters
         ----------
@@ -197,7 +197,7 @@ class SignedDistanceFunction(object):
         return points_sdf
 
     def _transform_pts_sdf_to_obj(self, points_sdf):
-        """Transform points from to a sdf-specific coordinate to an object coordinate.
+        """Transform points from to a sdf-specific coords to an object coords.
 
         Parameters
         ----------

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -451,7 +451,7 @@ class URDFType(object):
         return cls(**cls._parse(node, path))
 
     def _unparse_attrib(self, val_type, val):
-        """Convert a Python value into a string for storage in an XML attribute.
+        """Convert a value into a string for storage in an XML attribute.
 
         Parameters
         ----------

--- a/tests/skrobot_tests/test_interpolator.py
+++ b/tests/skrobot_tests/test_interpolator.py
@@ -34,7 +34,7 @@ class TestInterpolator(unittest.TestCase):
                 midpoint((i - t0) / (t1 - t0), p1, p0))
             i += 0.02
 
-        assert(ip.is_interpolating is False)
+        assert ip.is_interpolating is False
 
     def test_minjerk_interpolator(self):
         ip = MinjerkInterpolator()
@@ -58,4 +58,4 @@ class TestInterpolator(unittest.TestCase):
             i += 0.02
         testing.assert_almost_equal(ip.position, p0)
 
-        assert(ip.is_interpolating is False)
+        assert ip.is_interpolating is False

--- a/tests/skrobot_tests/test_urdf.py
+++ b/tests/skrobot_tests/test_urdf.py
@@ -12,7 +12,7 @@ class TestURDF(unittest.TestCase):
         RobotModelFromURDF(urdf_file=fetch_urdfpath())
 
     def test_load_urdfmodel_with_simplification(self):
-        if(sys.version_info.major < 3):
+        if sys.version_info.major < 3:
             return  # this feature is supported only for python3.x
 
         # create cache and load


### PR DESCRIPTION
By yesterday update of hacking module https://pypi.org/project/hacking/#history, newer flake8 starts to be installed recently. That's why CI fails last time. 
This PR fix the format error.