### PR TITLE
fix: dont use newest trimesh that is python2x compat

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,8 @@ jobs:
         pip install Cython
         pip install pytest hacking
     - name: Install scikit-robot
-      run: pip install .[all]
+      run: |
+          pip install .[all]
+          cd /tmp && git clone -b fix/use_format_compat2x https://github.com/HiroIshida/trimesh.git && cd trimesh && pip install -e . -v
     - name: Run Pytest
       run: sudo pytest -v tests  # require sudo to access /tmp dir

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,8 +87,6 @@ jobs:
         pip install Cython
         pip install pytest hacking
     - name: Install scikit-robot
-      run: |
-          pip install .[all]
-          cd /tmp && git clone -b fix/use_format_compat2x https://github.com/HiroIshida/trimesh.git && cd trimesh && pip install -e . -v
+      run: pip install .[all]
     - name: Run Pytest
       run: sudo pytest -v tests  # require sudo to access /tmp dir

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ scipy<=1.2.3;python_version<"3.0"
 six
 sphinx>=1.8.2
 sphinx_rtd_theme
-trimesh>=3.9.0
+trimesh>=3.9.0,!=3.23.0


### PR DESCRIPTION
Recent update of trimesh break the compatibility with 2.x. Because of that, CI on 2.7 starts to fail from this morning. 
This PR fix this issue by avoiding the specific version 3.23.0.

FYI, I've created a PR to trimesh, and hopefully this will be merged until next release of trimesh
https://github.com/mikedh/trimesh/pull/1990

