### PR TITLE
feat: enable callback in pybullet wait_interpolation

### DIFF
--- a/examples/pybullet_robot_interface.py
+++ b/examples/pybullet_robot_interface.py
@@ -44,7 +44,7 @@ def main():
         stop=1000,
     )
     interface.angle_vector(robot.angle_vector(), realtime_simulation=True)
-    interface.wait_interpolation()
+    interface.wait_interpolation(callback=lambda self: time.sleep(0.05))
 
     # wait
     while pybullet.isConnected():

--- a/skrobot/interfaces/_pybullet.py
+++ b/skrobot/interfaces/_pybullet.py
@@ -268,7 +268,7 @@ class PybulletRobotInterface(Coordinates):
 
         return angle_vector
 
-    def wait_interpolation(self, thresh=0.05, timeout=60.0):
+    def wait_interpolation(self, thresh=0.05, timeout=60.0, callback=None):
         """Wait robot movement.
 
         This function usually called after self.angle_vector.
@@ -281,9 +281,12 @@ class PybulletRobotInterface(Coordinates):
             velocity threshold for detecting movement stop.
         timeout : float
             maximum time of timeout.
+        callback: None or function
+            callback function. This function is called in each step.
         """
         start = time.time()
         while True:
+
             p.stepSimulation()
             wait = False
             for idx in self.joint_ids:
@@ -297,6 +300,10 @@ class PybulletRobotInterface(Coordinates):
                 break
             if time.time() - start > timeout:
                 return False
+
+            if callback is not None:
+                callback(self)
+
         return True
 
     def sync(self):


### PR DESCRIPTION
Enable to pass callback. Typical usecase is 
```python
interface.wait_interpolation(callback = lambda self: time.sleep(0.01))
```
Without this, the simulation is so fast that we cannot actually see the motion.

@iory do you prefer `time_step` argument rather than `callback`. `time_step` may be more scoped and user-friendly I guess.