### PR TITLE
Set max joint torque

### DIFF
--- a/skrobot/interfaces/_pybullet.py
+++ b/skrobot/interfaces/_pybullet.py
@@ -216,7 +216,6 @@ class PybulletRobotInterface(Coordinates):
         self.joint_ids = joint_ids
         self.joint_name_to_joint_id = joint_name_to_joint_id
 
-        self.force = 200
         self.max_velocity = 1.0
         self.position_gain = 0.1
         self.target_velocity = 0.0
@@ -261,7 +260,7 @@ class PybulletRobotInterface(Coordinates):
                                     controlMode=p.POSITION_CONTROL,
                                     targetPosition=angle,
                                     targetVelocity=self.target_velocity,
-                                    force=self.force,
+                                    force=joint.max_joint_torque,
                                     positionGain=self.position_gain,
                                     velocityGain=self.velocity_gain,
                                     maxVelocity=self.max_velocity)

--- a/skrobot/model/joint.py
+++ b/skrobot/model/joint.py
@@ -147,6 +147,7 @@ class Joint(object):
         if max_joint_torque is None:
             max_joint_torque = _default_max_joint_torque
         self.max_joint_velocity = max_joint_velocity
+        self.max_joint_torque = max_joint_torque
         self.joint_min_max_table = joint_min_max_table
         self.joint_min_max_target = joint_min_max_target
         self.default_coords = self.child_link.copy_coords()


### PR DESCRIPTION
```
from skrobot.models import PR2

robot = PR2()
for joint in robot.joint_list:
    print(joint.name, joint.max_joint_torque)
fl_caster_rotation_joint 6.5
fl_caster_l_wheel_joint 7.0
fl_caster_r_wheel_joint 7.0
fr_caster_rotation_joint 6.5
fr_caster_l_wheel_joint 7.0
fr_caster_r_wheel_joint 7.0
bl_caster_rotation_joint 6.5
bl_caster_l_wheel_joint 7.0
bl_caster_r_wheel_joint 7.0
br_caster_rotation_joint 6.5
br_caster_l_wheel_joint 7.0
br_caster_r_wheel_joint 7.0
torso_lift_joint 10000.0
torso_lift_motor_screw_joint 0.0
head_pan_joint 2.645
head_tilt_joint 18.0
laser_tilt_mount_joint 0.65
r_shoulder_pan_joint 30.0
r_shoulder_lift_joint 30.0
r_upper_arm_roll_joint 30.0
r_forearm_roll_joint 30.0
r_elbow_flex_joint 30.0
r_wrist_flex_joint 10.0
r_wrist_roll_joint 10.0
r_gripper_motor_slider_joint 1000.0
r_gripper_motor_screw_joint 0.0
r_gripper_l_finger_joint 1000.0
r_gripper_r_finger_joint 1000.0
r_gripper_l_finger_tip_joint 1000.0
r_gripper_r_finger_tip_joint 1000.0
r_gripper_joint 1000.0
l_shoulder_pan_joint 30.0
l_shoulder_lift_joint 30.0
l_upper_arm_roll_joint 30.0
l_forearm_roll_joint 30.0
l_elbow_flex_joint 30.0
l_wrist_flex_joint 10.0
l_wrist_roll_joint 10.0
l_gripper_motor_slider_joint 1000.0
l_gripper_motor_screw_joint 0.0
l_gripper_l_finger_joint 1000.0
l_gripper_r_finger_joint 1000.0
l_gripper_l_finger_tip_joint 1000.0
l_gripper_r_finger_tip_joint 1000.0
l_gripper_joint 1000.0
```
close #142 