### PR TITLE
Refactor to speed up 

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -10,7 +10,7 @@ Utilities functions
    :toctree: generated/
    :nosignatures:
 
-   skrobot.coordinates.math._wrap_axis
+   skrobot.coordinates.math.convert_to_axis_vector
    skrobot.coordinates.math._check_valid_rotation
    skrobot.coordinates.math._check_valid_translation
    skrobot.coordinates.math.triple_product

--- a/skrobot/coordinates/__init__.py
+++ b/skrobot/coordinates/__init__.py
@@ -6,7 +6,7 @@ from .base import Transform
 from .base import make_coords
 from .base import make_cascoords
 
-from .geo import _wrap_axis
+from .geo import convert_to_axis_vector
 from .geo import midcoords
 from .geo import midpoint
 from .geo import orient_coords_to_axis

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -1100,18 +1100,26 @@ class Coordinates(object):
         """
         if pos is not None:
             if check_validity:
-                self.rotation = copy.deepcopy(c)
-                self.translation = copy.deepcopy(pos)
+                if id(self._rotation) != id(c):
+                    self.rotation = copy.deepcopy(c)
+                if id(self._translation) != id(pos):
+                    self.translation = copy.deepcopy(pos)
             else:
-                self._rotation = np.copy(c)
-                self._translation = np.copy(pos)
+                if id(self._rotation) != id(c):
+                    self._rotation = np.copy(c)
+                if id(self._translation) != id(pos):
+                    self._translation = np.copy(pos)
         else:
             if check_validity:
-                self.rotation = copy.deepcopy(c.rotation)
-                self.translation = copy.deepcopy(c.translation)
+                if id(self._rotation) != id(c._rotation):
+                    self.rotation = copy.deepcopy(c._rotation)
+                if id(self._translation) != id(c._translation):
+                    self.translation = copy.deepcopy(c._translation)
             else:
-                self._rotation = np.copy(c.rotation)
-                self._translation = np.copy(c.translation)
+                if id(self._rotation) != id(c._rotation):
+                    self._rotation = np.copy(c._rotation)
+                if id(self._translation) != id(c._translation):
+                    self._translation = np.copy(c._translation)
         return self
 
     def __mul__(self, other_c):

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -8,8 +8,8 @@ import numpy as np
 from skrobot.coordinates.dual_quaternion import DualQuaternion
 from skrobot.coordinates.math import _check_valid_rotation
 from skrobot.coordinates.math import _check_valid_translation
-from skrobot.coordinates.math import _wrap_axis
 from skrobot.coordinates.math import angle_between_vectors
+from skrobot.coordinates.math import convert_to_axis_vector
 from skrobot.coordinates.math import cross_product
 from skrobot.coordinates.math import matrix2quaternion
 from skrobot.coordinates.math import matrix_log
@@ -763,7 +763,7 @@ class Coordinates(object):
         return rpy_angle(self.rotation)
 
     def axis(self, ax):
-        ax = _wrap_axis(ax)
+        ax = convert_to_axis_vector(ax)
         return self.rotate_vector(ax)
 
     def difference_position(self, coords,
@@ -802,7 +802,7 @@ class Coordinates(object):
         array([ 0.2, -0.5, -0.2])
         """
         dif_pos = self.inverse_transform_vector(coords.worldpos())
-        translation_axis = _wrap_axis(translation_axis)
+        translation_axis = convert_to_axis_vector(translation_axis)
         dif_pos[translation_axis == 1] = 0.0
         return dif_pos
 

--- a/skrobot/coordinates/geo.py
+++ b/skrobot/coordinates/geo.py
@@ -1,8 +1,8 @@
 import numpy as np
 
 from skrobot.coordinates import make_coords
-from skrobot.coordinates.math import _wrap_axis
 from skrobot.coordinates.math import angle_between_vectors
+from skrobot.coordinates.math import convert_to_axis_vector
 from skrobot.coordinates.math import midpoint
 from skrobot.coordinates.math import midrot
 from skrobot.coordinates.math import normalize_vector
@@ -50,7 +50,7 @@ def orient_coords_to_axis(target_coords, v, axis='z', eps=0.005):
     v : list or numpy.ndarray
         position of target [x, y, z]
     axis : list or string or numpy.ndarray
-        see _wrap_axis function
+        see convert_to_axis_vector function
     eps : float (optional)
         eps
 
@@ -91,7 +91,7 @@ def orient_coords_to_axis(target_coords, v, axis='z', eps=0.005):
     if np.linalg.norm(v) == 0.0:
         v = np.array([0, 0, 1], 'f')
     nv = normalize_vector(v)
-    axis = _wrap_axis(axis)
+    axis = convert_to_axis_vector(axis)
     ax = target_coords.rotate_vector(axis)
     rot_axis = np.cross(ax, nv)
     rot_angle_cos = np.clip(np.dot(nv, ax), -1.0, 1.0)

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -388,7 +388,7 @@ def transform(m, v):
     return np.matmul(m, v)
 
 
-def rotation_matrix(theta, axis):
+def rotation_matrix(theta, axis, skip_normalization=False):
     """Return the rotation matrix.
 
     Return the rotation matrix associated with counterclockwise rotation
@@ -401,6 +401,8 @@ def rotation_matrix(theta, axis):
     axis : str or list or numpy.ndarray
         rotation axis such that 'x', 'y', 'z'
         [0, 0, 1], [0, 1, 0], [1, 0, 0]
+    skip_normalization : bool
+        if `True`, skip normalization for axis.
 
     Returns
     -------
@@ -420,8 +422,9 @@ def rotation_matrix(theta, axis):
            [ 0.00000000e+00,  1.00000000e+00,  0.00000000e+00],
            [-1.00000000e+00,  0.00000000e+00,  2.22044605e-16]])
     """
-    axis = convert_to_axis_vector(axis)
-    axis = axis / np.sqrt(np.dot(axis, axis))
+    if not skip_normalization:
+        axis = convert_to_axis_vector(axis)
+        axis = axis / np.sqrt(np.dot(axis, axis))
     a = np.cos(theta / 2.0)
     b, c, d = -axis * np.sin(theta / 2.0)
     aa, bb, cc, dd = a * a, b * b, c * c, d * d
@@ -466,10 +469,15 @@ def rotate_vector(vec, theta, axis):
     return rotated_vec
 
 
-def rotate_matrix(matrix, theta, axis, world=None):
+def rotate_matrix(matrix, theta, axis, world=None, skip_normalization=False):
     if world is False or world is None:
-        return np.dot(matrix, rotation_matrix(theta, axis))
-    return np.dot(rotation_matrix(theta, axis), matrix)
+        return np.dot(
+            matrix,
+            rotation_matrix(theta, axis,
+                            skip_normalization=skip_normalization))
+    return np.dot(
+        rotation_matrix(theta, axis, skip_normalization=skip_normalization),
+        matrix)
 
 
 def rpy_matrix(az, ay, ax):

--- a/skrobot/model/joint.py
+++ b/skrobot/model/joint.py
@@ -242,7 +242,8 @@ class RotationalJoint(Joint):
             v = self.min_angle
         diff_angle = v - self._joint_angle
         self._joint_angle = v
-        self.child_link.rotate(diff_angle, self.axis)
+        self.child_link.rotate(diff_angle, self.axis,
+                               skip_normalization=True)
         if enable_hook:
             for hook in self._hooks:
                 hook()

--- a/skrobot/model/joint.py
+++ b/skrobot/model/joint.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 import numpy as np
 
-from skrobot.coordinates import _wrap_axis
+from skrobot.coordinates import convert_to_axis_vector
 from skrobot.coordinates.math import cross_product
 from skrobot.coordinates import normalize_vector
 
@@ -191,7 +191,7 @@ class RotationalJoint(Joint):
             max_joint_velocity=max_joint_velocity,
             max_joint_torque=max_joint_torque,
             *args, **kwargs)
-        self.axis = normalize_vector(_wrap_axis(axis))
+        self.axis = normalize_vector(convert_to_axis_vector(axis))
         self._joint_angle = 0.0
 
         if self.min_angle is None:
@@ -343,7 +343,7 @@ class LinearJoint(Joint):
                  max_joint_velocity=np.pi / 4,  # [m/s]
                  max_joint_torque=100,  # [N]
                  *args, **kwargs):
-        self.axis = normalize_vector(_wrap_axis(axis))
+        self.axis = normalize_vector(convert_to_axis_vector(axis))
         self._joint_angle = 0.0
         super(LinearJoint, self).__init__(
             max_joint_velocity=max_joint_velocity,

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -9,8 +9,8 @@ from ordered_set import OrderedSet
 import six
 import trimesh
 
-from skrobot.coordinates import _wrap_axis
 from skrobot.coordinates import CascadedCoords
+from skrobot.coordinates import convert_to_axis_vector
 from skrobot.coordinates import Coordinates
 from skrobot.coordinates import make_coords
 from skrobot.coordinates import make_matrix
@@ -1060,7 +1060,7 @@ class CascadedLink(CascadedCoords):
 
         translation_axis : list of axis
         rotation_axis : list of axis
-            see _wrap_axis
+            see convert_to_axis_vector
         """
         for i in range(len(dif_pos)):
             if LA.norm(dif_pos[i]) > thre[i]:
@@ -1532,7 +1532,7 @@ class CascadedLink(CascadedCoords):
 
                     if self._is_relevant(joint, move_target):
                         if joint.joint_dof <= 1:
-                            paxis = _wrap_axis(joint.axis)
+                            paxis = convert_to_axis_vector(joint.axis)
                         else:
                             paxis = joint.axis
                         child_link = joint.child_link


### PR DESCRIPTION
```
from datetime import datetime

import numpy as np
from skrobot.coordinates.math import matrix2quaternion


class RobotDataset(object):

    def __init__(self, robot_model):
        self.robot_model = robot_model

    def sample(self, n):
        robot_model = self.robot_model
        ndof = len(robot_model.joint_max_angles)

        j_max = robot_model.joint_max_angles.copy()
        j_min = robot_model.joint_min_angles.copy()
        j_max[j_max == np.inf] = 2 * np.pi
        j_min[j_min == -np.inf] = - 2 * np.pi
        return np.random.uniform(low=j_min,
                                 high=j_max,
                                 size=(n, ndof))

    def end_coords_from_samples(self, samples):
        robot_model = self.robot_model
        end_coords_list = []
        from tqdm import tqdm
        for s in tqdm(samples):
            robot_model.angle_vector(s)
            end_coords = robot_model.end_coords
            t_xyz = end_coords.worldpos()
            q_wxyz = matrix2quaternion(end_coords.worldrot())
            end_coords_list.append(
                np.concatenate(
                    [t_xyz, q_wxyz]))
        return np.array(end_coords_list)


if __name__ == '__main__':
    from skrobot.models import PR2
    robot_model = PR2()
    robot_dataset = RobotDataset(robot_model.rarm)

    n = 100000
    start = datetime.now()
    samples = robot_dataset.sample(n)
    end_coords_array = robot_dataset.end_coords_from_samples(samples)
    end = datetime.now()
    print(end - start)
```
0:00:10.482203 -> 0:00:06.810289
