### PR TITLE
Remove rescalling for 3dxml.

### DIFF
--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -252,11 +252,9 @@ def _load_meshes(filename):
         _, ext = os.path.splitext(filename)
         # It seems that .3DXML files assume [mm] unit.
         # Convert the mesh unit from [mm] to [m].
-        if ext.lower() in ['.3dxml']:
-            meshes = trimesh.load(filename)
-            meshes = meshes.scaled(0.001)
-        else:
-            meshes = trimesh.load(filename)
+        # To convert the mesh unit from millimeters to meters,
+        # use the function meshes.convert_units('meter').
+        meshes = trimesh.load(filename)
         if meshes.units is not None and meshes.units != 'meter':
             meshes = meshes.convert_units('meter')
     except Exception as e:


### PR DESCRIPTION
To convert the mesh unit from millimeters to meters, use the function meshes.convert_units('meter').

https://github.com/ros/solidworks_urdf_exporter/issues/114
To output color in URDF exporter, it is beneficial to use 3DXML. This allows for the export of colored URDF, which can be accurately rendered by Skrobot.