### PR TITLE
Assoced robot ik

### DIFF
--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -59,10 +59,15 @@ class CascadedLink(CascadedCoords):
         self._collision_manager = None
         self._relevance_predicate_table = None
 
-    def _compute_relevance_predicate_table(self):
+    def _compute_relevance_predicate_table(self, joint_list=None,
+                                           link_list=None):
+        if joint_list is None:
+            joint_list = self.joint_list
+        if link_list is None:
+            link_list = self.link_list
         relevance_predicate_table = {}
-        for joint in self.joint_list:
-            for link in self.link_list:
+        for joint in joint_list:
+            for link in link_list:
                 key = (joint, link)
                 relevance_predicate_table[key] = False
 
@@ -75,7 +80,7 @@ class CascadedLink(CascadedCoords):
             for clink in link._child_links:
                 inner_recursion(joint, clink)
 
-        for joint in self.joint_list:
+        for joint in joint_list:
             link = joint.child_link
             inner_recursion(joint, link)
         return relevance_predicate_table


### PR DESCRIPTION
When a robot is associated with another robot, this is a modification to solve the IK (Inverse Kinematics). This is necessary when robots transform or combine.

https://github.com/iory/scikit-robot/assets/4690682/19b79641-abba-4e7d-93bd-672236489680


```
import numpy as np

import skrobot
from skrobot.coordinates import Coordinates


robot = skrobot.models.PR2()
robot2 = skrobot.models.PR2()
robot2.newcoords(robot.rarm.end_coords.copy_worldcoords()).rotate(np.pi / 2.0, 'y')
robot.rarm.end_coords.parent.assoc(robot2)
viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
plane = skrobot.model.Box(
    extents=(2, 2, 0.01), face_colors=(0.75, 0.75, 0.75)
)
viewer.add(plane)
viewer.add(robot)
viewer.add(robot2)
viewer.show()


link_list = robot.find_link_path(robot.base_link, robot2.rarm.end_coords.parent)
link_list = [l for l in link_list
             if hasattr(l, 'joint') and l.joint is not None and l.joint.__class__.__name__ != 'FixedJoint']

robot._relevance_predicate_table = \
            robot._compute_relevance_predicate_table(
                joint_list=[l.joint for l in link_list],
                link_list=link_list)

robot.reset_pose()
robot2.reset_pose()
robot.inverse_kinematics(
    robot2.rarm_end_coords.copy_worldcoords().translate((-0.1, 0, 0)),
    link_list=link_list,
    move_target=robot2.rarm.end_coords,
    rotation_axis=True,
    stop=1000)

````