### PR TITLE
refactor: remove origin of sdf except GridSDF

### DIFF
--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -64,7 +64,7 @@ class Box(Link):
                                   visual_mesh=mesh)
         self._extents = extents
         if with_sdf:
-            sdf = BoxSDF(np.zeros(3), extents)
+            sdf = BoxSDF(extents)
             self.assoc(sdf.coords, relative_coords="local")
             self.sdf = sdf
 
@@ -131,7 +131,7 @@ class Cylinder(Link):
                                        collision_mesh=mesh,
                                        visual_mesh=mesh)
         if with_sdf:
-            sdf = CylinderSDF(np.zeros(3), height, radius)
+            sdf = CylinderSDF(height, radius)
             self.assoc(sdf.coords, relative_coords="local")
             self.sdf = sdf
 
@@ -153,7 +153,7 @@ class Sphere(Link):
                                      visual_mesh=mesh)
 
         if with_sdf:
-            sdf = SphereSDF(np.zeros(3), radius)
+            sdf = SphereSDF(radius)
             self.assoc(sdf.coords, relative_coords="local")
             self.sdf = sdf
 

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -88,7 +88,7 @@ class CascadedLink(CascadedCoords):
         this method returns `True`. Otherwise returns `False`.
         """
 
-        assert isinstance(something, CascadedCoords),\
+        assert isinstance(something, CascadedCoords), \
             "input must be at least a cascaded coords"
 
         def find_nearest_ancestor_link(something):
@@ -1457,7 +1457,7 @@ class CascadedLink(CascadedCoords):
                                      additional_jacobi_dimension=0,
                                      n_joint_dimension=None,
                                      *args, **kwargs):
-        assert self._relevance_predicate_table is not None,\
+        assert self._relevance_predicate_table is not None, \
             "relevant table must be set beforehand"
 
         if link_list is None:

--- a/skrobot/planner/collision_checker.py
+++ b/skrobot/planner/collision_checker.py
@@ -77,7 +77,7 @@ class SweptSphereSdfCollisionChecker(object):
         self.coll_link_name_list.append(coll_link)
 
         col_mesh = coll_link.collision_mesh
-        assert type(col_mesh) == trimesh.base.Trimesh
+        assert type(col_mesh) is trimesh.base.Trimesh
 
         centers, R = compute_swept_sphere(col_mesh)
         sphere_list = []

--- a/tests/skrobot_tests/test_sdf.py
+++ b/tests/skrobot_tests/test_sdf.py
@@ -33,7 +33,7 @@ class TestSDF(unittest.TestCase):
 
         # prepare boxsdf
         box_withds = np.array([0.05, 0.1, 0.05])
-        boxsdf = BoxSDF([0, 0, 0], box_withds)
+        boxsdf = BoxSDF(box_withds)
         boxtrans = np.array([0.0, 0.1, 0.0])
         boxsdf.coords.translate(boxtrans)
 
@@ -48,8 +48,8 @@ class TestSDF(unittest.TestCase):
         height = 1.0
         cls.radius = radius
         cls.height = height
-        cls.sphere_sdf = SphereSDF([0, 0, 0], radius=radius)
-        cls.cylinder_sdf = CylinderSDF([0, 0, 0], radius=radius, height=height)
+        cls.sphere_sdf = SphereSDF(radius=radius)
+        cls.cylinder_sdf = CylinderSDF(radius=radius, height=height)
 
         # preapare UnionSDF
         unionsdf = UnionSDF(sdf_list=[boxsdf, gridsdf])


### PR DESCRIPTION
## What does this refactor? 
- back ground: why did we need `local` flame and `local->sdf` transformation in the first place
When we think about it naturally, we only need "world" -> "sdf" coordinates and transformation. The "local" frame seems unnecessary. So, why did we introduce it? Here, "sdf" refers to the coordinates where the sdf function is defined. The need for the "local" intermediate frame is specifically tied to "GridSDF". In GridSDF, the origin is computed by sdfgen and this cannot be "zero". Therefore, we introduced the local frame. By treating the GridSDF's origin as local -> sdf, we effectively manage it.

However, we don't actually need the local -> sdf transformation for **any primitive sdfs**. Instead of setting `origin` value, we can simply apply `translate` to the `sdf.coords`. In fact, for all primitive sdf's, the origin is already set to zero. See the following examples:
see:
https://github.com/iory/scikit-robot/blob/7752de8710591b32f95a9d72a62ff91cce5feed1/skrobot/model/primitives.py#L67
https://github.com/iory/scikit-robot/blob/7752de8710591b32f95a9d72a62ff91cce5feed1/skrobot/model/primitives.py#L139
https://github.com/iory/scikit-robot/blob/7752de8710591b32f95a9d72a62ff91cce5feed1/skrobot/model/primitives.py#L161  

Additionally, in my more than two years of heavy usage of scikit-robot's sdf, I've never encountered a situation where I needed to specify an extra origin for the primitive sdfs.

Given these considerations, it seems reasonable to only consider origin for GridSDF and not for other primitive shapes. This pull request reflects such a perspective.

## performance improvement by this PR 
This PR not only reduce the complexity of the code, but also reduce the computation time considerably.
For example the running time of the following code is reduced  about1.5 times. 

```python
from pyinstrument import Profiler
import numpy as np
from skrobot.model.primitives import Sphere

sdf = Sphere(radius=0.1, with_sdf=True).sdf
X = np.random.randn(10, 3)

profiler = Profiler()
profiler.start()
for _ in range(1000):
    sdf(X)
profiler.stop()
print(profiler.output_text(unicode=True, color=True, show_all=True))
```

Before this PR:
```
0.023 <module>  tmp.py:1
└─ 0.023 SphereSDF.__call__  skrobot/sdf/signed_distance_function.py:122
   ├─ 0.014 SphereSDF._transform_pts_obj_to_sdf  skrobot/sdf/signed_distance_function.py:179
   │  ├─ 0.005 Transform.transform_vector  skrobot/coordinates/base.py:94
   │  ├─ 0.004 CascadedCoords.get_transform  skrobot/coordinates/base.py:239
   │  │  ├─ 0.002 CascadedCoords.worldrot  skrobot/coordinates/base.py:1503
   │  │  ├─ 0.001 [self]  skrobot/coordinates/base.py
   │  │  └─ 0.001 CascadedCoords.worldpos  skrobot/coordinates/base.py:1506
   │  │     └─ 0.001 CascadedCoords.worldcoords  skrobot/coordinates/base.py:1498
   │  ├─ 0.004 Transform.inverse_transformation  skrobot/coordinates/base.py:132
   │  │  ├─ 0.002 Transform.__init__  skrobot/coordinates/base.py:90
   │  │  │  ├─ 0.001 [self]  skrobot/coordinates/base.py
   │  │  │  └─ 0.001 array  <built-in>
   │  │  ├─ 0.001 [self]  skrobot/coordinates/base.py
   │  │  └─ 0.001 ndarray.dot  <built-in>
   │  └─ 0.001 [self]  skrobot/sdf/signed_distance_function.py
   ├─ 0.008 SphereSDF._signed_distance  skrobot/sdf/signed_distance_function.py:322
   │  ├─ 0.004 [self]  skrobot/sdf/signed_distance_function.py
   │  └─ 0.004 sum  <__array_function__ internals>:177
   │     ├─ 0.003 sum  numpy/core/fromnumeric.py:2160
   │     │  ├─ 0.002 _wrapreduction  numpy/core/fromnumeric.py:69
   │     │  │  └─ 0.002 ufunc.reduce  <built-in>
   │     │  └─ 0.001 [self]  numpy/core/fromnumeric.py
   │     └─ 0.001 [self]  <__array_function__ internals>
   └─ 0.001 [self]  skrobot/sdf/signed_distance_function.py
```
After this PR:
```
0.016 <module>  tmp.py:1
├─ 0.015 SphereSDF.__call__  skrobot/sdf/signed_distance_function.py:119
│  ├─ 0.008 SphereSDF._signed_distance  skrobot/sdf/signed_distance_function.py:313
│  │  ├─ 0.004 [self]  skrobot/sdf/signed_distance_function.py
│  │  └─ 0.004 sum  <__array_function__ internals>:177
│  │     └─ 0.004 sum  numpy/core/fromnumeric.py:2160
│  │        ├─ 0.003 _wrapreduction  numpy/core/fromnumeric.py:69
│  │        │  ├─ 0.002 ufunc.reduce  <built-in>
│  │        │  └─ 0.001 dict.items  <built-in>
│  │        └─ 0.001 [self]  numpy/core/fromnumeric.py
│  └─ 0.007 SphereSDF._transform_pts_obj_to_sdf  skrobot/sdf/signed_distance_function.py:176
│     ├─ 0.003 CascadedCoords.get_transform  skrobot/coordinates/base.py:239
│     │  ├─ 0.002 CascadedCoords.worldpos  skrobot/coordinates/base.py:1506
│     │  └─ 0.001 Transform.__init__  skrobot/coordinates/base.py:90
│     │     └─ 0.001 array  <built-in>
│     ├─ 0.002 Transform.inverse_transformation  skrobot/coordinates/base.py:132
│     │  └─ 0.002 ndarray.dot  <built-in>
│     └─ 0.002 Transform.transform_vector  skrobot/coordinates/base.py:94
│        ├─ 0.001 [self]  skrobot/coordinates/base.py
│        └─ 0.001 ndarray.dot  <built-in>
└─ 0.001 [self]  tmp.py
```

## Removing bug
This PR, actually removing (not fixing) bug. 
In the original code, `local->sdf` transformation was done **twice** for primitive shapes. 
The origin is stored as `sdf_to_obj_transform` and `_origin`
https://github.com/iory/scikit-robot/blob/master/skrobot/sdf/signed_distance_function.py#L118-L119
Then used here
https://github.com/iory/scikit-robot/blob/7752de8710591b32f95a9d72a62ff91cce5feed1/skrobot/sdf/signed_distance_function.py#L194
So, because origin is used here, we are not supposed to be use origin in the later computations. 
However, in each primitive sdf computation we found
https://github.com/iory/scikit-robot/blob/7752de8710591b32f95a9d72a62ff91cce5feed1/skrobot/sdf/signed_distance_function.py#L293
https://github.com/iory/scikit-robot/blob/master/skrobot/sdf/signed_distance_function.py#L324-L326
https://github.com/iory/scikit-robot/blob/master/skrobot/sdf/signed_distance_function.py#L352-L355



This bug has  just not been found because we have only used `origin = np.zeros(3)` for all primitive shapes.   



 