### PR TITLE
perf: cache forward/backward transformation of sdf in update()

### DIFF
--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -65,7 +65,7 @@ class Box(Link):
         self._extents = extents
         if with_sdf:
             sdf = BoxSDF(extents)
-            self.assoc(sdf.coords, relative_coords="local")
+            self.assoc(sdf, relative_coords="local")
             self.sdf = sdf
 
 
@@ -137,7 +137,7 @@ class Cylinder(Link):
                                        visual_mesh=mesh)
         if with_sdf:
             sdf = CylinderSDF(height, radius)
-            self.assoc(sdf.coords, relative_coords="local")
+            self.assoc(sdf, relative_coords="local")
             self.sdf = sdf
 
 
@@ -159,7 +159,7 @@ class Sphere(Link):
 
         if with_sdf:
             sdf = SphereSDF(radius)
-            self.assoc(sdf.coords, relative_coords="local")
+            self.assoc(sdf, relative_coords="local")
             self.sdf = sdf
 
 
@@ -238,7 +238,7 @@ class MeshLink(Link):
         if with_sdf:
             sdf = trimesh2sdf(self._collision_mesh, dim_grid=dim_grid,
                               padding_grid=padding_grid)
-            self.assoc(sdf.coords, relative_coords="local")
+            self.assoc(sdf, relative_coords="local")
             self.sdf = sdf
 
 

--- a/tests/skrobot_tests/test_sdf.py
+++ b/tests/skrobot_tests/test_sdf.py
@@ -35,7 +35,7 @@ class TestSDF(unittest.TestCase):
         box_withds = np.array([0.05, 0.1, 0.05])
         boxsdf = BoxSDF(box_withds)
         boxtrans = np.array([0.0, 0.1, 0.0])
-        boxsdf.coords.translate(boxtrans)
+        boxsdf.translate(boxtrans)
 
         cls.box_withds = box_withds
         cls.boxsdf = boxsdf
@@ -128,6 +128,16 @@ class TestSDF(unittest.TestCase):
         testing.assert_array_almost_equal(
             sdf(points_box_edge_world), [0, 0])
 
+    def test_update(self):
+        origins = np.zeros((1, 3))
+        width = np.array([1, 1, 1])
+        sdf = BoxSDF(width)
+        testing.assert_almost_equal(sdf(origins)[0], -0.5)
+
+        # after translation, transformations must be updated
+        sdf.translate(0.5 * width)
+        testing.assert_almost_equal(sdf(origins)[0], 0.0)
+
     def test_surface_points(self):
         sdf = self.boxsdf
         surface_points_world, _ = sdf.surface_points(n_sample=20)
@@ -180,8 +190,8 @@ class TestSDF(unittest.TestCase):
         assert np.all(logicals)
 
     def test_unionsdf_assert_use_abs_false(self):
-        b1 = BoxSDF([1, 1, 1], [0, 0, 0], use_abs=True)
-        b2 = BoxSDF([1, 1, 1], [0, 0, 0], use_abs=False)
+        b1 = BoxSDF([1, 1, 1], use_abs=True)
+        b2 = BoxSDF([1, 1, 1], use_abs=False)
         with self.assertRaises(AssertionError):
             UnionSDF(sdf_list=[b1, b2])
 


### PR DESCRIPTION
!!!! Please merge after https://github.com/iory/scikit-robot/pull/324 is merged

Only **the last commit** corresponds to this PR. 

## whats this
cache forward/backward transformation in update(). I found it is simpler to implement this if sdfs are CascadedCoords, so I changed its relation from "has-a" to "is-a".   

By this PR, about 1.5x speed up of sdf computation is achieved.  and combined with https://github.com/iory/scikit-robot/pull/323, the about 2x sppedup is achieved! 
the benchmark script:
```python
from pyinstrument import Profiler
import numpy as np
from skrobot.model.primitives import Sphere

s = Sphere(radius=0.1, with_sdf=True)
sdf = s.sdf
X = np.zeros((10, 3))

profiler = Profiler()
profiler.start()
for _ in range(10000):
    sdf(X)
profiler.stop()
print(profiler.output_text(unicode=True, color=True, show_all=True))
```

Before this PR:
```
0.170 <module>  bench.py:1
├─ 0.168 SphereSDF.__call__  skrobot/sdf/signed_distance_function.py:123
│  ├─ 0.098 SphereSDF._transform_pts_world_to_sdf  skrobot/sdf/signed_distance_function.py:180
│  │  ├─ 0.038 Transform.transform_vector  skrobot/coordinates/base.py:94
│  │  │  ├─ 0.029 [self]  skrobot/coordinates/base.py
│  │  │  └─ 0.009 ndarray.dot  <built-in>
│  │  ├─ 0.032 CascadedCoords.get_transform  skrobot/coordinates/base.py:239
│  │  │  ├─ 0.010 CascadedCoords.worldpos  skrobot/coordinates/base.py:1506
│  │  │  │  ├─ 0.004 CascadedCoords.worldcoords  skrobot/coordinates/base.py:1498
│  │  │  │  ├─ 0.003 Coordinates.translation  skrobot/coordinates/base.py:311
│  │  │  │  │  ├─ 0.002 [self]  skrobot/coordinates/base.py
│  │  │  │  │  └─ 0.001 CascadedCoords.update  skrobot/coordinates/base.py:1484
│  │  │  │  └─ 0.003 [self]  skrobot/coordinates/base.py
│  │  │  ├─ 0.009 CascadedCoords.worldrot  skrobot/coordinates/base.py:1503
│  │  │  │  ├─ 0.004 CascadedCoords.worldcoords  skrobot/coordinates/base.py:1498
│  │  │  │  │  ├─ 0.003 [self]  skrobot/coordinates/base.py
│  │  │  │  │  └─ 0.001 CascadedCoords.update  skrobot/coordinates/base.py:1484
│  │  │  │  ├─ 0.004 [self]  skrobot/coordinates/base.py
│  │  │  │  └─ 0.001 Coordinates.rotation  skrobot/coordinates/base.py:249
│  │  │  ├─ 0.009 Transform.__init__  skrobot/coordinates/base.py:90
│  │  │  │  ├─ 0.005 array  <built-in>
│  │  │  │  └─ 0.004 [self]  skrobot/coordinates/base.py
│  │  │  └─ 0.004 [self]  skrobot/coordinates/base.py
│  │  ├─ 0.021 Transform.inverse_transformation  skrobot/coordinates/base.py:132
│  │  │  ├─ 0.009 ndarray.dot  <built-in>
│  │  │  ├─ 0.007 Transform.__init__  skrobot/coordinates/base.py:90
│  │  │  │  ├─ 0.005 array  <built-in>
│  │  │  │  └─ 0.002 [self]  skrobot/coordinates/base.py
│  │  │  └─ 0.005 [self]  skrobot/coordinates/base.py
│  │  └─ 0.007 [self]  skrobot/sdf/signed_distance_function.py
│  ├─ 0.066 SphereSDF._signed_distance  skrobot/sdf/signed_distance_function.py:317
│  │  ├─ 0.041 sum  <__array_function__ internals>:177
│  │  │  ├─ 0.033 sum  numpy/core/fromnumeric.py:2160
│  │  │  │  ├─ 0.027 _wrapreduction  numpy/core/fromnumeric.py:69
│  │  │  │  │  ├─ 0.019 ufunc.reduce  <built-in>
│  │  │  │  │  ├─ 0.004 <dictcomp>  numpy/core/fromnumeric.py:70
│  │  │  │  │  ├─ 0.003 [self]  numpy/core/fromnumeric.py
│  │  │  │  │  └─ 0.001 dict.items  <built-in>
│  │  │  │  ├─ 0.004 [self]  numpy/core/fromnumeric.py
│  │  │  │  └─ 0.002 isinstance  <built-in>
│  │  │  ├─ 0.007 [self]  <__array_function__ internals>
│  │  │  └─ 0.001 implement_array_function  <built-in>
│  │  └─ 0.025 [self]  skrobot/sdf/signed_distance_function.py
│  └─ 0.004 [self]  skrobot/sdf/signed_distance_function.py
└─ 0.002 [self]  bench.py
```
After this PR:
```
0.114 <module>  bench.py:1
├─ 0.113 SphereSDF.__call__  skrobot/sdf/signed_distance_function.py:139
│  ├─ 0.068 SphereSDF._signed_distance  skrobot/sdf/signed_distance_function.py:332
│  │  ├─ 0.040 sum  <__array_function__ internals>:177
│  │  │  ├─ 0.032 sum  numpy/core/fromnumeric.py:2160
│  │  │  │  ├─ 0.024 _wrapreduction  numpy/core/fromnumeric.py:69
│  │  │  │  │  ├─ 0.013 ufunc.reduce  <built-in>
│  │  │  │  │  ├─ 0.007 [self]  numpy/core/fromnumeric.py
│  │  │  │  │  ├─ 0.002 <dictcomp>  numpy/core/fromnumeric.py:70
│  │  │  │  │  └─ 0.002 dict.items  <built-in>
│  │  │  │  └─ 0.008 [self]  numpy/core/fromnumeric.py
│  │  │  ├─ 0.004 [self]  <__array_function__ internals>
│  │  │  └─ 0.004 _sum_dispatcher  numpy/core/fromnumeric.py:2155
│  │  └─ 0.028 [self]  skrobot/sdf/signed_distance_function.py
│  ├─ 0.043 SphereSDF._transform_pts_world_to_sdf  skrobot/sdf/signed_distance_function.py:197
│  │  ├─ 0.029 Transform.transform_vector  skrobot/coordinates/base.py:94
│  │  │  ├─ 0.021 [self]  skrobot/coordinates/base.py
│  │  │  └─ 0.008 ndarray.dot  <built-in>
│  │  ├─ 0.009 SphereSDF.update  skrobot/sdf/signed_distance_function.py:124
│  │  │  ├─ 0.007 [self]  skrobot/sdf/signed_distance_function.py
│  │  │  └─ 0.002 SphereSDF.update  skrobot/coordinates/base.py:1484
│  │  └─ 0.005 [self]  skrobot/sdf/signed_distance_function.py
│  └─ 0.002 [self]  skrobot/sdf/signed_distance_function.py
└─ 0.001 [self]  bench.py
```

## double check by visualization
As this change is bit complex, I doubled checked by the following script. Following script create pr2's sdf. and filter the near-surface points using the sdf. After `reset_manip_pose` the overall coordinates are changed, and the following visualization shows that sdf's transformation are properly reflect the change.

`h-ishida@azarashi:~/tmp/debug$ cat pr2.py `
```python
import argparse
import numpy as np
from skrobot.models.pr2 import PR2
from skrobot.model.primitives import PointCloudLink
from skrobot.sdf.signed_distance_function import UnionSDF
from skrobot.viewers import TrimeshSceneViewer

import argparse
parser = argparse.ArgumentParser()
parser.add_argument("--manip", action="store_true")
args = parser.parse_args()

pr2 = PR2()
sdf = UnionSDF.from_robot_model(pr2)

if args.manip:
    pr2.reset_manip_pose()
pts = np.random.rand(100000, 3) * np.array([1.5, 1.5, 2]) - np.array([0.75, 0.75, 0.0])
pts_surface = pts[np.abs(sdf(pts)) < 0.05]
pc = PointCloudLink(pts_surface)

v = TrimeshSceneViewer(resolution=(640, 480))
v.add(pc)
v.show()
import time; time.sleep(1000)
```

Result of `python3 pr2.py`: (pr2 is init pose)
![image](https://github.com/iory/scikit-robot/assets/38597814/898bf0f2-e73d-430b-954d-1ad0d3bcc112)

Result of `python3 pr2.py --manip` (pr2 is manip pose)
![image](https://github.com/iory/scikit-robot/assets/38597814/2a499882-0ee8-4aee-975d-3501d43474a3)

