### PR TITLE
fix: read actual av not previously-commanded one

### DIFF
--- a/skrobot/interfaces/ros/pr2.py
+++ b/skrobot/interfaces/ros/pr2.py
@@ -160,7 +160,7 @@ class PR2ROSRobotInterface(ROSRobotMoveBaseInterface):
             controller_type = self.controller_type  # use default controller
 
         if av is not None:
-            av_diff = av - self.potentio_vector()
+            av_diff = av - self.angle_vector()
             diff_max, joint_name = self._continous_joint_largest_movement(
                 av_diff, controller_type)
             if diff_max > math.pi:
@@ -204,7 +204,7 @@ class PR2ROSRobotInterface(ROSRobotMoveBaseInterface):
         assert isinstance(times, list), 'times must be None or list'
         assert len(avs) == len(times), 'length of times and avs must be equal'
 
-        av_initial = self.potentio_vector()
+        av_initial = self.angle_vector()
         avs_with_initial = [av_initial] + avs
 
         avs_reformed = []


### PR DESCRIPTION
The current angle vector should be the actual one, not the cached (previously commanded one). 

2023/12/27: Tested on real robot for couple of days and no problem found. @iory could you review this?