### PR TITLE
Synchronize camera and trackball transform

### DIFF
--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -7,6 +7,7 @@ import threading
 import pyglet
 from pyglet import compat_platform
 import trimesh
+from trimesh.transformations import euler_from_matrix
 import trimesh.viewer
 from trimesh.viewer.trackball import Trackball
 
@@ -176,6 +177,10 @@ class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
         self._redraw = True
 
     def set_camera(self, *args, **kwargs):
+        if len(args) < 1 and 'angles' not in kwargs:
+            if hasattr(self, "view"):
+                kwargs['angles'] = euler_from_matrix(
+                    self.view["ball"].pose[:3, :3])
         with self.lock:
             self.scene.set_camera(*args, **kwargs)
             if hasattr(self, "view"):

--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -8,6 +8,7 @@ import pyglet
 from pyglet import compat_platform
 import trimesh
 import trimesh.viewer
+from trimesh.viewer.trackball import Trackball
 
 from .. import model as model_module
 
@@ -177,6 +178,13 @@ class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
     def set_camera(self, *args, **kwargs):
         with self.lock:
             self.scene.set_camera(*args, **kwargs)
+            if hasattr(self, "view"):
+                self.view["ball"] = Trackball(
+                    pose=self.scene.camera_transform,
+                    size=self.scene.camera.resolution,
+                    scale=self.scene.scale,
+                    target=self.scene.centroid
+                )
 
     def save_image(self, file_obj):
         self.switch_to()


### PR DESCRIPTION
- Without this PR, `set_camera` uses `angles=[0,0,0]` by default. 
ex. `viewer.set_camera(distance=0.3)`
<img src="https://github.com/iory/scikit-robot/assets/63297509/c465ff6b-5eaa-47c1-b3dc-65e59f5603f0" width="200px">
<img src="https://github.com/iory/scikit-robot/assets/63297509/c1400129-36e9-40a7-b456-380c673669d2" width="200px">

And the view return to the original posture(left) by clicking.
- With this PR, `set_camera` keeps camera_transform if `angles` is not specified. 
<img src="https://github.com/iory/scikit-robot/assets/63297509/2ae0949d-3e9b-4066-a9cd-10a79bd750d6" width="180px">
<img src="https://github.com/iory/scikit-robot/assets/63297509/6456b067-f2e1-42e1-95e4-7b16b9f1528e" width="180px">

You can move the view from the transformed posture(right).