### PR TITLE
Add convert-urdf-mesh command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,12 @@ if (sys.version_info.major, sys.version_info.minor) <= (3, 7):
 extra_all_requires += docs_install_requires + opt_install_requires
 
 
+console_scripts = ["visualize-urdf=skrobot.apps.visualize_urdf:main"]
+if (sys.version_info.major, sys.version_info.minor) >= (3, 6):
+    console_scripts.append(
+        "convert-urdf-mesh=skrobot.apps.convert_urdf_mesh:main")
+
+
 setup(
     name='scikit-robot',
     version=version,
@@ -124,10 +130,7 @@ setup(
     setup_requires=setup_requires,
     install_requires=install_requires,
     entry_points={
-        "console_scripts": [
-            "convert-urdf-mesh=skrobot.apps.convert_urdf_mesh:main",
-            "visualize-urdf=skrobot.apps.visualize_urdf:main",
-        ]
+        "console_scripts": console_scripts,
     },
     extras_require={
         'opt': opt_install_requires,

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,8 @@ setup(
     install_requires=install_requires,
     entry_points={
         "console_scripts": [
-            "visualize-urdf=skrobot.apps.visualize_urdf:main"
+            "convert-urdf-mesh=skrobot.apps.convert_urdf_mesh:main",
+            "visualize-urdf=skrobot.apps.visualize_urdf:main",
         ]
     },
     extras_require={

--- a/skrobot/apps/convert_urdf_mesh.py
+++ b/skrobot/apps/convert_urdf_mesh.py
@@ -15,11 +15,18 @@ def main():
                         help='Path to the input URDF file')
     parser.add_argument('--format', '-f',
                         default='dae',
-                        choices=['dae', 'obj', 'stl'],
+                        choices=['dae', 'stl'],
                         help='Mesh format for export. Default is dae.')
     parser.add_argument('--output', help='Path for the output URDF file. If not specified, a filename is automatically generated based on the input URDF file.')  # NOQA
     parser.add_argument('--inplace', '-i', action='store_true',
                         help='Modify the input URDF file inplace. If not specified, a new file is created.')  # NOQA
+    parser.add_argument(
+        '--voxel-size', default=None, type=float,
+        help='Specifies the voxel size for the simplify_vertex_clustering'
+        ' function in open3d. When this value is provided, '
+        'it is used as the voxel size in the function to perform '
+        'mesh simplification. This process reduces the complexity'
+        ' of the mesh by clustering vertices within the specified voxel size.')
 
     args = parser.parse_args()
 
@@ -41,7 +48,9 @@ def main():
     with open(base_path / urdf_path) as f:
         r.load_urdf_file(f)
 
-    with export_mesh_format('.' + args.format):
+    with export_mesh_format(
+            '.' + args.format,
+            simplify_vertex_clustering_voxel_size=args.voxel_size):
         r.urdf_robot_model.save(str(base_path / output_path))
     if args.inplace:
         shutil.move(str(base_path / output_path),

--- a/skrobot/apps/convert_urdf_mesh.py
+++ b/skrobot/apps/convert_urdf_mesh.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import argparse
+import os.path as osp
+from pathlib import Path
+import shutil
+
+from skrobot.model import RobotModel
+from skrobot.utils.urdf import export_mesh_format
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert URDF Mesh.')
+    parser.add_argument('urdf',
+                        help='Path to the input URDF file')
+    parser.add_argument('--format', '-f',
+                        default='dae',
+                        choices=['dae', 'obj', 'stl'],
+                        help='Mesh format for export. Default is dae.')
+    parser.add_argument('--output', help='Path for the output URDF file. If not specified, a filename is automatically generated based on the input URDF file.')  # NOQA
+    parser.add_argument('--inplace', '-i', action='store_true',
+                        help='Modify the input URDF file inplace. If not specified, a new file is created.')  # NOQA
+
+    args = parser.parse_args()
+
+    base_path = Path(args.urdf).parent
+    urdf_path = Path(args.urdf)
+
+    if args.output is None:
+        fn, _ = osp.splitext(args.urdf)
+        index = 0
+        pattern = fn + "_%i.urdf"
+        outfile = pattern % index
+        while osp.exists(outfile):
+            index += 1
+            outfile = pattern % index
+        args.output = outfile
+    output_path = Path(args.output)
+
+    r = RobotModel()
+    with open(base_path / urdf_path) as f:
+        r.load_urdf_file(f)
+
+    with export_mesh_format('.' + args.format):
+        r.urdf_robot_model.save(str(base_path / output_path))
+    if args.inplace:
+        shutil.move(str(base_path / output_path),
+                    base_path / urdf_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/skrobot/utils/mesh.py
+++ b/skrobot/utils/mesh.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+
+def split_mesh_by_face_color(mesh):
+    """Split a trimesh mesh based on face colors.
+
+    Parameters
+    ----------
+    mesh : trimesh.Trimesh
+        Mesh to be split.
+
+    Returns
+    -------
+    List[trimesh.Trimesh]
+        List of meshes, each corresponding to a unique face color.
+
+    Notes
+    -----
+    This function uses the face colors of the provided mesh to
+    generate a list of submeshes, where each submesh contains
+    faces of the same color.
+    """
+    face_colors = mesh.visual.face_colors
+    unique_colors = np.unique(face_colors, axis=0)
+    submeshes = []
+    for color in unique_colors:
+        mask = np.all(face_colors == color, axis=1)
+        submesh = mesh.submesh([mask])[0]
+        submeshes.append(submesh)
+
+    return submeshes

--- a/skrobot/utils/mesh.py
+++ b/skrobot/utils/mesh.py
@@ -20,6 +20,8 @@ def split_mesh_by_face_color(mesh):
     generate a list of submeshes, where each submesh contains
     faces of the same color.
     """
+    if mesh.visual.kind == 'texture':
+        return [mesh]
     face_colors = mesh.visual.face_colors
     unique_colors = np.unique(face_colors, axis=0)
     submeshes = []

--- a/skrobot/utils/mesh.py
+++ b/skrobot/utils/mesh.py
@@ -1,4 +1,5 @@
 import numpy as np
+import trimesh
 
 
 def split_mesh_by_face_color(mesh):
@@ -31,3 +32,35 @@ def split_mesh_by_face_color(mesh):
         submeshes.append(submesh)
 
     return submeshes
+
+
+def to_open3d(mesh):
+    import open3d
+    o3d_mesh = open3d.geometry.TriangleMesh()
+    o3d_mesh.vertices = open3d.utility.Vector3dVector(np.array(mesh.vertices))
+    o3d_mesh.triangles = open3d.utility.Vector3iVector(np.array(mesh.faces))
+
+    # Convert vertex colors from RGBA to RGB and normalize the color values
+    # Use NumPy slicing and broadcasting for efficient conversion
+    vertex_colors = np.array(mesh.visual.vertex_colors)[:, :3] / 255.0
+    o3d_mesh.vertex_colors = open3d.utility.Vector3dVector(vertex_colors)
+    return o3d_mesh
+
+
+def simplify_vertex_clustering(
+        meshes, simplify_vertex_clustering_voxel_size=0.001):
+    if not isinstance(meshes, list):
+        meshes = [meshes]
+    simplify_meshes = []
+    for mesh in meshes:
+        if mesh.visual.kind == 'texture':
+            simplify_meshes.append(mesh)
+            continue
+        simple = to_open3d(mesh).simplify_vertex_clustering(
+            simplify_vertex_clustering_voxel_size)
+        mesh = trimesh.Trimesh(
+            vertices=simple.vertices,
+            faces=simple.triangles,
+            vertex_colors=simple.vertex_colors)
+        simplify_meshes.append(mesh)
+    return simplify_meshes

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -868,6 +868,9 @@ class Mesh(URDFType):
             dae_data = trimesh.exchange.dae.export_collada(meshes)
             with open(fn, 'wb') as f:
                 f.write(dae_data)
+        elif fn.endswith('.stl') or fn.endswith('.obj'):
+            meshes = trimesh.util.concatenate(meshes)
+            trimesh.exchange.export.export_mesh(meshes, fn)
         else:
             trimesh.exchange.export.export_mesh(meshes, fn)
 

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -285,14 +285,18 @@ def _load_meshes(filename):
     if isinstance(meshes, (list, tuple, set)):
         meshes = list(meshes)
         if len(meshes) == 0:
-            raise ValueError('At least one mesh must be present in file')
+            logger.error('At least one mesh must be present in file.'
+                         ' Please check {} file'.format(filename))
+            meshes = [trimesh.creation.box((0.001, 0.001, 0.001))]
         for r in meshes:
             if not isinstance(r, trimesh.Trimesh):
-                raise TypeError('Could not load meshes from file')
+                raise TypeError('Could not load meshes from file {}'.
+                                format(filename))
     elif isinstance(meshes, trimesh.Trimesh):
         meshes = [meshes]
     else:
-        raise ValueError('Unable to load mesh from file')
+        logger.error('Unable to load mesh from file {}'.format(filename))
+        meshes = [trimesh.creation.box((0.001, 0.001, 0.001))]
 
     for mesh in meshes:
         transparency = get_transparency(mesh)

--- a/tests/skrobot_tests/test_console_scripts.py
+++ b/tests/skrobot_tests/test_console_scripts.py
@@ -1,6 +1,8 @@
+import os
 import os.path as osp
 import subprocess
 import sys
+import tempfile
 import unittest
 
 import pytest
@@ -12,21 +14,20 @@ class TestConsoleScripts(unittest.TestCase):
 
     @pytest.mark.skipif(sys.version_info[0] == 2, reason="Skip in Python 2")
     def test_convert_urdf_mesh(self):
+        tmp_output = tempfile.TemporaryDirectory()
+        os.environ['SKROBOT_CACHE_DIR'] = tmp_output.name
         urdfpath = fetch_urdfpath()
 
         # fetch_0.urdf will be create after f'convert-urdf-mesh {urdfpath}'
         out_urdfpath = osp.join(osp.dirname(urdfpath), 'fetch_0.urdf')
         out_stl_urdfpath = osp.join(osp.dirname(urdfpath), 'fetch_stl.urdf')
-        out_obj_urdfpath = osp.join(osp.dirname(urdfpath), 'fetch_obj.urdf')
 
         cmds = ['convert-urdf-mesh {}'.format(urdfpath),
                 'convert-urdf-mesh {} --inplace'.format(out_urdfpath),
                 'convert-urdf-mesh {} --output {} -f stl'.format(
                     out_urdfpath,
                     out_stl_urdfpath),
-                'convert-urdf-mesh {} --output {} -f obj'.format(
-                    out_urdfpath,
-                    out_obj_urdfpath)
+                'convert-urdf-mesh {} --voxel-size 0.001'.format(urdfpath),
                 ]
         kwargs = {}
         kwargs["stdout"] = subprocess.PIPE

--- a/tests/skrobot_tests/test_console_scripts.py
+++ b/tests/skrobot_tests/test_console_scripts.py
@@ -1,0 +1,40 @@
+import os.path as osp
+import subprocess
+import sys
+import unittest
+
+import pytest
+
+from skrobot.data import fetch_urdfpath
+
+
+class TestConsoleScripts(unittest.TestCase):
+
+    @pytest.mark.skipif(sys.version_info[0] == 2, reason="Skip in Python 2")
+    def test_convert_urdf_mesh(self):
+        urdfpath = fetch_urdfpath()
+
+        # fetch_0.urdf will be create after f'convert-urdf-mesh {urdfpath}'
+        out_urdfpath = osp.join(osp.dirname(urdfpath), 'fetch_0.urdf')
+        out_stl_urdfpath = osp.join(osp.dirname(urdfpath), 'fetch_stl.urdf')
+        out_obj_urdfpath = osp.join(osp.dirname(urdfpath), 'fetch_obj.urdf')
+
+        cmds = ['convert-urdf-mesh {}'.format(urdfpath),
+                'convert-urdf-mesh {} --inplace'.format(out_urdfpath),
+                'convert-urdf-mesh {} --output {} -f stl'.format(
+                    out_urdfpath,
+                    out_stl_urdfpath),
+                'convert-urdf-mesh {} --output {} -f obj'.format(
+                    out_urdfpath,
+                    out_obj_urdfpath)
+                ]
+        kwargs = {}
+        kwargs["stdout"] = subprocess.PIPE
+        kwargs["stderr"] = subprocess.PIPE
+
+        for cmd in cmds:
+            print('Executing {}'.format(cmd))
+            result = subprocess.run(cmd,
+                                    shell=True,
+                                    **kwargs)
+            assert result.returncode == 0


### PR DESCRIPTION
Many software packages in ROS primarily support only the DAE format for meshes in URDF files. When using URDF Exporter with SolidWorks, there is sometimes a need to output colored meshes as 3DXML instead of STL. However, most software does not support 3DXML for loading URDFs. This contribution is intended to enable the conversion of URDF files into different formats such as DAE or STL

This PR needs https://github.com/mikedh/trimesh/pull/2105

## quickstart
```
git clone https://github.com/iory/trimesh -b dae-color
cd trimesh
pip install -e .
git clone https://github.com/iory/scikit-robot -b urdf
cd scikit-robot 
pip install -e .
```


After that,
```
convert-urdf-mesh <MESH_PATH> --inplace
```

cc: @708yamaguchi @kenmat765
