### PR TITLE
Enhance mesh simplification in skrobot by updating trimesh dependencies and adding decimation options

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ scikit-learn
 scipy;python_version>="3.0"
 scipy<=1.2.3;python_version<"3.0"
 six
-trimesh>=3.9.0,!=3.23.0
+trimesh[easy]>=3.9.0,!=3.23.0  # need rtree for simplify_quadric_decimation

--- a/skrobot/apps/convert_urdf_mesh.py
+++ b/skrobot/apps/convert_urdf_mesh.py
@@ -20,6 +20,16 @@ def main():
     parser.add_argument('--output', help='Path for the output URDF file. If not specified, a filename is automatically generated based on the input URDF file.')  # NOQA
     parser.add_argument('--inplace', '-i', action='store_true',
                         help='Modify the input URDF file inplace. If not specified, a new file is created.')  # NOQA
+    decimation_help = """
+Specifies the minimum area ratio threshold for the mesh simplification process.
+This threshold determines the minimum proportion of the original mesh area
+that must be preserved in the simplified mesh. It is a float value
+between 0 and 1.
+A higher value means more of the original mesh area is preserved,
+resulting in less simplification. Default is None."""
+    parser.add_argument(
+        '-d', "--decimation-area-ratio-threshold", type=float, default=None,
+        help=decimation_help)
     parser.add_argument(
         '--voxel-size', default=None, type=float,
         help='Specifies the voxel size for the simplify_vertex_clustering'
@@ -50,6 +60,7 @@ def main():
 
     with export_mesh_format(
             '.' + args.format,
+            decimation_area_ratio_threshold=args.decimation_area_ratio_threshold,  # NOQA
             simplify_vertex_clustering_voxel_size=args.voxel_size):
         r.urdf_robot_model.save(str(base_path / output_path))
     if args.inplace:

--- a/skrobot/apps/visualize_urdf.py
+++ b/skrobot/apps/visualize_urdf.py
@@ -10,9 +10,16 @@ from skrobot.models.urdf import RobotModelFromURDF
 def main():
     parser = argparse.ArgumentParser(description='Visualize URDF')
     parser.add_argument('input_urdfpath', type=str, help='Input URDF path')
+    parser.add_argument(
+        '--viewer', type=str,
+        choices=['trimesh', 'pyrender'], default='trimesh',
+        help='Choose the viewer type: trimesh or pyrender')
     args = parser.parse_args()
 
-    viewer = skrobot.viewers.TrimeshSceneViewer()
+    if args.viewer == 'trimesh':
+        viewer = skrobot.viewers.TrimeshSceneViewer()
+    elif args.viewer == 'pyrender':
+        viewer = skrobot.viewers.PyrenderViewer()
     model = RobotModelFromURDF(urdf_file=osp.abspath(args.input_urdfpath))
     viewer.add(model)
     viewer._init_and_start_app()

--- a/tests/skrobot_tests/test_console_scripts.py
+++ b/tests/skrobot_tests/test_console_scripts.py
@@ -28,6 +28,7 @@ class TestConsoleScripts(unittest.TestCase):
                     out_urdfpath,
                     out_stl_urdfpath),
                 'convert-urdf-mesh {} --voxel-size 0.001'.format(urdfpath),
+                'convert-urdf-mesh {} -d 0.98'.format(urdfpath),
                 ]
         kwargs = {}
         kwargs["stdout"] = subprocess.PIPE


### PR DESCRIPTION
## Quickstart

```
pip uninstall scikit-robot && pip install git+https://github.com/iory/scikit-robot.git@mesh-simplification
convert-urdf-mesh <MESH_PATH> -d 0.98
```


- Update trimesh dependency in requirements.txt to include rtree for simplify_quadric_decimation
- Add command-line options in convert_urdf_mesh.py for specifying mesh decimation area ratio threshold
- Introduce auto_simplify_quadric_decimation function in mesh.py for automated mesh simplification
- Implement mesh export format options in urdf.py to support new simplification features
- Extend test_console_scripts.py with new test cases for the added mesh simplification functionalities