### PR TITLE
Speedup visualization

### DIFF
--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -22,12 +22,11 @@ class Axis(Link):
         if name is None:
             name = 'axis_{}'.format(str(uuid.uuid1()).replace('-', '_'))
 
-        super(Axis, self).__init__(pos=pos, rot=rot, name=name)
-        self._visual_mesh = trimesh.creation.axis(
-            origin_size=0.00000001,
-            axis_radius=axis_radius,
-            axis_length=axis_length,
-        )
+        super(Axis, self).__init__(pos=pos, rot=rot, name=name,
+                                   visual_mesh=trimesh.creation.axis(
+                                       origin_size=0.00000001,
+                                       axis_radius=axis_radius,
+                                       axis_length=axis_length))
 
     @classmethod
     def from_coords(cls, coords, **kwargs):
@@ -78,8 +77,6 @@ class CameraMarker(Link):
             name = 'camera_marker_{}'.format(
                 str(uuid.uuid1()).replace('-', '_'))
 
-        super(CameraMarker, self).__init__(
-            pos=pos, rot=rot, name=name)
         camera = trimesh.scene.Camera(name=name,
                                       focal=focal,
                                       fov=fov,
@@ -89,10 +86,12 @@ class CameraMarker(Link):
         origin_size = None
         if without_axis is True:
             origin_size = 0.0
-        self._visual_mesh = trimesh.creation.camera_marker(
-            camera,
-            marker_height=marker_height,
-            origin_size=origin_size)
+        super(CameraMarker, self).__init__(
+            pos=pos, rot=rot, name=name,
+            visual_mesh=trimesh.creation.camera_marker(
+                camera,
+                marker_height=marker_height,
+                origin_size=origin_size))
 
 
 class Cone(Link):
@@ -225,8 +224,8 @@ class MeshLink(Link):
         if name is None:
             name = 'meshlink_{}'.format(str(uuid.uuid1()).replace('-', '_'))
 
-        super(MeshLink, self).__init__(pos=pos, rot=rot, name=name)
-        self.visual_mesh = visual_mesh
+        super(MeshLink, self).__init__(pos=pos, rot=rot, name=name,
+                                       visual_mesh=visual_mesh)
         if self.visual_mesh is not None:
             if isinstance(self.visual_mesh, list):
                 self._collision_mesh = \
@@ -264,5 +263,5 @@ class PointCloudLink(Link):
             name = 'pointcloudlink_{}'.format(
                 str(uuid.uuid1()).replace('-', '_'))
 
-        super(PointCloudLink, self).__init__(pos=pos, rot=rot, name=name)
-        self.visual_mesh = pcloud_mesh
+        super(PointCloudLink, self).__init__(pos=pos, rot=rot, name=name,
+                                             visual_mesh=pcloud_mesh)

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -33,6 +33,7 @@ from skrobot.model.link import find_link_path
 from skrobot.model.link import Link
 from skrobot.utils.listify import listify
 from skrobot.utils import urdf
+from skrobot.utils.urdf import enable_mesh_cache
 from skrobot.utils.urdf import URDF
 
 
@@ -1737,7 +1738,8 @@ class RobotModel(CascadedLink):
             self.urdf_path = file_obj
         else:
             self.urdf_path = getattr(file_obj, 'name', None)
-        self.urdf_robot_model = URDF.load(file_obj=file_obj)
+        with enable_mesh_cache():
+            self.urdf_robot_model = URDF.load(file_obj=file_obj)
         self.name = self.urdf_robot_model.name
         root_link = self.urdf_robot_model.base_link
 

--- a/skrobot/planner/collision_checker.py
+++ b/skrobot/planner/collision_checker.py
@@ -159,12 +159,9 @@ class SweptSphereSdfCollisionChecker(object):
 
         for idx in range(self.n_feature):
             sphere = self.coll_sphere_list[idx]
-            n_facet = len(sphere._visual_mesh.visual.face_colors)
-
             color = self.color_collision_sphere if idx in idxes_collide \
                 else self.color_normal_sphere
-            sphere._visual_mesh.visual.face_colors = np.array(
-                [color] * n_facet)
+            sphere.set_color(color)
         return dists
 
     def compute_batch_sd_vals(self,

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -890,6 +890,10 @@ class Mesh(URDFType):
                 name, _ = os.path.splitext(fn)
                 fn = name + _CONFIGURABLE_VALUES['export_mesh_format']
                 self.filename = os.path.splitext(self.filename)[0] + ext
+                if os.path.exists(fn):
+                    # skip mesh save process.
+                    node = self._unparse(path)
+                    return node
 
         # Export the meshes as a single file
         meshes = self.meshes

--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -121,7 +121,7 @@ class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
             if link_id in self._links:
                 return
             transform = link.worldcoords().T()
-            mesh = link.visual_mesh
+            mesh = link.concatenated_visual_mesh
             # TODO(someone) fix this at trimesh's scene.
             if (isinstance(mesh, list) or isinstance(mesh, tuple)) \
                and len(mesh) > 0:
@@ -134,7 +134,7 @@ class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
                         transform=transform,
                     )
                     self._links[link_mesh_id] = link
-            else:
+            elif mesh is not None:
                 self.scene.add_geometry(
                     geometry=mesh,
                     node_name=link_id,

--- a/tests/skrobot_tests/planner_tests/test_collision_checker.py
+++ b/tests/skrobot_tests/planner_tests/test_collision_checker.py
@@ -82,7 +82,7 @@ class TestCollisionChecker(unittest.TestCase):
         color_collide = self.coll_checker.color_collision_sphere
         for idx in idxes_colliding:
             sphere = self.coll_checker.coll_sphere_list[idx]
-            color_actual = sphere._visual_mesh.visual.face_colors[0]
+            color_actual = sphere.colors[0]
             testing.assert_equal(color_actual, color_collide)
 
     def test_coll_batch_forward_kinematics(self):


### PR DESCRIPTION
This PR aims to expedite visualization by adding a concatenated version of each link's visual_mesh to the viewer. Some meshes consist of numerous Trimesh objects in their visual_mesh.

Additionally, this update introduces the set_color function and colors property, widely used in visual_mesh. By using `set_color((0, 0, 255))`, users can specify a color to alter the color of a link.

It's important to note that access to trimesh.visual is no longer recommended.

Furthermore, this PR includes the addition of `skrobot.utils.urdf.enable_mesh_cache` as a context manager for caching meshes. It's automatically called within `load_urdf_file`, so it requires no user intervention. This feature is particularly effective for modular robots that repeatedly use the same mesh.

Overall, this PR enhances mesh visualization and user interaction in skrobot.

## Example

```
import time
from skrobot.viewers import TrimeshSceneViewer
from skrobot.models import PR2
import numpy as np


v = TrimeshSceneViewer()
r = PR2()
v.add(r)
v.show()

color = [255, 0, 0, 200]
for link in r.find_link_path(r.rarm_root_link, r.r_gripper_l_finger_tip_link) + r.find_link_path(r.rarm_root_link, r.r_gripper_r_finger_tip_link):
    link.set_color(color)


time.sleep(4.0)

for link in r.find_link_path(r.rarm_root_link, r.r_gripper_l_finger_tip_link) + r.find_link_path(r.rarm_root_link, r.r_gripper_r_finger_tip_link):
    link.reset_color()

```



