### PR TITLE
Fix for Inverse Kinematics Issue with Unset Joint Velocity by setting Default Max Joint Velocity

### DIFF
--- a/skrobot/data/__init__.py
+++ b/skrobot/data/__init__.py
@@ -53,7 +53,7 @@ def pr2_urdfpath():
     gdown.cached_download(
         url='https://github.com/iory/scikit-robot-models/raw/master/pr2_description.tar.gz',  # NOQA
         path=osp.join(get_cache_dir(), 'pr2_description.tar.gz'),
-        md5='e4fb915accdb3568a5524c92e9c35c9a',
+        md5='6e6e2d4f38e2c5c0a93f44b67962b98a',
         postprocess=gdown.extractall,
         quiet=True,
     )

--- a/skrobot/data/kuka_description/kuka.urdf
+++ b/skrobot/data/kuka_description/kuka.urdf
@@ -62,7 +62,7 @@
     <axis xyz="0  0  1"/>
     <limit effort="300.0" lower="-3.05433" upper="3.05433" velocity="10.0"/>
   </joint>
-  <joint name="lbr_iiwa_with_wsg50__gripper_to_arm" type="continuous">
+  <joint name="lbr_iiwa_with_wsg50__gripper_to_arm" type="fixed">
     <parent link="lbr_iiwa_with_wsg50__lbr_iiwa_link_7"/>
     <child link="lbr_iiwa_with_wsg50__base_link"/>
     <origin rpy="0  0  0" xyz="0     0     0.044"/>
@@ -74,7 +74,7 @@
     <child link="lbr_iiwa_with_wsg50__left_finger"/>
     <origin rpy="0   -0.05  0" xyz="0     0.024  0.045"/>
     <axis xyz="0  1  0"/>
-    <limit effort="100.0" lower="-10.4" upper="10.01" velocity="0.0"/>
+    <limit effort="100.0" lower="-10.4" upper="10.01" velocity="1.0"/>
   </joint>
   <joint name="lbr_iiwa_with_wsg50__left_finger_base_joint" type="fixed">
     <parent link="lbr_iiwa_with_wsg50__left_finger"/>
@@ -88,14 +88,14 @@
     <child link="lbr_iiwa_with_wsg50__left_finger_tip"/>
     <origin rpy="0   0.5  0" xyz="0.0034   0       0.06175"/>
     <axis xyz="0  1  0"/>
-    <limit effort="0.0" lower="-10.1" upper="10.3" velocity="0.0"/>
+    <limit effort="0.0" lower="-10.1" upper="10.3" velocity="1.0"/>
   </joint>
   <joint name="lbr_iiwa_with_wsg50__base_right_finger_joint" type="revolute">
     <parent link="lbr_iiwa_with_wsg50__base_link"/>
     <child link="lbr_iiwa_with_wsg50__right_finger"/>
     <origin rpy="0    0.05  0" xyz="0     0.024  0.045"/>
     <axis xyz="0  1  0"/>
-    <limit effort="100.0" lower="-10.01" upper="10.4" velocity="0.0"/>
+    <limit effort="100.0" lower="-10.01" upper="10.4" velocity="1.0"/>
   </joint>
   <joint name="lbr_iiwa_with_wsg50__right_finger_base_joint" type="fixed">
     <parent link="lbr_iiwa_with_wsg50__right_finger"/>
@@ -109,7 +109,7 @@
     <child link="lbr_iiwa_with_wsg50__right_finger_tip"/>
     <origin rpy="0  -0.5  0" xyz="-0.0034   0       0.06175"/>
     <axis xyz="0  1  0"/>
-    <limit effort="0.0" lower="-10.3" upper="10.1" velocity="0.0"/>
+    <limit effort="0.0" lower="-10.3" upper="10.1" velocity="1.0"/>
   </joint>
   <link name="lbr_iiwa_with_wsg50__lbr_iiwa_link_0">
     <inertial>

--- a/skrobot/model/joint.py
+++ b/skrobot/model/joint.py
@@ -203,6 +203,13 @@ class RotationalJoint(Joint):
         self.joint_acceleration = 0.0  # [rad/s^2]
         self.joint_torque = 0.0  # [Nm]
 
+        if max_joint_velocity <= 0:
+            message = '[WARN] Joint "{}" '.format(self.name)
+            message += "max_joint_velocity cannot be zero. "
+            message += 'Setting to default value np.deg2rad(5).'
+            logger.warning(message)
+            self.max_joint_velocity = np.deg2rad(5)
+
     def joint_angle(self, v=None, relative=None, enable_hook=True):
         """Return joint angle.
 
@@ -357,6 +364,13 @@ class LinearJoint(Joint):
         self.joint_velocity = 0.0  # [m/s]
         self.joint_acceleration = 0.0  # [m/s^2]
         self.joint_torque = 0.0  # [N]
+
+        if max_joint_velocity <= 0:
+            message = '[WARN] Joint "{}" '.format(self.name)
+            message += "max_joint_velocity cannot be zero. "
+            message += 'Setting to default value np.pi / 4.0.'
+            logger.warning(message)
+            self.max_joint_velocity = np.pi / 4.0
 
     def joint_angle(self, v=None, relative=None, enable_hook=True):
         """Return this joint's linear translation (joint angle).


### PR DESCRIPTION
When solving inverse kinematics, if the joint velocity is not set (i.e., it is 0), the calculation of movement based on the max joint velocity fails. This Pull Request addresses the issue by issuing a warning and setting a default value for max_joint_velocity.