### PR TITLE
Support PointCloudLink in PyrenderViewer

### DIFF
--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -245,6 +245,7 @@ class PointCloudLink(Link):
 
     def __init__(self,
                  point_cloud_like=None,
+                 colors=None,
                  pos=(0, 0, 0), rot=np.eye(3), name=None):
 
         accep_types = (type(None), np.ndarray, PointCloud)
@@ -255,7 +256,7 @@ class PointCloudLink(Link):
         if isinstance(point_cloud_like, np.ndarray):
             assert point_cloud_like.ndim == 2
             assert point_cloud_like.shape[1] == 3
-            pcloud_mesh = PointCloud(point_cloud_like)
+            pcloud_mesh = PointCloud(point_cloud_like, colors)
         else:
             pcloud_mesh = point_cloud_like
 

--- a/skrobot/viewers/_pyrender.py
+++ b/skrobot/viewers/_pyrender.py
@@ -17,7 +17,8 @@ from .. import model as model_module
 
 class PyrenderViewer(pyrender.Viewer):
 
-    def __init__(self, resolution=None):
+    def __init__(self, resolution=None, render_flags=None):
+
         if resolution is None:
             resolution = (640, 480)
 
@@ -31,6 +32,7 @@ class PyrenderViewer(pyrender.Viewer):
             run_in_thread=False,
             use_raymond_lighting=True,
             auto_start=False,
+            render_flags=render_flags,
         )
         super(PyrenderViewer, self).__init__(**self._kwargs)
 
@@ -102,6 +104,13 @@ class PyrenderViewer(pyrender.Viewer):
                         primitives=[pyrender.Primitive(
                             mesh.vertices[mesh.vertex_nodes].reshape(-1, 3),
                             mode=pyrender.constants.GLTF.LINE_STRIP,
+                            color_0=mesh.colors)])
+                    node = self.scene.add(pyrender_mesh)
+                elif isinstance(mesh, trimesh.PointCloud):
+                    pyrender_mesh = pyrender.Mesh(
+                        primitives=[pyrender.Primitive(
+                            mesh.vertices,
+                            mode=pyrender.constants.GLTF.POINTS,
                             color_0=mesh.colors)])
                     node = self.scene.add(pyrender_mesh)
                 else:


### PR DESCRIPTION
Before this PR, the following code 
```python
import copy
import numpy as np
from skrobot.model.primitives import PointCloudLink
import trimesh
from skrobot.viewers import PyrenderViewer

v = PyrenderViewer(resolution=(640, 480))
pts = np.random.rand(10000, 3)
colors = [255, 0, 0, 255]

link = PointCloudLink(pts, colors)
v.add(PointCloudLink(pts, colors))
v.show()
import time; time.sleep(1000)
```
fails with 
```
Traceback (most recent call last):
  File "render.py", line 12, in <module>
    link = PointCloudLink(pts, colors)
  File "/home/h-ishida/python/scikit-robot/skrobot/model/primitives.py", line 266, in __init__
    super(PointCloudLink, self).__init__(pos=pos, rot=rot, name=name,
  File "/home/h-ishida/python/scikit-robot/skrobot/model/link.py", line 20, in __init__
    super(Link, self).__init__(*args, **kwargs)
  File "/home/h-ishida/python/scikit-robot/skrobot/coordinates/base.py", line 1198, in __init__
    super(CascadedCoords, self).__init__(*args, **kwargs)
  File "/home/h-ishida/python/scikit-robot/skrobot/coordinates/base.py", line 213, in __init__
    self.translation = pos
  File "/home/h-ishida/python/scikit-robot/skrobot/coordinates/base.py", line 346, in translation
    _check_valid_translation(translation)
  File "/home/h-ishida/python/scikit-robot/skrobot/coordinates/math.py", line 123, in _check_valid_translation
    raise ValueError(
ValueError: Translation must be specified as numeric numpy array
```
So, this PR change additional conditional branch for PointCloudLink to visualize it properly.
Note that, the default point cloud size is too small. So, I set the default size to 2. 
After this PR, the above script produces the following image: 
Note that to show the colorized image, the patch https://github.com/mikedh/trimesh/pull/2110 should be reflected. 

![image](https://github.com/iory/scikit-robot/assets/38597814/3231cf60-578e-4c26-8d68-b19552470161)

