### PR TITLE
Pass all kwargs related to gridsdf

### DIFF
--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -220,7 +220,7 @@ class MeshLink(Link):
     def __init__(self,
                  visual_mesh=None,
                  pos=(0, 0, 0), rot=np.eye(3), name=None, with_sdf=False,
-                 dim_grid=100, padding_grid=5):
+                 **gridsdf_kwargs):
         if name is None:
             name = 'meshlink_{}'.format(str(uuid.uuid1()).replace('-', '_'))
 
@@ -235,8 +235,7 @@ class MeshLink(Link):
             self._collision_mesh.metadata['origin'] = np.eye(4)
 
         if with_sdf:
-            sdf = trimesh2sdf(self._collision_mesh, dim_grid=dim_grid,
-                              padding_grid=padding_grid)
+            sdf = trimesh2sdf(self._collision_mesh, **gridsdf_kwargs)
             self.assoc(sdf, relative_coords="local")
             self.sdf = sdf
 

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -17,18 +17,15 @@ from skrobot.utils import checksum_md5
 logger = getLogger(__name__)
 
 
-def trimesh2sdf(mesh, dim_grid=100, padding_grid=5):
+def trimesh2sdf(mesh, **gridsdf_kwargs):
     """Convert trimesh to signed distance function.
 
     Parameters
     ----------
     mesh : trimesh.base.Trimesh
         mesh object.
-    dim_grid : int
-        dimension of the GridSDF.
-        This value is used for a not primitive mesh.
-    padding_grid : int
-        number of padding.
+    gridsdf_kwargs : dict
+        keyword args for skrobot.sdf.GridSDF.from_objfile
 
     Returns
     -------
@@ -42,8 +39,7 @@ def trimesh2sdf(mesh, dim_grid=100, padding_grid=5):
     is_loaded_mesh = 'file_path' in mesh.metadata
     if is_loaded_mesh:
         file_path = mesh.metadata['file_path']
-        sdf = GridSDF.from_objfile(file_path, dim_grid=dim_grid,
-                                   padding_grid=padding_grid)
+        sdf = GridSDF.from_objfile(file_path, **gridsdf_kwargs)
     else:
         # process primtives
         shape = mesh.metadata['shape']

--- a/tests/skrobot_tests/model_tests/test_primitives.py
+++ b/tests/skrobot_tests/model_tests/test_primitives.py
@@ -117,6 +117,13 @@ class TestMeshLink(unittest.TestCase):
         is_all_vertices_on_surface = np.all(booleans)
         self.assertTrue(is_all_vertices_on_surface)
 
+        # test: check if kwargs are passed
+        mesh = trimesh.load(bunny_obj_path)
+        m_custom = skrobot.model.MeshLink(
+            mesh, with_sdf=True, fill_value=123456, dim_grid=30)
+        self.assertEqual(m_custom.sdf.itp.fill_value, 123456)
+        self.assertEqual(len(m_custom.sdf.itp.values.flatten()), 30 ** 3)
+
 
 class TestPointCloudLink(unittest.TestCase):
 


### PR DESCRIPTION
This PR enables to pass gridsdf-related keywords from trimesh2sdf and MeshLink. 