### PR TITLE
fix: add dummy file name to string io when loading urdf from text

### DIFF
--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -2,6 +2,7 @@ import io
 import itertools
 from logging import getLogger
 import os
+import sys
 import tempfile
 import warnings
 
@@ -1751,8 +1752,12 @@ class RobotModel(CascadedLink):
             rospy.logwarn('Waiting {} set.'.format(param_name))
 
     def load_urdf(self, urdf):
+        is_python3 = sys.version_info.major > 2
         f = io.StringIO()
-        f.write(urdf)
+        if is_python3:
+            f.write(urdf)
+        else:
+            f.write(urdf.decode('utf-8'))
         f.seek(0)
         f.name = "dummy"
         self.load_urdf_file(file_obj=f)

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -1754,6 +1754,7 @@ class RobotModel(CascadedLink):
         f = io.StringIO()
         f.write(urdf)
         f.seek(0)
+        f.name = "dummy"
         self.load_urdf_file(file_obj=f)
 
     def load_urdf_file(self, file_obj):

--- a/tests/skrobot_tests/test_urdf.py
+++ b/tests/skrobot_tests/test_urdf.py
@@ -17,6 +17,9 @@ class TestURDF(unittest.TestCase):
         os.chdir(os.path.dirname(urdfpath))
         RobotModelFromURDF(
             urdf_file=os.path.basename(urdfpath))
+        # String
+        with open(urdfpath, 'r') as f:
+            RobotModelFromURDF(urdf=f.read())
 
     def test_load_urdfmodel_with_simplification(self):
         if sys.version_info.major < 3:


### PR DESCRIPTION
String IO does not have name attribute thus 
https://github.com/iory/scikit-robot/blob/dc3d7742c06678f8bf90f6489dc86043a4959a31/skrobot/model/robot_model.py#L1766C1-L1767C1
this like causes error. This PR fix this issue.

