### PR TITLE
Add cautionary note on update_interval for faster rendering in viewer docs

### DIFF
--- a/docs/source/reference/viewers.rst
+++ b/docs/source/reference/viewers.rst
@@ -77,3 +77,14 @@ PyrenderViewer
 
 - **Camera Management:**
   Offers detailed camera setup options, including angle adjustments, distance settings, center positioning, and field of view configuration, providing flexibility in viewing angles for complex scenes.
+
+
+.. caution::
+
+  To speed up the rendering cycle in **TrimeshSceneViewer** and **PyrenderViewer**, adjust the ``update_interval`` to the reciprocal of the desired frequency. For example, to achieve updates at 30 Hz, set the ``update_interval`` to 1/30. This change will increase the frequency at which the ``redraw()`` function is called, making the rendering process faster.
+
+  Example usage:
+
+  .. code-block:: python
+
+    viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480), update_interval=1.0/30)   # Set update interval for 30 Hz


### PR DESCRIPTION
This commit adds a cautionary note in the viewers documentation explaining how to adjust the update_interval for TrimeshSceneViewer and PyrenderViewer to speed up the rendering cycle. An example usage is also provided to demonstrate setting the update_interval to achieve a 30 Hz refresh rate. This enhancement aims to help users optimize rendering performance for their specific needs.