### PR TITLE
fix: handle urdf with scale parameter

### DIFF
--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -2558,9 +2558,7 @@ class Link(URDFType):
                     pose = c.origin
                     if c.geometry.mesh is not None:
                         if c.geometry.mesh.scale is not None:
-                            S = np.eye(4)
-                            S[:3, :3] = np.diag(c.geometry.mesh.scale)
-                            pose = pose.dot(S)
+                            pose[3, :3] *= c.geometry.mesh.scale
                     m.apply_transform(pose)
                     m.metadata["origin"] = pose
                     meshes.append(m)

--- a/tests/skrobot_tests/test_urdf.py
+++ b/tests/skrobot_tests/test_urdf.py
@@ -67,3 +67,6 @@ class TestURDF(unittest.TestCase):
         rot = origin[:3, :3]
         determinant = np.linalg.det(rot)
         self.assertAlmostEqual(determinant, 1.0, places=5)
+        # TODO(HiroIshida): check if trans is correctly scaled
+        # however, to check this, we must fix the issue:
+        # https://github.com/mmatl/urdfpy/issues/17


### PR DESCRIPTION
## what's this
As pointed out the issue #372 if collision mesh is specifeid with a scale parameter, transformation matrix is set to an invalid value (i.e. det(rotmat) != 1.0). This PR fix this issue.
Fix https://github.com/iory/scikit-robot/issues/372
@sktometometo
## caution!!! 
Although urdf.py scales the "origin" of the primitive shape, it seems that urdfpy cannot reflect the origin of the Visual or Collision mesh. I'll fix this bug in another PR when I have time. (maybe this problem seems bit complecated)

This PR also fixes the issue, which is the bug in urdfpy
https://github.com/mmatl/urdfpy/issues/17