### PR TITLE
fix: properly create UnionSDF from urdf file with scale-specified mesh

### DIFF
--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -232,7 +232,6 @@ class MeshLink(Link):
                     self.visual_mesh[0] + self.visual_mesh[1:]
             else:
                 self._collision_mesh = self.visual_mesh
-            self._collision_mesh.metadata['origin'] = np.eye(4)
 
         if with_sdf:
             sdf = trimesh2sdf(self._collision_mesh, **gridsdf_kwargs)

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -1724,7 +1724,6 @@ class RobotModel(CascadedLink):
                     mesh.visual.face_colors = visual.material.color
 
             mesh.apply_transform(visual.origin)
-            mesh.metadata["origin"] = visual.origin
             meshes.append(mesh)
         return meshes
 

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -52,17 +52,19 @@ def trimesh2sdf(mesh, **gridsdf_kwargs):
         else:
             msg = "primtive type {0} is not supported".format(shape)
             raise ValueError(msg)
+
+        if "original_primitive_origin_for_sdf" in mesh.metadata:
+            # this value is set when loading a mesh from a URDF file
+            origin = mesh.metadata["original_primitive_origin_for_sdf"]
+            rotation_matrix = origin[:3, :3]
+            translation = origin[:3, 3]
+            sdf.newcoords(Coordinates(pos=translation, rot=rotation_matrix))
     else:
         tmpdir = tempfile.mkdtemp()
         tmpfile = os.path.join(tmpdir, 'tmp.obj')
         mesh.export(tmpfile)
         sdf = GridSDF.from_objfile(tmpfile, **gridsdf_kwargs)
         shutil.rmtree(tmpdir)
-    if "origin" in mesh.metadata:
-        origin = mesh.metadata["origin"]
-        rotation_matrix = origin[:3, :3]
-        translation = origin[:3, 3]
-        sdf.newcoords(Coordinates(pos=translation, rot=rotation_matrix))
     return sdf
 
 

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -34,10 +34,7 @@ def trimesh2sdf(mesh, **gridsdf_kwargs):
     sdf : skrobot.sdf.SignedDistanceFunction
         converted signed distance function.
     """
-    if 'file_path' in mesh.metadata:
-        file_path = mesh.metadata['file_path']
-        sdf = GridSDF.from_objfile(file_path, **gridsdf_kwargs)
-    elif 'shape' in mesh.metadata:
+    if 'shape' in mesh.metadata:
         shape = mesh.metadata['shape']
         if shape == 'box':
             extents = mesh.metadata['extents']

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -2555,6 +2555,8 @@ class Link(URDFType):
             for c in self.collisions:
                 for m in c.geometry.meshes:
                     m = m.copy()
+                    if c.geometry.mesh is None:
+                        m.metadata["original_primitive_origin_for_sdf"] = c.origin.copy()  # noqa: E501
                     pose = c.origin
                     if c.geometry.mesh is not None:
                         if c.geometry.mesh.scale is not None:
@@ -2562,7 +2564,6 @@ class Link(URDFType):
                             S[:3, :3] = np.diag(c.geometry.mesh.scale)
                             pose = pose.dot(S)
                     m.apply_transform(pose)
-                    m.metadata["origin"] = pose
                     meshes.append(m)
             if len(meshes) == 0:
                 return None

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -2558,7 +2558,9 @@ class Link(URDFType):
                     pose = c.origin
                     if c.geometry.mesh is not None:
                         if c.geometry.mesh.scale is not None:
-                            pose[3, :3] *= c.geometry.mesh.scale
+                            S = np.eye(4)
+                            S[:3, :3] = np.diag(c.geometry.mesh.scale)
+                            pose = pose.dot(S)
                     m.apply_transform(pose)
                     m.metadata["origin"] = pose
                     meshes.append(m)

--- a/tests/skrobot_tests/test_urdf.py
+++ b/tests/skrobot_tests/test_urdf.py
@@ -1,12 +1,7 @@
 import os
-import shutil
 import sys
-import tempfile
 import unittest
 
-import numpy as np
-
-from skrobot.data import bunny_objpath
 from skrobot.data import fetch_urdfpath
 from skrobot.models.urdf import RobotModelFromURDF
 from skrobot.utils.urdf import mesh_simplify_factor
@@ -37,36 +32,3 @@ class TestURDF(unittest.TestCase):
         # load using existing cache
         with mesh_simplify_factor(0.1):
             RobotModelFromURDF(urdf_file=fetch_urdfpath())
-
-    def test_load_urdfmodel_with_scale_parameter(self):
-        td = tempfile.mkdtemp()
-        urdf_file = """
-        <robot name="myfirst">
-          <link name="base_link">
-            <visual>
-              <geometry>
-                <mesh filename="./bunny.obj" scale="10 10 10" />
-              </geometry>
-            </visual>
-            <collision>
-              <geometry>
-                <mesh filename="./bunny.obj" scale="10 10 10" />
-              </geometry>
-            </collision>
-          </link>
-        </robot>
-        """
-        # write urdf file
-        with open(os.path.join(td, 'temp.urdf'), 'w') as f:
-            f.write(urdf_file)
-
-        shutil.copy(bunny_objpath(), os.path.join(td, 'bunny.obj'))
-        urdf_file = os.path.join(td, 'temp.urdf')
-        dummy_robot = RobotModelFromURDF(urdf_file=urdf_file)
-        origin = dummy_robot.base_link.collision_mesh.metadata["origin"]
-        rot = origin[:3, :3]
-        determinant = np.linalg.det(rot)
-        self.assertAlmostEqual(determinant, 1.0, places=5)
-        # TODO(HiroIshida): check if trans is correctly scaled
-        # however, to check this, we must fix the issue:
-        # https://github.com/mmatl/urdfpy/issues/17


### PR DESCRIPTION
## what's this
This PR fixes the bugs in sdf construction using `metadata[origin]`.
Also, related to this, I noticed that the previous #374 is totally wrong. So the PR is reverted in this PR.

### 1. fix a bug introduced in https://github.com/iory/scikit-robot/pull/374  **(I'm sorry)**
The original implementation before the #374 was correct in that it properly scales and transform the mesh vertices. However the PR #374 changed the code such that scale is applied only to the origin attribute not vertices because we remove `apply_transform` operation. So I revert this change.

### 2. Do not consider `metadata["origin"]` for non-primitive mesh.
Because the mesh's origin is applied to the vertices in the urdf loading time, operation like `metadata["origin"] = pose` in the original implementation
https://github.com/iory/scikit-robot/blob/841cf2ebe2d3b6564281f234b8f05ca90544a31c/skrobot/utils/urdf.py#L2563
is misleading and actually causes bug for `trimesh2sdf` computation. In `trimesh2sdf` computation, the `metadata["origin"]` value is set to the coords of the sdf instance. This means that for the sdf of non-primitive mesh, we compute doubly-transformed sdf.
https://github.com/iory/scikit-robot/blob/841cf2ebe2d3b6564281f234b8f05ca90544a31c/skrobot/sdf/signed_distance_function.py#L65
To circumvent this problem, I decided to set `metadata["origin"]` only for primitive mesh and use it only when we create a primitive shape's sdf. Consequently, the `.newcoords()` will no longer called for non-primitive mesh in `trimesh2sdf`.

### 3. do not create sdf from filepath
Original implementation created gridsdf by loading mesh from filepath. However, as pointed out above, some transformation including scale defined in urdf file is applied already in urdf loading phase. So, we need to use a raw trimmesh object rather than filepath. Fortunately, this can be don by my previous PR: https://github.com/iory/scikit-robot/pull/359 I added a test to `test_sdf.py` to check that constructed unionsdf from urdf file actually reflects the scale parameter. Note that, fixing the bug https://github.com/mmatl/urdfpy/issues/17 is still work in progress in other PR. 

### 4. Some refactoring
The `metadata["origin"]` is introduced by my past PR https://github.com/iory/scikit-robot/pull/199 solely for `trimesh2sdf` function. I found that the keyword "origin" is somewhat confusing, because reader might consider it as the origin of the trimesh object, which is actually not because after the `apply_transform` in `urdf.py` the origin must be `np.eye(4)`. To avoid such a confusion, I renamed it to `original_primitive_origin_for_sdf`. Also, I removed this line 
https://github.com/iory/scikit-robot/blob/841cf2ebe2d3b6564281f234b8f05ca90544a31c/skrobot/model/robot_model.py#L1727
because visual meshes will supposed to be never used in `trimesh2sdf`.

@sktometometo Could you check this PR before I ask the final review to @iory ? 