### PR TITLE
[GA] Downlgrade pip for ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,9 @@ jobs:
         python-version: 3.8
     - name: Install Formatting
       run: |
-        python -m pip install --upgrade pip
+        # python -m pip install --upgrade pip
+        # https://github.com/pytorch/pytorch/issues/104598#issuecomment-1662871612
+        python -m pip install pip==20.0.2
         pip install hacking isort
     - name: Check Formatting
       run: |
@@ -56,6 +58,9 @@ jobs:
     - name: Install Pytest
       run: |
         python -m pip install --upgrade pip setuptools wheel
+        # python -m pip install --upgrade pip
+        # https://github.com/pytorch/pytorch/issues/104598#issuecomment-1662871612
+        python -m pip install pip==20.0.2
         pip install Cython
         pip install pytest hacking
     - name: Install scikit-robot
@@ -78,6 +83,9 @@ jobs:
     - name: Install Pytest
       run: |
         python -m pip install --upgrade pip setuptools wheel
+        # python -m pip install --upgrade pip
+        # https://github.com/pytorch/pytorch/issues/104598#issuecomment-1662871612
+        python -m pip install pip==20.0.2
         pip install Cython
         pip install pytest hacking
     - name: Install scikit-robot
@@ -97,7 +105,9 @@ jobs:
         python-version: '3.x'
     - name: Install publishing dependencies
       run: |
-        python -m pip install --upgrade pip
+        # python -m pip install --upgrade pip
+        # https://github.com/pytorch/pytorch/issues/104598#issuecomment-1662871612
+        python -m pip install pip==20.0.2
         pip install setuptools wheel
     - name: Build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,9 @@ jobs:
         python-version: 3.8
     - name: Install Formatting
       run: |
-        python -m pip install --upgrade pip
+        # python -m pip install --upgrade pip
+        # https://github.com/pytorch/pytorch/issues/104598#issuecomment-1662871612
+        python -m pip install pip==20.0.2
         pip install hacking isort
     - name: Check Formatting
       run: |
@@ -62,6 +64,9 @@ jobs:
     - name: Install Pytest
       run: |
         python -m pip install --upgrade pip setuptools wheel
+        # python -m pip install --upgrade pip
+        # https://github.com/pytorch/pytorch/issues/104598#issuecomment-1662871612
+        python -m pip install pip==20.0.2
         pip install Cython
         pip install pytest hacking
     - name: Install scikit-robot
@@ -84,6 +89,9 @@ jobs:
     - name: Install Pytest
       run: |
         python -m pip install --upgrade pip setuptools wheel
+        # python -m pip install --upgrade pip
+        # https://github.com/pytorch/pytorch/issues/104598#issuecomment-1662871612
+        python -m pip install pip==20.0.2
         pip install Cython
         pip install pytest hacking
     - name: Install scikit-robot


### PR DESCRIPTION

I am frequently encountering errors where the hash for pip does not match. I will try downgrading pip to see if it resolves the issue.

Ref: https://github.com/pytorch/pytorch/issues/104598#issuecomment-1662871612
