### PR TITLE
Check trimesh version for colored dae

### DIFF
--- a/skrobot/apps/convert_urdf_mesh.py
+++ b/skrobot/apps/convert_urdf_mesh.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 import argparse
+from distutils.version import StrictVersion
 import os.path as osp
 from pathlib import Path
+import pkg_resources
 import shutil
 
 from skrobot.model import RobotModel
@@ -62,7 +64,12 @@ resulting in less simplification. Default is None."""
             '.' + args.format,
             decimation_area_ratio_threshold=args.decimation_area_ratio_threshold,  # NOQA
             simplify_vertex_clustering_voxel_size=args.voxel_size):
-        r.urdf_robot_model.save(str(base_path / output_path))
+        if StrictVersion(pkg_resources.get_distribution("trimesh").version) < StrictVersion("4.0.10"):
+            print('[Error] With `trimesh` < 4.0.10, the output dae is not colored. Please `pip install trimesh -U`')
+            print('Convert failed.')
+        else:
+            r.urdf_robot_model.save(str(base_path / output_path))
+            
     if args.inplace:
         shutil.move(str(base_path / output_path),
                     base_path / urdf_path)

--- a/skrobot/apps/convert_urdf_mesh.py
+++ b/skrobot/apps/convert_urdf_mesh.py
@@ -4,8 +4,9 @@ import argparse
 from distutils.version import StrictVersion
 import os.path as osp
 from pathlib import Path
-import pkg_resources
 import shutil
+
+import pkg_resources
 
 from skrobot.model import RobotModel
 from skrobot.utils.urdf import export_mesh_format
@@ -64,12 +65,14 @@ resulting in less simplification. Default is None."""
             '.' + args.format,
             decimation_area_ratio_threshold=args.decimation_area_ratio_threshold,  # NOQA
             simplify_vertex_clustering_voxel_size=args.voxel_size):
-        if StrictVersion(pkg_resources.get_distribution("trimesh").version) < StrictVersion("4.0.10"):
-            print('[Error] With `trimesh` < 4.0.10, the output dae is not colored. Please `pip install trimesh -U`')
+        trimesh_version = pkg_resources.get_distribution("trimesh").version
+        if StrictVersion(trimesh_version) < StrictVersion("4.0.10"):
+            print(
+                '[Error] With `trimesh` < 4.0.10, the output dae is not '
+                'colored. Please `pip install trimesh -U`')
             print('Convert failed.')
-        else:
-            r.urdf_robot_model.save(str(base_path / output_path))
-            
+        r.urdf_robot_model.save(str(base_path / output_path))
+
     if args.inplace:
         shutil.move(str(base_path / output_path),
                     base_path / urdf_path)


### PR DESCRIPTION
To output colored .dae, trimesh >= 4.0.10 is required.

With this PR, convert_urdf_mesh.py check trimesh version