### PR TITLE
Restrict numpy version to below 2.0 for compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install scikit-robot
       run: |
         pip cache purge
-        pip install --no-cache-dir .[all]
+        pip install --no-cache-dir .[all] "numpy<2.0"
     - name: Run Pytest
       run: pytest -v tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install scikit-robot
       run: |
         pip cache purge
-        pip install --no-cache-dir .[all]
+        pip install --no-cache-dir .[all] "numpy<2.0"
     - name: Run Pytest
       run: pytest -v tests
 


### PR DESCRIPTION
This is necessary because some libraries are not yet compatible with numpy 2.0 and above.