### PR TITLE
Add warning on joint velocity limit

### DIFF
--- a/skrobot/interfaces/ros/base.py
+++ b/skrobot/interfaces/ros/base.py
@@ -147,9 +147,19 @@ class ROSRobotInterfaceBase(object):
         if isinstance(time, Number):
             # Normal Number disgnated Mode
             if time < fastest_time:
+                rospy.logwarn(
+                    'Time has been changed from {} to {} '
+                    'due to joint velocity limit. '
+                    'Make sure that joint limit is correctly set in urdf'.
+                    format(time, fastest_time))
                 time = fastest_time
         elif time is None:
             time = time_scale * fastest_time
+            rospy.logwarn(
+                'Time of send angle vector is set to {}. '
+                'If the speed seems slow, check if '
+                'joint velocity limit is correctly set in urdf'.
+                format(time))
         else:
             raise ValueError(
                 'time is invalid type. {}'.format(time))


### PR DESCRIPTION
I added warnings for those who have not written joint velocity limits in the URDF.
Similar warnings can be found in the following section, but they are suppressed after importing ros.
https://github.com/iory/scikit-robot/blob/acce8579e194e452347a4a077adbc5a23f4c4c8d/skrobot/model/joint.py#L207-L210