### PR TITLE
wait_interpolation() returns list of is_interpolating for all controllers

### DIFF
--- a/skrobot/interfaces/ros/base.py
+++ b/skrobot/interfaces/ros/base.py
@@ -594,8 +594,8 @@ class ROSRobotInterfaceBase(object):
 
         Returns
         -------
+        list[bool]
             return values are a list of is_interpolating for all controllers.
-            if all interpolation has stopped, return True.
         """
         if controller_type:
             controller_actions = self.controller_table[controller_type]
@@ -604,8 +604,9 @@ class ROSRobotInterfaceBase(object):
         for action in controller_actions:
             # TODO(simultaneously wait_for_result)
             action.wait_for_result(timeout=rospy.Duration(timeout))
-        # TODO(Fix return value)
-        return True
+        is_interpolatings = map(
+            lambda action: action.is_interpolating(), controller_actions)
+        return list(is_interpolatings)
 
     def angle_vector_duration(self, start_av, end_av, controller_type=None):
         """Calculate maximum time to reach goal for all joint.


### PR DESCRIPTION
`wait_interpolation()` returns list of is_interpolating for all controllers.
This follows roseus `:wait-interpolation`.
https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/16cb8fa58aa1ef7884b01bfdc29c0de1bba76d5a/pr2eus/robot-interface.l#L714

My concern:
This pull request will lose the backward compatibility of the return value of wait_interpolation.