### PR TITLE
Fix is_interpolating()

### DIFF
--- a/skrobot/interfaces/ros/base.py
+++ b/skrobot/interfaces/ros/base.py
@@ -661,4 +661,4 @@ class ControllerActionClient(actionlib.SimpleActionClient):
         self.last_feedback_msg_stamp = msg.header.stamp
 
     def is_interpolating(self):
-        return self.time_sequence is None
+        return not self.simple_state == actionlib.SimpleGoalState.DONE


### PR DESCRIPTION
Fix is_interpolating() method.

This PR follows roseus impelementation.
https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/16cb8fa58aa1ef7884b01bfdc29c0de1bba76d5a/pr2eus/robot-interface.l#L146

Test code1

```python
ri.angle_vector([0,0,0,0,0,0,0,0,0,0], 3)
time.sleep(2)
print(ri.controller_table['default_controller'][0].is_interpolating())
time.sleep(2)
print(ri.controller_table['default_controller'][0].is_interpolating())
True
False
```

Test code2

```python
ri.angle_vector([0.5,0,0,0,0,0,0,0,0,0], 3); ri.wait_interpolation()
[False]
```

Test code 3 (with timeout)

```python
ri.angle_vector([0.0,0,0,0,0,0,0,0,0,0], 3); ri.wait_interpolation(timeout=1)
[True]
```