### PR TITLE
Added quaternion_xyzw method to Coordinates class

### DIFF
--- a/skrobot/interfaces/_pybullet.py
+++ b/skrobot/interfaces/_pybullet.py
@@ -4,7 +4,6 @@ import time
 import numpy as np
 
 from skrobot.coordinates import Coordinates
-from skrobot.coordinates.math import wxyz2xyzw
 from skrobot.coordinates.math import xyzw2wxyz
 from skrobot.coordinates import matrix2quaternion
 from skrobot.coordinates import quaternion2rpy
@@ -85,7 +84,7 @@ class PybulletRobotInterface(Coordinates):
             except Exception as e:
                 print(e)
         self.robot_id = p.loadURDF(urdf_path, self.translation,
-                                   wxyz2xyzw(self.quaternion),
+                                   self.quaternion_xyzw,
                                    useFixedBase=use_fixed_base)
 
         self.load_bullet()
@@ -125,7 +124,7 @@ class PybulletRobotInterface(Coordinates):
         This function is wrapper of pybullet.resetBasePositionAndOrientation.
         """
         p.resetBasePositionAndOrientation(self.robot_id, self.translation,
-                                          wxyz2xyzw(self.quaternion))
+                                          self.quaternion_xyzw)
 
     def translate(self, vec, wrt='local'):
         """Translate robot in simulator.

--- a/skrobot/interfaces/ros/tf_utils.py
+++ b/skrobot/interfaces/ros/tf_utils.py
@@ -20,7 +20,7 @@ def coords_to_geometry_pose(coords):
     pose.position.x = coords.translation[0]
     pose.position.y = coords.translation[1]
     pose.position.z = coords.translation[2]
-    q = coords.quaternion
+    q = coords.quaternion_wxyz
     pose.orientation.w = q[0]
     pose.orientation.x = q[1]
     pose.orientation.y = q[2]
@@ -45,7 +45,7 @@ def coords_to_tf_pose(coords):
     pose.translation.x = coords.translation[0]
     pose.translation.y = coords.translation[1]
     pose.translation.z = coords.translation[2]
-    q = coords.quaternion
+    q = coords.quaternion_wxyz
     pose.rotation.w = q[0]
     pose.rotation.x = q[1]
     pose.rotation.y = q[2]

--- a/skrobot/planner/utils.py
+++ b/skrobot/planner/utils.py
@@ -169,7 +169,7 @@ def _forward_kinematics(robot_model,
     link_list = [joint.child_link for joint in joint_list]
 
     ef_pos_wrt_world = move_target.worldpos()
-    ef_quat_wrt_world = move_target.worldcoords().quaternion
+    ef_quat_wrt_world = move_target.worldcoords().quaternion_wxyz
     world_coordinate = CascadedCoords()
 
     def quaternion_kinematic_matrix(q):


### PR DESCRIPTION
Introduced quaternion_xyzw method to return quaternion in [x, y, z, w] format, complementing the existing quaternion method, which uses [w, x, y, z] format. Added the option to specify input_quaternion_order in the Coordinates constructor, allowing users to input quaternions in either wxyz or xyzw order.