### PR TITLE
Add is_interpolating() to ROSRobotInterfaceBase class

### DIFF
--- a/skrobot/interfaces/ros/base.py
+++ b/skrobot/interfaces/ros/base.py
@@ -608,6 +608,15 @@ class ROSRobotInterfaceBase(object):
             lambda action: action.is_interpolating(), controller_actions)
         return list(is_interpolatings)
 
+    def is_interpolating(self, controller_type=None):
+        if controller_type:
+            controller_actions = self.controller_table[controller_type]
+        else:
+            controller_actions = self.controller_table[self.controller_type]
+        is_interpolatings = map(
+            lambda action: action.is_interpolating(), controller_actions)
+        return any(list(is_interpolatings))
+
     def angle_vector_duration(self, start_av, end_av, controller_type=None):
         """Calculate maximum time to reach goal for all joint.
 


### PR DESCRIPTION
Test code

```
In [20]: ri.angle_vector([0,0,0,0,0,0,0,0,0,0], 10)   
Out[20]: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]      

In [23]: ri.is_interpolating()
Out[23]: True
```

10 seconds later,

```
In [74]: ri.is_interpolating()                                          
Out[74]: False    
```

This function is the same as roseus `:interpolatingp`
https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/16cb8fa58aa1ef7884b01bfdc29c0de1bba76d5a/pr2eus/robot-interface.l#L715-L724