### PR TITLE
Check if joint_list has None element

### DIFF
--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -898,6 +898,9 @@ class CascadedLink(CascadedCoords):
         # store current angle vector
         joint_list = list(
             set([l.joint for l in union_link_list] + self.joint_list))
+        if None in joint_list:
+            logger.error('All links in link_list must have a parent joint')
+            return True
         av0 = [j.joint_angle() for j in joint_list]
         c0 = None
         if self.parent is None:


### PR DESCRIPTION
When passing a link without a parent joint to the `link_list` argument in `inverse_kinematics()`, an error occurs causing the program to crash.

```
Traceback (most recent call last):                                                                                                                                                                                                                                                                                 File "/home/rock/ros/kxr/src/riberry/ros/riberry_startup/node_scripts/teaching_mode.py", line 190, in <module>                                                                                                                                                                                                 
    tm.main_loop()                                                                                                                                      
  File "/home/rock/ros/kxr/src/riberry/ros/riberry_startup/node_scripts/teaching_mode.py", line 175, in main_loop                                                                                                                                                                                                
    self.motion_manager.play(self.play_file)                                                                                                                                                                                                                                                                       File "/home/rock/ros/kxr/src/riberry/riberry/motion_manager.py", line 246, in play                                                                                                                                                                                                                                 self.play_motion_with_marker()                                                                                                                                                                                                                                                                               
  File "/home/rock/ros/kxr/src/riberry/riberry/motion_manager.py", line 230, in play_motion_with_marker                                                                                                                                                                                                          
    moved_motion = self.move_motion(                                                                                                                                                                                                                                                                             
  File "/home/rock/ros/kxr/src/riberry/riberry/motion_manager.py", line 186, in move_motion                                                                                                                                                                                                                          robot.inverse_kinematics(                                                                                                                                                                                                                                                                                      File "/home/rock/scikit-robot/skrobot/model/robot_model.py", line 1970, in inverse_kinematics                                                                                                                                                                                                                  
    return super(RobotModel, self).inverse_kinematics(                                                                                                                                                                                                                                                           
  File "/home/rock/scikit-robot/skrobot/model/robot_model.py", line 901, in inverse_kinematics                                                                                                                                                                                                                   
    av0 = [j.joint_angle() for j in joint_list]                                                                                                                                                                                                                                                                  
  File "/home/rock/scikit-robot/skrobot/model/robot_model.py", line 901, in <listcomp>                                                                                                                                                                                                                           
    av0 = [j.joint_angle() for j in joint_list]                                                                                                                                                                                                                                                                  
AttributeError: 'NoneType' object has no attribute 'joint_angle' 
```

inappropritate link_list example (base_link does not have parent joint):

```
[#<Link:base_link 0xffff7c70ad30 0.000 0.000 0.000 / 0.0 -0.0 0.0>,
 #<Link:link1 0xffff7c70a3a0 0.081 0.032 0.000 / 0.0 -0.0 -2.0>,
 #<Link:link2 0xffff7c70a2b0 0.142 0.040 0.019 / 3.1 -1.0 -3.1>,
 #<Link:link3 0xffff7c70af10 0.073 0.134 -0.055 / 0.0 -0.0 -0.2>,
 #<Link:link4 0xffff7c719040 0.023 0.174 -0.062 / -1.8 -0.0 0.0>,
 #<Link:link5 0xffff7c719130 0.033 0.190 0.066 / 0.0 -0.0 0.5>,
 #<Link:link6 0xffff7c719220 0.023 0.176 0.100 / -0.2 0.0 -1.6>,
 #<Link:link7 0xffff7c719310 0.033 0.191 0.117 / 0.0 -0.0 -1.4>,
 #<Link:gripper_dummy_link 0xffff7c719400 0.037 0.189 0.171 / -3.1 -0.0 -2.9>,
 #<Link:gripper_link1 0xffff7c719460 0.028 0.193 0.195 / 0.0 -0.0 0.0>,
 #<Link:gripper_link2 0xffff7c719580 0.051 0.183 0.192 / 0.0 -0.0 0.0>,
 #<Link:camera_link 0xffff7c719760 0.061 0.229 0.160 / 0.0 -0.0 0.0>]
```

This pull request handles this error and displays an appropriate error message.

