### PR TITLE
test/fix: remove dependency on file_path of metadata

### DIFF
--- a/tests/skrobot_tests/test_sdf.py
+++ b/tests/skrobot_tests/test_sdf.py
@@ -298,12 +298,10 @@ class TestSDF(unittest.TestCase):
     def test_trimesh2sdf(self):
         # non-primitive mesh with file_path
         mesh = self.bunnymesh
-        assert "file_path" in mesh.metadata
         sdf = skrobot.sdf.trimesh2sdf(mesh)
         assert isinstance(sdf, GridSDF)
 
         # non-primitive mesh without file_path
-        mesh.metadata.pop("file_path")
         sdf = skrobot.sdf.trimesh2sdf(mesh)
         assert isinstance(sdf, GridSDF)
 


### PR DESCRIPTION
Trimesh new version release causes error regarding mesh metadata: cannot find "file_path" in metadata, which recently causes CI fails. 

Actually in the release note https://github.com/mikedh/trimesh/releases/tag/4.6.0, the author explicitly mention that 
```
Removes Geometry.metadata['file_path'] in favor of
Geometry.source.file_path. Everything that inherits from Geometry
should now have a .source attribute which is a typed dataclass. This
was something of a struggle as file_path was populated into metadata
on load, but we also try to make sure metadata is preserved through
round-trips if at all possible. And so the load inserted different
keys into the metadata. Making it first-class information rather than a
loose key seems like an improvement, but users will have to replace
mesh.metadata["file_name"] with mesh.source.file_name.
```
So, it seems that the change is intentional, and we are encouraged to use `trimesh.source.file_path` instead

Anyway,  I previously removed the dependency on the file_path of metdaata in the sdf creation. Thus, removing the assertion in the test code is just fine.
https://github.com/iory/scikit-robot/pull/376/commits/694ec2baf7754d2a8ebe0f6d777e1dae878f93d3  