### PR TITLE
[convert-urdf-mesh] Add force_visual_mesh_origin_to_zero option for mujoco

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ networkx>=2.2.0
 numpy>=1.16.0
 ordered_set
 pillow
-pycollada!=0.7  # required for robot model using collada
+pycollada!=0.7;python_version>="3.2"  # required for robot model using collada
+pycollada<0.9;python_version<"3.2"  # required for robot model using collada
 pyglet<2.0
 pysdfgen>=0.1.5
 python-fcl  # for collision check in trimesh module

--- a/skrobot/apps/convert_urdf_mesh.py
+++ b/skrobot/apps/convert_urdf_mesh.py
@@ -86,7 +86,14 @@ resulting in less simplification. Default is None."""
         force_visual_mesh_origin_to_zero_or_not = \
             force_visual_mesh_origin_to_zero
     else:
-        force_visual_mesh_origin_to_zero_or_not = contextlib.nullcontext
+        try:
+            from contextlib import nullcontext
+        except ImportError:
+            # for python3.6
+            @contextlib.contextmanager
+            def nullcontext(enter_result=None):
+                yield enter_result
+        force_visual_mesh_origin_to_zero_or_not = nullcontext
 
     r = RobotModel()
     with open(base_path / urdf_path) as f:

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -48,6 +48,7 @@ _CONFIGURABLE_VALUES = {"mesh_simplify_factor": np.inf,
                         'decimation_area_ratio_threshold': None,
                         'simplify_vertex_clustering_voxel_size': None,
                         'enable_mesh_cache': False,
+                        'force_visual_mesh_origin_to_zero': False,
                         }
 _MESH_CACHE = {}
 
@@ -87,6 +88,13 @@ def enable_mesh_cache():
     _CONFIGURABLE_VALUES['enable_mesh_cache'] = True
     yield
     _CONFIGURABLE_VALUES['enable_mesh_cache'] = False
+
+
+@contextlib.contextmanager
+def force_visual_mesh_origin_to_zero():
+    _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero'] = True
+    yield
+    _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero'] = False
 
 
 def get_transparency(mesh):
@@ -1325,6 +1333,16 @@ class Visual(URDFType):
         self.name = name
         self.origin = origin
         self.material = material
+
+        if _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero']:
+            if self.geometry.mesh is not None:
+                new_mesh = []
+                for mesh in self.geometry.meshes:
+                    mesh.apply_transform(self.origin)
+                    new_mesh.append(mesh)
+                self.geometry.mesh.meshes = new_mesh
+                self.origin = np.eye(4)
+                del new_mesh
 
     @property
     def geometry(self):

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -1254,6 +1254,9 @@ class Collision(URDFType):
         self.geometry = geometry
         self.name = name
         self.origin = origin
+        if _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero']:
+            if self.geometry.mesh is not None:
+                self.origin = np.eye(4)
 
     @property
     def geometry(self):

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -1256,7 +1256,13 @@ class Collision(URDFType):
         self.origin = origin
         if _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero']:
             if self.geometry.mesh is not None:
+                new_mesh = []
+                for mesh in self.geometry.meshes:
+                    mesh.apply_transform(self.origin)
+                    new_mesh.append(mesh)
+                self.geometry.mesh.meshes = new_mesh
                 self.origin = np.eye(4)
+                del new_mesh
 
     @property
     def geometry(self):

--- a/tests/skrobot_tests/test_console_scripts.py
+++ b/tests/skrobot_tests/test_console_scripts.py
@@ -14,30 +14,30 @@ class TestConsoleScripts(unittest.TestCase):
 
     @pytest.mark.skipif(sys.version_info[0] == 2, reason="Skip in Python 2")
     def test_convert_urdf_mesh(self):
-        tmp_output = tempfile.TemporaryDirectory()
-        os.environ['SKROBOT_CACHE_DIR'] = tmp_output.name
-        urdfpath = fetch_urdfpath()
+        with tempfile.TemporaryDirectory() as tmp_output:
+            os.environ['SKROBOT_CACHE_DIR'] = tmp_output
+            urdfpath = fetch_urdfpath()
 
-        # fetch_0.urdf will be create after f'convert-urdf-mesh {urdfpath}'
-        out_urdfpath = osp.join(osp.dirname(urdfpath), 'fetch_0.urdf')
-        out_stl_urdfpath = osp.join(osp.dirname(urdfpath), 'fetch_stl.urdf')
+            out_urdfpath = osp.join(osp.dirname(urdfpath), 'fetch_0.urdf')
+            out_stl_urdfpath = osp.join(
+                osp.dirname(urdfpath), 'fetch_stl.urdf')
 
-        cmds = ['convert-urdf-mesh {}'.format(urdfpath),
-                'convert-urdf-mesh {} --output {} -f stl'.format(
-                    out_urdfpath,
-                    out_stl_urdfpath),
+            cmds = [
+                'convert-urdf-mesh {}'.format(urdfpath),
                 'convert-urdf-mesh {} --voxel-size 0.001'.format(urdfpath),
                 'convert-urdf-mesh {} -d 0.98'.format(urdfpath),
-                # inplace option should be used at last
+                # inplace option should be used last
+                'convert-urdf-mesh {} --output {} -f stl'.format(
+                    out_urdfpath, out_stl_urdfpath),
                 'convert-urdf-mesh {} --inplace'.format(out_urdfpath),
-                ]
-        kwargs = {}
-        kwargs["stdout"] = subprocess.PIPE
-        kwargs["stderr"] = subprocess.PIPE
+            ]
 
-        for cmd in cmds:
-            print('Executing {}'.format(cmd))
-            result = subprocess.run(cmd,
-                                    shell=True,
-                                    **kwargs)
-            assert result.returncode == 0
+            kwargs = {"stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
+
+            for cmd in cmds:
+                print('Executing {}'.format(cmd))
+                result = subprocess.run(cmd, shell=True, **kwargs)
+                if result.returncode != 0:
+                    print(result.stdout.decode())
+                    print(result.stderr.decode())
+                assert result.returncode == 0

--- a/tests/skrobot_tests/test_console_scripts.py
+++ b/tests/skrobot_tests/test_console_scripts.py
@@ -23,12 +23,13 @@ class TestConsoleScripts(unittest.TestCase):
         out_stl_urdfpath = osp.join(osp.dirname(urdfpath), 'fetch_stl.urdf')
 
         cmds = ['convert-urdf-mesh {}'.format(urdfpath),
-                'convert-urdf-mesh {} --inplace'.format(out_urdfpath),
                 'convert-urdf-mesh {} --output {} -f stl'.format(
                     out_urdfpath,
                     out_stl_urdfpath),
                 'convert-urdf-mesh {} --voxel-size 0.001'.format(urdfpath),
                 'convert-urdf-mesh {} -d 0.98'.format(urdfpath),
+                # inplace option should be used at last
+                'convert-urdf-mesh {} --inplace'.format(out_urdfpath),
                 ]
         kwargs = {}
         kwargs["stdout"] = subprocess.PIPE


### PR DESCRIPTION
In MuJoCo and similar environments, the `visual` tag may cause bugs if its origin is not set to `(0, 0, 0)`.
The `--force-zero-origin` option ensures that the `visual` tag is set to `(0, 0, 0)` to prevent such issues.

```
convert-urdf-mesh ./jedy.urdf --force-zero-origin
```

cc: @KenMat765

