### PR TITLE
Set collision/origin to be zero on force_visual_mesh_origin_to_zero

### DIFF
--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -1254,6 +1254,9 @@ class Collision(URDFType):
         self.geometry = geometry
         self.name = name
         self.origin = origin
+        if _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero']:
+            if self.geometry.mesh is not None:
+                self.origin = np.eye(4)
 
     @property
     def geometry(self):

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -1256,7 +1256,13 @@ class Collision(URDFType):
         self.origin = origin
         if _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero']:
             if self.geometry.mesh is not None:
+                new_mesh = []
+                for mesh in self.geometry.meshes:
+                    mesh.apply_transform(self.origin)
+                    new_mesh.append(mesh)
+                self.geometry.mesh.meshes = new_mesh
                 self.origin = np.eye(4)
+                del new_mesh
 
     @property
     def geometry(self):


### PR DESCRIPTION
Modified [urdf.py](https://github.com/KenMat765/scikit-robot/blob/e2fc84d31d9430da368107dda410c9a75f126aa1/skrobot/utils/urdf.py#L1257) to also set `collision/origin` to zero when the `force_visual_mesh_origin_to_zero` option is enabled.