### PR TITLE
Add typo check using crate-ci/typos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,18 @@ jobs:
       run: |
         isort -c .
 
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: typos-action
+        uses: crate-ci/typos@v1.29.10
+
   documents:
     name: Build Sphinx Documentation
     runs-on: ubuntu-20.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.typos]
+default.extend-ignore-re = [
+    "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",  # spellchecker:disable-line
+    "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",  # spellchecker:<on|off>
+    "thre",  # TODO(iory) delete thre by using threshold
+]
+
+default.extend-ignore-identifiers-re = [
+    # Add individual words here to ignore them
+]

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -117,7 +117,7 @@ class Transform(object):
         Parameters
         ----------
         vec : numpy.ndarray(3,) or numpy.ndarray(3, n_points)
-            vector (or vectors) to be roated
+            vector (or vectors) to be rotated
 
         Returns
         -------
@@ -252,7 +252,7 @@ class Coordinates(object):
         Returns
         -------
         transform : skrobot.coordinates.base.Transform
-            corrensponding Transform to this coordinates
+            corresponding Transform to this coordinates
         """
         return Transform(self.worldpos(), self.worldrot())
 
@@ -288,7 +288,7 @@ class Coordinates(object):
     def rotation(self, rotation):
         """Set rotation of this coordinate
 
-        This setter checkes the given rotation and set it this coordinate.
+        This setter checks the given rotation and set it this coordinate.
 
         Parameters
         ----------
@@ -345,7 +345,7 @@ class Coordinates(object):
     def translation(self, translation):
         """Set translation of this coordinate
 
-        This setter checkes the given translation and set it this coordinate.
+        This setter checks the given translation and set it this coordinate.
 
         Parameters
         ----------
@@ -811,7 +811,7 @@ class Coordinates(object):
 
     def difference_position(self, coords,
                             translation_axis=True):
-        """Return differences in positoin of given coords.
+        """Return differences in position of given coords.
 
         Parameters
         ----------

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -1233,7 +1233,7 @@ def rodrigues(axis, theta=None, skip_normalization=False):
 
 
 def rotation_angle(mat, return_angular_velocity=False):
-    """Inverse Rodrigues formula Convert Rotation-Matirx to Axis-Angle.
+    """Inverse Rodrigues formula Convert Rotation-Matrix to Axis-Angle.
 
     Return theta and axis.
     If given unit matrix, return None.

--- a/skrobot/interfaces/_pybullet.py
+++ b/skrobot/interfaces/_pybullet.py
@@ -104,14 +104,14 @@ class PybulletRobotInterface(Coordinates):
 
     @property
     def pose(self):
-        """Getter of Pose in pybullet phsyics simulator.
+        """Getter of Pose in pybullet physics simulator.
 
         Wrapper of pybullet.getBasePositionAndOrientation.
 
         Returns
         -------
         pose : skrobot.coordinates.Coordinates
-            pose of this robot in the phsyics simulator.
+            pose of this robot in the physics simulator.
         """
         pos, q_xyzw = p.getBasePositionAndOrientation(
             self.robot_id)
@@ -221,7 +221,7 @@ class PybulletRobotInterface(Coordinates):
         self.velocity_gain = 0.1
 
     def angle_vector(self, angle_vector=None, realtime_simulation=None):
-        """Send a angle vector to pybullet's phsyics engine.
+        """Send a angle vector to pybullet's physics engine.
 
         Parameters
         ----------

--- a/skrobot/interfaces/ros/base.py
+++ b/skrobot/interfaces/ros/base.py
@@ -37,9 +37,9 @@ def _flatten(xlst):
 
 class ROSRobotInterfaceBase(object):
 
-    """ROSRobotInterface is class for interacting real robot.
+    """ROSRobotInterface is a class for interacting with a real robot.
 
-    RobotInterface is class for interacting real robot thorugh
+    ROSRobotInterface is a class for interacting with a real robot through
     JointTrajectoryAction servers and JointState topics.
 
     """

--- a/skrobot/interfaces/ros/move_base.py
+++ b/skrobot/interfaces/ros/move_base.py
@@ -435,7 +435,7 @@ class ROSRobotMoveBaseInterface(ROSRobotInterfaceBase):
 
         trajectory-points [ list of #f(x y yaw) ([m] for x, y; [rad] for yaw) ]
         time-list [list of time span [sec] ]
-        stop [ stop after msec moveing ]
+        stop [ stop after msec moving ]
         start-time [ robot will move at start-time [sec or ros::Time] ]
         send-action [ send message to action server, it means robot will move ]
 

--- a/skrobot/interfaces/ros/pr2.py
+++ b/skrobot/interfaces/ros/pr2.py
@@ -123,7 +123,7 @@ class PR2ROSRobotInterface(ROSRobotMoveBaseInterface):
             action_type=control_msgs.msg.FollowJointTrajectoryAction,
             joint_names=['torso_lift_joint'])
 
-    def _continous_joint_largest_movement(self, av_diff, controller_type):
+    def _continuous_joint_largest_movement(self, av_diff, controller_type):
         assert isinstance(controller_type, str)
 
         controller_params = self.controller_param_table[controller_type]
@@ -161,7 +161,7 @@ class PR2ROSRobotInterface(ROSRobotMoveBaseInterface):
 
         if av is not None:
             av_diff = av - self.angle_vector()
-            diff_max, joint_name = self._continous_joint_largest_movement(
+            diff_max, joint_name = self._continuous_joint_largest_movement(
                 av_diff, controller_type)
             if diff_max > math.pi:
                 rospy.logwarn(
@@ -214,13 +214,13 @@ class PR2ROSRobotInterface(ROSRobotMoveBaseInterface):
             av_next = avs_with_initial[i + 1]
             av_diff = av_next - av_here
 
-            diff_max, joint_name = self._continous_joint_largest_movement(
+            diff_max, joint_name = self._continuous_joint_largest_movement(
                 av_diff, controller_type)
             if diff_max > math.pi:
                 rospy.logwarn(
                     "continuous joint {} movement over 180 degree detected"
                     .format(joint_name))
-                rospy.logwarn('inverval will be split')
+                rospy.logwarn('interval will be split')
                 n_split = int(math.ceil(diff_max / (math.pi * 2 / 3)))
                 av_diff_partial = av_diff / n_split
                 for j in range(n_split):

--- a/skrobot/interpolator.py
+++ b/skrobot/interpolator.py
@@ -19,7 +19,7 @@ class Interpolator(object):
                 list of control point
             time-list:
                 list of time from start for each control point,
-                time in fisrt contrall point is zero, so length
+                time in first control point is zero, so length
                 of this list is length of control point minus 1
         """
         if position_list is None:

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -301,7 +301,7 @@ class CascadedLink(CascadedCoords):
         # a : avoid-collision-joint-gain
         # b : avoid-collision-null-gain
         #
-        # implimentation issue:
+        # implementation issue:
         # when link and object are collide,
         # p = (nearestpoint_on_object_surface - center_of_link )
         # else

--- a/skrobot/models/pr2.py
+++ b/skrobot/models/pr2.py
@@ -169,7 +169,7 @@ class PR2(RobotModelFromURDF):
         dist : None or float
             gripper distance.
             If dist is None, return gripper distance.
-            If flaot value is given, change joint angle.
+            If float value is given, change joint angle.
         arm : str
             Specify target arm.  You can specify 'larm', 'rarm', 'arms'.
 

--- a/skrobot/planner/collision_checker.py
+++ b/skrobot/planner/collision_checker.py
@@ -214,7 +214,7 @@ class SweptSphereSdfCollisionChecker(object):
         Returns
         -------
         sd_vals : numpy.ndarray[float](n_wp * n_feature,)
-            signed distnaces for all feature points through the trajectory
+            signed distances for all feature points through the trajectory
         sd_vals_jacobi : numpy.ndarray[float](n_wp * n_feature, n_wp * n_dof)
             jacobain of sd_vals with respect to DOF (i.e. n_wp * n_dof) of the
             trajectory
@@ -242,7 +242,7 @@ class SweptSphereSdfCollisionChecker(object):
         -------
         sd_vals_batch_flatten_sphere :
         numpy.ndarray[float](n_wp * n_feature,)
-            signed distnaces for all feature points through the trajectory
+            signed distances for all feature points through the trajectory
         jac_whole : numpy.ndarray[float](n_wp * n_feature, n_wp * n_dof)
             jacobain of sd_vals with respect to DOF (i.e. n_wp * n_dof) of the
             trajectory. If `jac_batch = None`, `jac_whole = None`.
@@ -258,7 +258,7 @@ class SweptSphereSdfCollisionChecker(object):
         pts_batch_flatten = pts_batch.reshape((n_total_feature, 3))
         sd_vals_batch_flatten = self.sdf(pts_batch_flatten)
 
-        # we must convert it to sphere's signed distnace
+        # we must convert it to sphere's signed distance
         radius_arr_traj = np.array(self.coll_radius_list * n_wp)
         sd_vals_batch_flatten_sphere = sd_vals_batch_flatten - radius_arr_traj
 

--- a/skrobot/planner/sqp_based.py
+++ b/skrobot/planner/sqp_based.py
@@ -18,7 +18,7 @@ def sqp_plan_trajectory(collision_checker,
                         ):
     """Gradient based trajectory optimization using scipy's SLSQP.
 
-    Collision constraint is considered in an inequality constraits.
+    Collision constraint is considered in an inequality constraints.
     Terminal constraint (start and end) is considered as an
     equality constraint.
 
@@ -42,7 +42,7 @@ def sqp_plan_trajectory(collision_checker,
         high cost compared to others. If set to `None` it's automatically
         determined.
     initial_trajectory : numpy.ndarray(n_wp, n_dof) or None
-        initial solution in the trajectory optimization specifeid by a
+        initial solution in the trajectory optimization specified by a
         angle vector sequence. If None, initial trajectory is
         automatically generated.
     slsqp_option: dict or None

--- a/skrobot/planner/swept_sphere.py
+++ b/skrobot/planner/swept_sphere.py
@@ -15,7 +15,7 @@ def compute_swept_sphere(collision_mesh,
         number of sphere to approximate the mesh. If it's set to `None`,
         the number of sphere is automatically determined.
     tol : float
-        tolerance determins how much mesh jutting-out from the swept-spheres
+        tolerance determines how much mesh jutting-out from the swept-spheres
         are accepted. Let `max_jut` be the maximum jut-distance. Then the
         setting `tol` enforces `max_jut / radius < max_jut`. If some integer
         is set to `n_sphere`, `tol` does not affects the result.
@@ -67,7 +67,8 @@ def compute_swept_sphere(collision_mesh,
     radius = determine_radius(verts_mapped[:, plane_axes]) * margin_factor
 
     # compute the maximum and minimum heights (h_center_max, h_center_min)
-    # of the sphere centers. Here, hight is defined in the principle direction.
+    # of the sphere centers.
+    # Here, height is defined in the principle direction.
     squared_radius_arr = np.sum(verts_mapped[:, plane_axes] ** 2, axis=1)
     h_center_arr = verts_mapped[:, principle_axis]
 

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -48,7 +48,7 @@ def trimesh2sdf(mesh, **gridsdf_kwargs):
             radius = mesh.metadata['radius']
             sdf = SphereSDF(radius)
         else:
-            msg = "primtive type {0} is not supported".format(shape)
+            msg = "primitive type {0} is not supported".format(shape)
             raise ValueError(msg)
 
         if "original_primitive_origin_for_sdf" in mesh.metadata:
@@ -250,7 +250,7 @@ class UnionSDF(SignedDistanceFunction):
         return sd_vals_union
 
     def _surface_points(self, n_sample=1000):
-        # equaly assign sample number to each sdf.surface_points()
+        # equally assign sample number to each sdf.surface_points()
         n_list = len(self.sdf_list)
         n_sample_each = int(floor(n_sample / n_list))
         n_sample_last = n_sample - n_sample_each * (n_list - 1)
@@ -421,7 +421,7 @@ class GridSDF(SignedDistanceFunction):
         -------
         is_out_arr : numpy.ndarray[bool](n_points,)
             If points is out of the interpolator's boundary,
-            the correspoinding element of is_out_arr is True
+            the corresponding element of is_out_arr is True
         """
         points_sdf \
             = super(GridSDF, self)._transform_pts_world_to_sdf(points_world)

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -2488,7 +2488,7 @@ class Link(URDFType):
         The inertial properties of the link.
     visuals : list of :class:`.Visual`, optional
         The visual properties of the link.
-    collsions : list of :class:`.Collision`, optional
+    collisions : list of :class:`.Collision`, optional
         The collision properties of the link.
     """
 
@@ -2532,7 +2532,7 @@ class Link(URDFType):
     @inertial.setter
     def inertial(self, value):
         if value is not None and not isinstance(value, Inertial):
-            raise TypeError('Expected Intertial object')
+            raise TypeError('Expected Inertial object')
         self._inertial = value
 
     @property

--- a/tests/skrobot_tests/model_tests/test_robot_model.py
+++ b/tests/skrobot_tests/model_tests/test_robot_model.py
@@ -118,7 +118,7 @@ class TestRobotModel(unittest.TestCase):
         with self.assertRaises(AssertionError):
             fetch._is_relevant(fetch.shoulder_pan_joint, co)
 
-        # if it's not connceted to the robot,
+        # if it's not connected to the robot,
         casco = CascadedCoords()
         with self.assertRaises(AssertionError):
             fetch._is_relevant(fetch.shoulder_pan_joint, casco)
@@ -129,7 +129,7 @@ class TestRobotModel(unittest.TestCase):
             fetch.shoulder_pan_joint, casco))
 
     def test_calc_jacobian_from_link_list(self):
-        # must be coinside with the one computed via numerical method
+        # must be coincide with the one computed via numerical method
         fetch = self.fetch
         link_list = [fetch.torso_lift_link] + fetch.rarm.link_list
         joint_list = [l.joint for l in link_list]


### PR DESCRIPTION
This PR introduces a typo-checking step in the GitHub Actions workflow using crate-ci/typos.

# Summary of Changes:
- Added a new typos job in .github/workflows/test.yml to automatically check for typos using typos-action.
- Created a pyproject.toml file to configure the typo checker.
- Ignored thre as a valid identifier to prevent false positives.

This ensures that our codebase maintains consistency and avoids unintended typos while allowing specific terms to be used as intended.