### PR TITLE
[convert-urdf-mesh] Exit on low trimesh version to alert users

### DIFF
--- a/skrobot/apps/convert_urdf_mesh.py
+++ b/skrobot/apps/convert_urdf_mesh.py
@@ -6,6 +6,7 @@ from distutils.version import StrictVersion
 import os.path as osp
 from pathlib import Path
 import shutil
+import sys
 
 import pkg_resources
 
@@ -53,6 +54,7 @@ resulting in less simplification. Default is None."""
         print(
             '[WARNING] With `trimesh` < 4.0.10, the output dae is not '
             + 'colored. Please `pip install trimesh -U`')
+        sys.exit(1)
     if args.decimation_area_ratio_threshold:
         disable_decimation = False
         if is_package_installed('open3d') is False:
@@ -65,8 +67,7 @@ resulting in less simplification. Default is None."""
                   + "Please install it with 'pip install fast-simplification'")
             disable_decimation = True
         if disable_decimation:
-            print("Disable --decimation-area-ratio-threshold arguments.")
-            args.decimation_area_ratio_threshold = None
+            sys.exit(1)
 
     base_path = Path(args.urdf).parent
     urdf_path = Path(args.urdf)

--- a/tests/skrobot_tests/test_console_scripts.py
+++ b/tests/skrobot_tests/test_console_scripts.py
@@ -12,7 +12,9 @@ from skrobot.data import fetch_urdfpath
 
 class TestConsoleScripts(unittest.TestCase):
 
-    @pytest.mark.skipif(sys.version_info[0] == 2, reason="Skip in Python 2")
+    @pytest.mark.skipif(
+        sys.version_info[0] == 2 or sys.version_info[:2] == (3, 6),
+        reason="Skip in Python 2 and Python 3.6")
     def test_convert_urdf_mesh(self):
         with tempfile.TemporaryDirectory() as tmp_output:
             os.environ['SKROBOT_CACHE_DIR'] = tmp_output


### PR DESCRIPTION
Add sys.exit(1) when trimesh version is below 4.0.10. This ensures users
are notified of the issue, as the output DAE file may not be colored
correctly otherwise.