### PR TITLE
Remove automatic python-fcl exclusion and update collision check docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ pycollada!=0.7;python_version>="3.2"  # required for robot model using collada
 pycollada<0.9;python_version<"3.2"  # required for robot model using collada
 pyglet<2.0
 pysdfgen>=0.1.5
-python-fcl  # for collision check in trimesh module
 repoze.lru;python_version<"3.2"
 rtree # need rtree for simplify_quadric_decimation
 scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import os
-import platform
 import re
 import sys
 
@@ -10,14 +9,6 @@ from setuptools import setup
 
 
 version = '0.0.53'
-
-
-def get_os_and_architecture():
-    uname = platform.uname()
-    # In Python 2, uname is a tuple, in Python 3, it's a named tuple.
-    os_type = uname[0] if isinstance(uname, tuple) else uname.system
-    architecture = uname[4] if isinstance(uname, tuple) else uname.machine
-    return os_type, architecture
 
 
 def listup_package_data():
@@ -65,10 +56,6 @@ def remove_from_requirements(install_requires, remove_req):
     assert len(delete_requirement) == 1, "expect only one match"
     install_requires.remove(delete_requirement.pop())
 
-
-os_type, architecture = get_os_and_architecture()
-if os_type == 'Darwin' or architecture == 'aarch64':
-    install_requires.remove('python-fcl')
 
 extra_all_requires = ['pybullet>=2.1.9']
 if (sys.version_info.major > 2):

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -1623,6 +1623,11 @@ class CascadedLink(CascadedCoords):
     def self_collision_check(self):
         """Return collision link pair
 
+        Note: This function uses trimesh.collision.CollisionManager internally.
+        We need to install python-fcl to use this function.
+        If you want to use this function, please install python-fcl by
+        `pip install python-fcl`.
+
         Returns
         -------
         is_collision : bool


### PR DESCRIPTION
- Remove python-fcl from requirements.txt and the conditional removal logic in setup.py.
- Update robot_model.py docstring to instruct users to install python-fcl for collision checking.