### PR TITLE
Improve Import Performance with Lazy Imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pillow
 pycollada!=0.7;python_version>="3.2"  # required for robot model using collada
 pycollada<0.9;python_version<"3.2"  # required for robot model using collada
 pyglet<2.0
-pysdfgen>=0.1.5
+pysdfgen>=0.2.0
 repoze.lru;python_version<"3.2"
 rtree # need rtree for simplify_quadric_decimation
 scikit-learn

--- a/skrobot/__init__.py
+++ b/skrobot/__init__.py
@@ -1,18 +1,51 @@
-# flake8: noqa
-
+import importlib
 import pkg_resources
-
 
 __version__ = pkg_resources.get_distribution('scikit-robot').version
 
+_SUBMODULES = [
+    "coordinates",
+    "data",
+    "interpolator",
+    "planner",
+    "interfaces",
+    "model",
+    "models",
+    "viewers",
+    "utils",
+    "sdf"
+]
+__all__ = _SUBMODULES
 
-from skrobot import coordinates
-from skrobot import data
-from skrobot import interpolator
-from skrobot import planner
-from skrobot import interfaces
-from skrobot import model
-from skrobot import models
-from skrobot import viewers
-from skrobot import utils
-from skrobot import sdf
+
+class LazyModule(object):
+    def __init__(self, name):
+        self.__name__ = "skrobot." + name
+        self._name = name
+        self._module = None
+
+    def __getattr__(self, attr):
+        if self._module is None:
+            self._module = importlib.import_module("skrobot." + self._name)
+        return getattr(self._module, attr)
+
+    def __dir__(self):
+        if self._module is None:
+            return ["__all__"]
+        return dir(self._module)
+
+
+_module_cache = {}
+for submodule in _SUBMODULES:
+    _module_cache[submodule] = LazyModule(submodule)
+
+
+def __getattr__(name):
+    if name in _SUBMODULES:
+        return _module_cache[name]
+    raise AttributeError(
+        "module {} has no attribute {}".format(__name__, name))
+
+
+def __dir__():
+    return __all__ + ['__version__']

--- a/skrobot/__init__.py
+++ b/skrobot/__init__.py
@@ -1,7 +1,5 @@
 import importlib
-import pkg_resources
 
-__version__ = pkg_resources.get_distribution('scikit-robot').version
 
 _SUBMODULES = [
     "coordinates",
@@ -16,6 +14,16 @@ _SUBMODULES = [
     "sdf"
 ]
 __all__ = _SUBMODULES
+_pkg_resources = None
+_version = None
+
+
+def _lazy_pkg_resources():
+    global _pkg_resources
+    if _pkg_resources is None:
+        import pkg_resources
+        _pkg_resources = pkg_resources
+    return _pkg_resources
 
 
 class LazyModule(object):
@@ -41,6 +49,13 @@ for submodule in _SUBMODULES:
 
 
 def __getattr__(name):
+    global _version
+    if name == "__version__":
+        if _version is None:
+            pkg_resources = _lazy_pkg_resources()
+            _version = pkg_resources.get_distribution(
+                'scikit-robot').version
+        return _version
     if name in _SUBMODULES:
         return _module_cache[name]
     raise AttributeError(

--- a/skrobot/__init__.py
+++ b/skrobot/__init__.py
@@ -1,66 +1,88 @@
-import importlib
+# flake8: noqa
+
+import sys
 
 
-_SUBMODULES = [
-    "coordinates",
-    "data",
-    "interpolator",
-    "planner",
-    "interfaces",
-    "model",
-    "models",
-    "viewers",
-    "utils",
-    "sdf"
-]
-__all__ = _SUBMODULES
-_pkg_resources = None
-_version = None
+if (sys.version_info[0] == 3 and sys.version_info[1] >= 7) \
+    or sys.version_info[0] > 3:
+    import importlib
+    _SUBMODULES = [
+        "coordinates",
+        "data",
+        "interpolator",
+        "planner",
+        "interfaces",
+        "model",
+        "models",
+        "viewers",
+        "utils",
+        "sdf"
+    ]
+    __all__ = _SUBMODULES
+    _pkg_resources = None
+    _version = None
 
 
-def _lazy_pkg_resources():
-    global _pkg_resources
-    if _pkg_resources is None:
-        import pkg_resources
-        _pkg_resources = pkg_resources
-    return _pkg_resources
+    def _lazy_pkg_resources():
+        global _pkg_resources
+        if _pkg_resources is None:
+            import pkg_resources
+            _pkg_resources = pkg_resources
+        return _pkg_resources
 
 
-class LazyModule(object):
-    def __init__(self, name):
-        self.__name__ = "skrobot." + name
-        self._name = name
-        self._module = None
+    class LazyModule(object):
+        def __init__(self, name):
+            self.__name__ = "skrobot." + name
+            self._name = name
+            self._module = None
 
-    def __getattr__(self, attr):
-        if self._module is None:
-            self._module = importlib.import_module("skrobot." + self._name)
-        return getattr(self._module, attr)
+        def __getattr__(self, attr):
+            if self._module is None:
+                self._module = importlib.import_module("skrobot." + self._name)
+            return getattr(self._module, attr)
 
-    def __dir__(self):
-        if self._module is None:
-            return ["__all__"]
-        return dir(self._module)
-
-
-_module_cache = {}
-for submodule in _SUBMODULES:
-    _module_cache[submodule] = LazyModule(submodule)
+        def __dir__(self):
+            if self._module is None:
+                return ["__all__"]
+            return dir(self._module)
 
 
-def __getattr__(name):
-    global _version
-    if name == "__version__":
-        if _version is None:
-            pkg_resources = _lazy_pkg_resources()
-            _version = pkg_resources.get_distribution(
-                'scikit-robot').version
-        return _version
-    if name in _SUBMODULES:
-        return _module_cache[name]
-    raise AttributeError(
-        "module {} has no attribute {}".format(__name__, name))
+    _module_cache = {}
+    for submodule in _SUBMODULES:
+        _module_cache[submodule] = LazyModule(submodule)
 
 
-def __dir__():
-    return __all__ + ['__version__']
+    def __getattr__(name):
+        global _version
+        if name == "__version__":
+            if _version is None:
+                pkg_resources = _lazy_pkg_resources()
+                _version = pkg_resources.get_distribution(
+                    'scikit-robot').version
+            return _version
+        if name in _SUBMODULES:
+            return _module_cache[name]
+        raise AttributeError(
+            "module {} has no attribute {}".format(__name__, name))
+
+
+    def __dir__():
+        return __all__ + ['__version__']
+else:
+    import pkg_resources
+
+
+    __version__ = pkg_resources.get_distribution('scikit-robot').version
+
+
+    from skrobot import coordinates
+    from skrobot import data
+    from skrobot import interpolator
+    from skrobot import planner
+    from skrobot import interfaces
+    from skrobot import model
+    from skrobot import models
+    from skrobot import viewers
+    from skrobot import utils
+    from skrobot import sdf

--- a/skrobot/_lazy_imports.py
+++ b/skrobot/_lazy_imports.py
@@ -1,3 +1,6 @@
+import importlib
+
+
 _trimesh = None
 
 
@@ -18,3 +21,41 @@ def _lazy_scipy():
         import scipy
         _scipy = scipy
     return _scipy
+
+
+class LazyImportClass(object):
+
+    def __init__(self, module_name, class_name, package):
+        self._module_name = module_name
+        self._class_name = class_name
+        self._class = None
+        self._package = package
+
+    def __getattr__(self, attr):
+        if self._class is None:
+            try:
+                module = importlib.import_module(self._module_name,
+                                                 package=self._package)
+                self._class = getattr(module, self._class_name)
+            except ImportError:
+                self._class = None
+        if self._class is None:
+            raise AttributeError("Failed to load {}".format(self._class_name))
+        return getattr(self._class, attr)
+
+    def __call__(self, *args, **kwargs):
+        if self._class is None:
+            try:
+                module = importlib.import_module(self._module_name,
+                                                 package=self._package)
+                self._class = getattr(module, self._class_name)
+            except ImportError as e:
+                raise AttributeError(
+                    "Failed to load {}. Error log: {}".format(
+                        self._class_name, e))
+        return self._class(*args, **kwargs)
+
+    def __dir__(self):
+        if self._class is None:
+            return []
+        return dir(self._class)

--- a/skrobot/_lazy_imports.py
+++ b/skrobot/_lazy_imports.py
@@ -7,3 +7,14 @@ def _lazy_trimesh():
         import trimesh
         _trimesh = trimesh
     return _trimesh
+
+
+_scipy = None
+
+
+def _lazy_scipy():
+    global _scipy
+    if _scipy is None:
+        import scipy
+        _scipy = scipy
+    return _scipy

--- a/skrobot/_lazy_imports.py
+++ b/skrobot/_lazy_imports.py
@@ -1,0 +1,9 @@
+_trimesh = None
+
+
+def _lazy_trimesh():
+    global _trimesh
+    if _trimesh is None:
+        import trimesh
+        _trimesh = trimesh
+    return _trimesh

--- a/skrobot/data/__init__.py
+++ b/skrobot/data/__init__.py
@@ -1,11 +1,18 @@
 import os
 import os.path as osp
 
-import gdown
-
-
 data_dir = osp.abspath(osp.dirname(__file__))
 _default_cache_dir = osp.expanduser('~/.skrobot')
+
+_gdown = None
+
+
+def _lazy_gdown():
+    global _gdown
+    if _gdown is None:
+        import gdown
+        _gdown = gdown
+    return _gdown
 
 
 def get_cache_dir():
@@ -13,6 +20,7 @@ def get_cache_dir():
 
 
 def bunny_objpath():
+    gdown = _lazy_gdown()
     target_path = osp.join(get_cache_dir(), 'mesh', 'bunny.obj')
     gdown.cached_download(
         url='https://raw.githubusercontent.com/iory/scikit-robot-models/master/data/bunny.obj',  # NOQA
@@ -24,6 +32,7 @@ def bunny_objpath():
 
 
 def fetch_urdfpath():
+    gdown = _lazy_gdown()
     gdown.cached_download(
         url='https://github.com/iory/scikit-robot-models/raw/master/fetch_description.tar.gz',  # NOQA
         path=osp.join(get_cache_dir(), 'fetch_description.tar.gz'),
@@ -39,6 +48,7 @@ def kuka_urdfpath():
 
 
 def panda_urdfpath():
+    gdown = _lazy_gdown()
     gdown.cached_download(
         url='https://github.com/iory/scikit-robot-models/raw/master/franka_description.tar.gz',  # NOQA
         path=osp.join(get_cache_dir(), 'franka_description.tar.gz'),
@@ -50,6 +60,7 @@ def panda_urdfpath():
 
 
 def pr2_urdfpath():
+    gdown = _lazy_gdown()
     gdown.cached_download(
         url='https://github.com/iory/scikit-robot-models/raw/master/pr2_description.tar.gz',  # NOQA
         path=osp.join(get_cache_dir(), 'pr2_description.tar.gz'),

--- a/skrobot/interfaces/ros/__init__.py
+++ b/skrobot/interfaces/ros/__init__.py
@@ -1,11 +1,9 @@
-# flake8: noqa
+from skrobot._lazy_imports import LazyImportClass
 
-try:
-    from .panda import PandaROSRobotInterface
-except ImportError:
-    pass
 
-try:
-    from .pr2 import PR2ROSRobotInterface
-except ImportError:
-    pass
+PandaROSRobotInterface = LazyImportClass(
+    ".panda", "PandaROSRobotInterface", "skrobot.interfaces.ros")
+PR2ROSRobotInterface = LazyImportClass(
+    ".pr2", "PR2ROSRobotInterface", "skrobot.interfaces.ros")
+
+__all__ = ["PandaROSRobotInterface", "PR2ROSRobotInterface"]

--- a/skrobot/model/link.py
+++ b/skrobot/model/link.py
@@ -87,6 +87,9 @@ class Link(CascadedCoords):
             specified in the link frame,
             or None if there is not one.
         """
+        if mesh is None or (isinstance(mesh, Sequence) and len(mesh) == 0):
+            self._collision_mesh = None
+            return
         trimesh = _lazy_trimesh()
         if mesh is not None and \
            not isinstance(mesh, trimesh.base.Trimesh):
@@ -116,9 +119,13 @@ class Link(CascadedCoords):
                trimesh.points.PointCloud or str
             A set of visual meshes for the link in the link frame.
         """
+        if mesh is None or (isinstance(mesh, Sequence) and len(mesh) == 0):
+            self._visual_mesh = mesh
+            self._concatenated_visual_mesh = None
+            self._visual_mesh_changed = True
+            return
         trimesh = _lazy_trimesh()
-        if not (mesh is None
-                or isinstance(mesh, trimesh.Trimesh)
+        if not (isinstance(mesh, trimesh.Trimesh)
                 or (isinstance(mesh, Sequence)
                     and all(isinstance(m, trimesh.Trimesh) for m in mesh))
                 or isinstance(mesh, trimesh.points.PointCloud)

--- a/skrobot/model/link.py
+++ b/skrobot/model/link.py
@@ -4,9 +4,9 @@ except ImportError:
     from collections import Sequence
 
 import numpy as np
-import trimesh
 
 import skrobot
+from skrobot._lazy_imports import _lazy_trimesh
 from skrobot.coordinates import CascadedCoords
 
 
@@ -27,6 +27,7 @@ class Link(CascadedCoords):
         self._collision_mesh = collision_mesh
         self.visual_mesh = visual_mesh
         if visual_mesh is not None:
+            trimesh = _lazy_trimesh()
             self._concatenated_visual_mesh = trimesh.util.concatenate(
                 self._visual_mesh)
         else:
@@ -86,6 +87,7 @@ class Link(CascadedCoords):
             specified in the link frame,
             or None if there is not one.
         """
+        trimesh = _lazy_trimesh()
         if mesh is not None and \
            not isinstance(mesh, trimesh.base.Trimesh):
             raise TypeError('input mesh is should be trimesh.base.Trimesh, '
@@ -114,6 +116,7 @@ class Link(CascadedCoords):
                trimesh.points.PointCloud or str
             A set of visual meshes for the link in the link frame.
         """
+        trimesh = _lazy_trimesh()
         if not (mesh is None
                 or isinstance(mesh, trimesh.Trimesh)
                 or (isinstance(mesh, Sequence)
@@ -166,6 +169,7 @@ class Link(CascadedCoords):
         self._visual_mesh_changed = True
 
     def reset_color(self):
+        trimesh = _lazy_trimesh()
         concat_mesh = trimesh.util.concatenate(self._visual_mesh)
         self._concatenated_visual_mesh.visual.face_colors = \
             concat_mesh.visual.face_colors

--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -1,9 +1,8 @@
 import uuid
 
 import numpy as np
-import trimesh
-from trimesh import PointCloud
 
+from skrobot._lazy_imports import _lazy_trimesh
 from skrobot.coordinates.base import CascadedCoords
 from skrobot.coordinates.base import Coordinates
 from skrobot.model import Link
@@ -28,9 +27,9 @@ class Axis(Link):
                  axis_radius=0.01,
                  axis_length=0.1,
                  pos=(0, 0, 0), rot=np.eye(3), name=None):
+        trimesh = _lazy_trimesh()
         if name is None:
             name = 'axis_{}'.format(str(uuid.uuid1()).replace('-', '_'))
-
         super(Axis, self).__init__(pos=pos, rot=rot, name=name,
                                    visual_mesh=trimesh.creation.axis(
                                        origin_size=0.00000001,
@@ -59,6 +58,7 @@ class Box(Link, SDFImplemented):
 
     def __init__(self, extents, vertex_colors=None, face_colors=None,
                  pos=(0, 0, 0), rot=np.eye(3), name=None, with_sdf=False):
+        trimesh = _lazy_trimesh()
         if name is None:
             name = 'box_{}'.format(str(uuid.uuid1()).replace('-', '_'))
 
@@ -85,6 +85,7 @@ class CameraMarker(Link):
     def __init__(self, focal=None, fov=(70, 40), z_near=0.01, z_far=1000.0,
                  marker_height=0.4, pos=(0, 0, 0), rot=np.eye(3),
                  without_axis=False, name=None):
+        trimesh = _lazy_trimesh()
         if name is None:
             name = 'camera_marker_{}'.format(
                 str(uuid.uuid1()).replace('-', '_'))
@@ -112,6 +113,7 @@ class Cone(Link):
                  sections=32,
                  vertex_colors=None, face_colors=None,
                  pos=(0, 0, 0), rot=np.eye(3), name=None):
+        trimesh = _lazy_trimesh()
         if name is None:
             name = 'cone_{}'.format(str(uuid.uuid1()).replace('-', '_'))
 
@@ -135,6 +137,7 @@ class Cylinder(Link, SDFImplemented):
                  sections=32,
                  vertex_colors=None, face_colors=None,
                  pos=(0, 0, 0), rot=np.eye(3), name=None, with_sdf=False):
+        trimesh = _lazy_trimesh()
         if name is None:
             name = 'cylinder_{}'.format(str(uuid.uuid1()).replace('-', '_'))
 
@@ -162,6 +165,7 @@ class Sphere(Link, SDFImplemented):
 
     def __init__(self, radius, subdivisions=3, color=None,
                  pos=(0, 0, 0), rot=np.eye(3), name=None, with_sdf=False):
+        trimesh = _lazy_trimesh()
         if name is None:
             name = 'sphere_{}'.format(str(uuid.uuid1()).replace('-', '_'))
 
@@ -188,6 +192,7 @@ class Annulus(Link):
     def __init__(self, r_min, r_max, height,
                  vertex_colors=None, face_colors=None,
                  pos=(0, 0, 0), rot=np.eye(3), name=None):
+        trimesh = _lazy_trimesh()
         if name is None:
             name = 'annulus_{}'.format(str(uuid.uuid1()).replace('-', '_'))
 
@@ -214,7 +219,7 @@ class LineString(Link):
                  pos=(0, 0, 0),
                  rot=np.eye(3),
                  name=None):
-
+        trimesh = _lazy_trimesh()
         if not isinstance(points, np.ndarray):
             raise TypeError("points must be np.ndarray")
 
@@ -271,8 +276,8 @@ class PointCloudLink(Link):
                  point_cloud_like=None,
                  colors=None,
                  pos=(0, 0, 0), rot=np.eye(3), name=None):
-
-        accep_types = (type(None), np.ndarray, PointCloud)
+        trimesh = _lazy_trimesh()
+        accep_types = (type(None), np.ndarray, trimesh.PointCloud)
         if not isinstance(point_cloud_like, accep_types):
             message = "point cloud must be either of {}".format(accep_types)
             raise TypeError(message)
@@ -280,7 +285,7 @@ class PointCloudLink(Link):
         if isinstance(point_cloud_like, np.ndarray):
             assert point_cloud_like.ndim == 2
             assert point_cloud_like.shape[1] == 3
-            pcloud_mesh = PointCloud(point_cloud_like, colors)
+            pcloud_mesh = trimesh.PointCloud(point_cloud_like, colors)
         else:
             pcloud_mesh = point_cloud_like
 

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -10,8 +10,8 @@ import numpy as np
 import numpy.linalg as LA
 from ordered_set import OrderedSet
 import six
-import trimesh
 
+from skrobot._lazy_imports import _lazy_trimesh
 from skrobot.coordinates import CascadedCoords
 from skrobot.coordinates import convert_to_axis_vector
 from skrobot.coordinates import Coordinates
@@ -1639,6 +1639,7 @@ class CascadedLink(CascadedCoords):
             that the two corresponding objects are in collision.
         """
         if self._collision_manager is None:
+            trimesh = _lazy_trimesh()
             self._collision_manager = trimesh.collision.CollisionManager()
             for link in self.link_list:
                 transform = link.worldcoords().T()
@@ -1699,6 +1700,7 @@ class RobotModel(CascadedLink):
             raise TypeError('visual must be urdf.Visual, but got: {}'
                             .format(type(visual)))
 
+        trimesh = _lazy_trimesh()
         meshes = []
         for mesh in visual.geometry.meshes:
             mesh = mesh.copy()

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -1700,9 +1700,11 @@ class RobotModel(CascadedLink):
             raise TypeError('visual must be urdf.Visual, but got: {}'
                             .format(type(visual)))
 
-        trimesh = _lazy_trimesh()
+        trimesh = None
         meshes = []
         for mesh in visual.geometry.meshes:
+            if trimesh is None:
+                trimesh = _lazy_trimesh()
             mesh = mesh.copy()
 
             # rescale

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -9,8 +9,8 @@ import tempfile
 import filelock
 import numpy as np
 import pysdfgen
-from scipy.interpolate import RegularGridInterpolator
 
+from skrobot._lazy_imports import _lazy_scipy
 from skrobot.coordinates import CascadedCoords
 from skrobot.coordinates import Coordinates
 from skrobot.data import get_cache_dir
@@ -399,7 +399,8 @@ class GridSDF(SignedDistanceFunction):
         # create regular grid interpolator
         xlin, ylin, zlin = [
             np.array(range(d)) * resolution for d in self._data.shape]
-        self.itp = RegularGridInterpolator(
+        scipy = _lazy_scipy()
+        self.itp = scipy.interpolate.RegularGridInterpolator(
             (xlin, ylin, zlin),
             self._data,
             bounds_error=False,

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -24,15 +24,12 @@ import networkx as nx
 import numpy as np
 import PIL
 import six
-import trimesh
-from trimesh.visual.material import PBRMaterial
 
+from skrobot._lazy_imports import _lazy_trimesh
 from skrobot.coordinates import normalize_vector
 from skrobot.coordinates import rpy_angle
 from skrobot.coordinates import rpy_matrix
 from skrobot.pycompat import lru_cache
-from skrobot.utils.mesh import auto_simplify_quadric_decimation
-from skrobot.utils.mesh import split_mesh_by_face_color
 
 
 try:
@@ -293,6 +290,7 @@ def _load_meshes(filename):
     meshes : list of :class:`~trimesh.base.Trimesh`
         The meshes loaded from the file.
     """
+    trimesh = _lazy_trimesh()
     try:
         _, ext = os.path.splitext(filename)
         # It seems that .3DXML files assume [mm] unit.
@@ -331,7 +329,8 @@ def _load_meshes(filename):
     for mesh in meshes:
         transparency = get_transparency(mesh)
         if transparency is not None and transparency == 0.0:
-            if isinstance(mesh.visual.material, PBRMaterial):
+            if isinstance(mesh.visual.material,
+                          trimesh.visual.material.PBRMaterial):
                 mesh.visual.material.baseColorFactor[3] = 255
     return meshes
 
@@ -688,6 +687,7 @@ class Box(URDFType):
         """
         if len(self._meshes) == 0:
             if _CONFIGURABLE_VALUES['no_mesh_load_mode'] is False:
+                trimesh = _lazy_trimesh()
                 self._meshes = [trimesh.creation.box(extents=self.size)]
         return self._meshes
 
@@ -748,6 +748,7 @@ class Cylinder(URDFType):
         """
         if len(self._meshes) == 0:
             if _CONFIGURABLE_VALUES['no_mesh_load_mode'] is False:
+                trimesh = _lazy_trimesh()
                 self._meshes = [trimesh.creation.cylinder(
                     radius=self.radius, height=self.length
                 )]
@@ -792,6 +793,7 @@ class Sphere(URDFType):
         """
         if len(self._meshes) == 0:
             if _CONFIGURABLE_VALUES['no_mesh_load_mode'] is False:
+                trimesh = _lazy_trimesh()
                 self._meshes = [trimesh.creation.icosphere(radius=self.radius)]
         return self._meshes
 
@@ -861,6 +863,7 @@ class Mesh(URDFType):
 
     @meshes.setter
     def meshes(self, value):
+        trimesh = _lazy_trimesh()
         if isinstance(value, six.string_types):
             value = load_meshes(value)
         elif isinstance(value, (list, tuple, set)):
@@ -908,6 +911,7 @@ class Mesh(URDFType):
         meshes = self.meshes
         if _CONFIGURABLE_VALUES[
                 "decimation_area_ratio_threshold"] is not None:
+            from skrobot.utils.mesh import auto_simplify_quadric_decimation
             meshes = auto_simplify_quadric_decimation(
                 meshes, area_ratio_threshold=_CONFIGURABLE_VALUES[
                     "decimation_area_ratio_threshold"])
@@ -918,7 +922,9 @@ class Mesh(URDFType):
                 _CONFIGURABLE_VALUES['simplify_vertex_clustering_voxel_size'],
             )
 
+        trimesh = _lazy_trimesh()
         if fn.endswith('.dae'):
+            from skrobot.utils.mesh import split_mesh_by_face_color
             export_meshes = []
             has_texture_visual = False
             for mesh in meshes:
@@ -2419,6 +2425,7 @@ class Joint(URDFType):
                 cfg = 0.0
             else:
                 cfg = float(cfg)
+            trimesh = _lazy_trimesh()
             R = trimesh.transformations.rotation_matrix(cfg, self.axis)
             return self.origin.dot(R)
         elif self.joint_type == 'prismatic':

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -22,7 +22,7 @@ except ImportError:
 from lxml import etree as ET
 import networkx as nx
 import numpy as np
-import PIL
+import PIL.Image
 import six
 
 from skrobot._lazy_imports import _lazy_trimesh

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -893,8 +893,8 @@ class Mesh(URDFType):
 
         # Load the mesh, combining collision geometry meshes but keeping
         # visual ones separate to preserve colors and textures
-        fn = get_filename(path, kwargs['filename'])
         if _CONFIGURABLE_VALUES['no_mesh_load_mode'] is False:
+            fn = get_filename(path, kwargs['filename'])
             meshes = load_meshes(fn)
         else:
             meshes = []

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -863,20 +863,29 @@ class Mesh(URDFType):
 
     @meshes.setter
     def meshes(self, value):
-        trimesh = _lazy_trimesh()
         if isinstance(value, six.string_types):
             value = load_meshes(value)
-        elif isinstance(value, (list, tuple, set)):
+            self._meshes = value
+            return
+
+        if isinstance(value, (list, tuple, set)):
             value = list(value)
-            for m in value:
-                if not isinstance(m, trimesh.Trimesh):
-                    raise TypeError('Mesh requires a trimesh.Trimesh or a '
-                                    'list of them')
-        elif isinstance(value, trimesh.Trimesh):
-            value = [value]
-        else:
-            raise TypeError('Mesh requires a trimesh.Trimesh')
-        self._meshes = value
+            trimesh = None
+            for i, m in enumerate(value):
+                if not hasattr(m, '__module__') or m.__module__ != 'trimesh':
+                    if trimesh is None:
+                        trimesh = _lazy_trimesh()
+                    if not isinstance(m, trimesh.Trimesh):
+                        raise TypeError('Mesh requires a trimesh.Trimesh or a '
+                                        'list of them')
+            self._meshes = value
+            return
+
+        trimesh = _lazy_trimesh()
+        if isinstance(value, trimesh.Trimesh):
+            self._meshes = [value]
+            return
+        raise TypeError('Mesh requires a trimesh.Trimesh')
 
     @classmethod
     def _from_xml(cls, node, path):


### PR DESCRIPTION
On PCs with slow disk access, such as Raspberry Pi, Python import times can be significantly longer.
This PR introduces lazy imports to reduce unnecessary import time and improve overall performance.

## Key Changes:
- Refactored __init__.py to enable lazy loading of submodules.
- Introduced LazyImportClass and applied it to ROSRobotInterface.
- Made scipy, trimesh, pkg_resources, and gdown lazily imported to reduce initial import overhead.
- Updated pysdfgen to version 0.2.0 for better lazy import compatibility.
- Refactored meshes setter and get_filename function to optimize import behavior.
