### PR TITLE
[ga] Test multiple numpy and scipy versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,75 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6.15, 3.8.16, 3.10.10]
-        os: [ubuntu-20.04]
+        include:
+          - python-version: 3.6.15
+            os: ubuntu-20.04
+            numpy-version: "1.17.4"
+            scipy-version: "1.3.3"
+          - python-version: 3.6.15
+            os: ubuntu-20.04
+            numpy-version: "1.17.4"
+            scipy-version: "latest"
+          - python-version: 3.6.15
+            os: ubuntu-20.04
+            numpy-version: "latest"
+            scipy-version: "1.3.3"
+          - python-version: 3.6.15
+            os: ubuntu-20.04
+            numpy-version: "latest"
+            scipy-version: "latest"
+
+          - python-version: 3.8.16
+            os: ubuntu-20.04
+            numpy-version: "1.21.0"
+            scipy-version: "1.6.3"
+          - python-version: 3.8.16
+            os: ubuntu-20.04
+            numpy-version: "1.21.0"
+            scipy-version: "latest"
+          - python-version: 3.8.16
+            os: ubuntu-20.04
+            numpy-version: "latest"
+            scipy-version: "1.6.3"
+          - python-version: 3.8.16
+            os: ubuntu-20.04
+            numpy-version: "latest"
+            scipy-version: "latest"
+
+          - python-version: 3.10.10
+            os: ubuntu-22.04
+            numpy-version: "1.21.5"
+            scipy-version: "1.8.0"
+          - python-version: 3.10.10
+            os: ubuntu-22.04
+            numpy-version: "1.21.5"
+            scipy-version: "latest"
+          - python-version: 3.10.10
+            os: ubuntu-22.04
+            numpy-version: "latest"
+            scipy-version: "1.8.0"
+          - python-version: 3.10.10
+            os: ubuntu-22.04
+            numpy-version: "latest"
+            scipy-version: "latest"
+
+          - python-version: 3.12.3
+            os: ubuntu-24.04
+            numpy-version: "1.26.4"
+            scipy-version: "1.11.4"
+          - python-version: 3.12.3
+            os: ubuntu-24.04
+            numpy-version: "1.26.4"
+            scipy-version: "latest"
+          - python-version: 3.12.3
+            os: ubuntu-24.04
+            numpy-version: "latest"
+            scipy-version: "1.11.4"
+          - python-version: 3.12.3
+            os: ubuntu-24.04
+            numpy-version: "latest"
+            scipy-version: "latest"
+      fail-fast: false
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -99,7 +166,20 @@ jobs:
     - name: Install scikit-robot
       run: |
         pip cache purge
-        pip install --no-cache-dir .[all] "numpy<2.0"
+        pip install --no-cache-dir .[all]
+
+    - name: Install NumPy and SciPy
+      run: |
+        if [ "${{ matrix.numpy-version }}" = "latest" ]; then
+          pip install numpy -U
+        else
+          pip install numpy==${{ matrix.numpy-version }}
+        fi
+        if [ "${{ matrix.scipy-version }}" = "latest" ]; then
+          pip install scipy -U
+        else
+          pip install scipy==${{ matrix.scipy-version }}
+        fi
     - name: Run Pytest
       # Normally, users would run `pytest -v tests`, but this test uses xvfb to test the GUI scripts in the examples/ directory.
       run: xvfb-run pytest -v tests

--- a/examples/pybullet_robot_interface.py
+++ b/examples/pybullet_robot_interface.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python
 
 import argparse
+import sys
 import time
 
 import numpy as np
-import pybullet
 
 import skrobot
+from skrobot.interfaces._pybullet import _check_available
 
 
 def main():
+    if _check_available() is False:
+        sys.exit(0)
+    import pybullet
     parser = argparse.ArgumentParser(
         description='Scikit-robot pybullet interface example.')
     parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ future
 gdown
 lxml
 networkx>=2.2.0
-numpy>=1.16.0
+numpy>=1.16.0;python_version<="3.7"
+numpy>=1.21.0;python_version>="3.8"
 ordered_set
 pillow
 pycollada!=0.7;python_version>="3.2"  # required for robot model using collada
@@ -17,5 +18,6 @@ rtree # need rtree for simplify_quadric_decimation
 scikit-learn
 scipy;python_version>="3.0"
 scipy<=1.2.3;python_version<"3.0"
+scipy>=1.6.3;python_version>="3.8"
 six
 trimesh>=3.9.0,!=3.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,9 @@ filelock
 future
 gdown
 lxml
-networkx>=2.2.0
-numpy>=1.16.0;python_version<="3.7"
+networkx>=2.2.0;python_version<"3.8"
+networkx>=2.5;python_version>="3.8"
+numpy>=1.16.0;python_version<"3.8"
 numpy>=1.21.0;python_version>="3.8"
 ordered_set
 pillow
@@ -15,8 +16,9 @@ pyglet<2.0
 pysdfgen>=0.2.0
 repoze.lru;python_version<"3.2"
 rtree # need rtree for simplify_quadric_decimation
-scikit-learn
-scipy;python_version>="3.0"
+scikit-learn;python_version<"3.8"
+scikit-learn>=0.24.0;python_version>="3.8"
+scipy;python_version>="3.0" and python_version<"3.8"
 scipy<=1.2.3;python_version<"3.0"
 scipy>=1.6.3;python_version>="3.8"
 six

--- a/skrobot/interfaces/_pybullet.py
+++ b/skrobot/interfaces/_pybullet.py
@@ -21,16 +21,32 @@ def _check_available():
     if not _import_checked:
         try:
             p = importlib.import_module('pybullet')
-        except (ImportError, TypeError):
+        except ImportError as e:
+            if 'numpy.core.multiarray' in str(e):
+                print('Failed to import pybullet due to a NumPy compatibility issue '  # NOQA
+                      + '(numpy.core.multiarray failed to import). '
+                      + 'This may be caused by an incompatible NumPy version.\n'  # NOQA
+                      + 'Please try installing a different NumPy version, e.g., 1.20.3:\n\n'  # NOQA
+                      + '  $ pip install numpy==1.20.3\n'
+                      + 'Then reinstall pybullet:\n'
+                      + '  $ pip install pybullet\n')
+            else:
+                _available = False
+                print('pybullet is not installed on your environment, '
+                      'so nothing will be drawn at this time. '
+                      'Please install pybullet.\n\n'
+                      '  $ pip install pybullet\n')
+        except TypeError:
             _available = False
+            print('Unexpected TypeError occurred while importing pybullet.')
         finally:
             _import_checked = True
-            _available = True
+            if p is not None:
+                _available = True
     if not _available:
-        raise ImportError('pybullet is not installed on your environment, '
-                          'so nothing will be drawn at this time. '
-                          'Please install pybullet.\n\n'
-                          '  $ pip install pybullet\n')
+        print('pybullet is unavailable. '
+              'No drawing will occur until the issue is resolved.')
+    return _available
 
 
 class PybulletRobotInterface(Coordinates):
@@ -68,7 +84,8 @@ class PybulletRobotInterface(Coordinates):
 
     def __init__(self, robot, urdf_path=None, use_fixed_base=False,
                  connect=1, *args, **kwargs):
-        _check_available()
+        if _check_available() is False:
+            raise ImportError('pybullet is not available.')
         super(PybulletRobotInterface, self).__init__(*args, **kwargs)
         if urdf_path is None:
             if robot.urdf_path is not None:

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -400,7 +400,13 @@ class GridSDF(SignedDistanceFunction):
         xlin, ylin, zlin = [
             np.array(range(d)) * resolution for d in self._data.shape]
         scipy = _lazy_scipy()
-        self.itp = scipy.interpolate.RegularGridInterpolator(
+        try:
+            interpolator = scipy.interpolate.RegularGridInterpolator
+        except AttributeError:
+            # scipy<=1.8.0
+            from scipy.interpolate import \
+                RegularGridInterpolator as interpolator
+        self.itp = interpolator(
             (xlin, ylin, zlin),
             self._data,
             bounds_error=False,

--- a/tests/skrobot_tests/interfaces_tests/test__pybullet.py
+++ b/tests/skrobot_tests/interfaces_tests/test__pybullet.py
@@ -1,11 +1,16 @@
 import unittest
 
+import pytest
+
 import skrobot
+from skrobot.interfaces._pybullet import _check_available
 from skrobot.interfaces._pybullet import PybulletRobotInterface
 
 
 class TestPybulletRobotInterface(unittest.TestCase):
 
+    @pytest.mark.skipif(_check_available() is False,
+                        reason="Pybullet is not available")
     def test_init(self):
         fetch = skrobot.models.Fetch()
         PybulletRobotInterface(fetch, connect=2)

--- a/tests/skrobot_tests/model_tests/test_robot_model.py
+++ b/tests/skrobot_tests/model_tests/test_robot_model.py
@@ -379,7 +379,7 @@ class TestRobotModel(unittest.TestCase):
         j1.joint_angle(np.deg2rad(-60.0))
         testing.assert_almost_equal(
             joint_angle_limit_weight([j1]),
-            3.1019381e-01)
+            np.float32(3.1019381e-01))
 
         j2 = RotationalJoint(
             child_link=make_coords(),
@@ -388,7 +388,7 @@ class TestRobotModel(unittest.TestCase):
         j2.joint_angle(np.deg2rad(74.0))
         testing.assert_almost_equal(
             joint_angle_limit_weight([j2]),
-            1.3539208e+03)
+            np.float32(1.3539208e+03))
 
         j3 = RotationalJoint(
             child_link=make_coords(),
@@ -397,4 +397,4 @@ class TestRobotModel(unittest.TestCase):
         j3.joint_angle(np.deg2rad(-20.0))
         testing.assert_almost_equal(
             joint_angle_limit_weight([j3]),
-            0.0)
+            np.float32(0.0))


### PR DESCRIPTION
# PR Summary

This pull request adds tests to verify compatibility with multiple versions of numpy and scipy, especially addressing issues that arise with older versions of numpy.

## Motivation

Using numpy versions earlier than 1.22.0 can cause the following errors, which may be difficult for beginners to debug:
```
ModuleNotFoundError: No module named 'numpy.typing'
AttributeError: module 'numpy' has no attribute 'typeDict'
```
To prevent such issues, this PR introduces version checks in the test suite to ensure that compatible versions of numpy and scipy are used.

## Additional Changes

- Updated requirements.txt to specify compatible versions of dependencies.
- Adjusted compatibility to support Python 3.8 and above.