### PR TITLE
[viewer] Print instruction in case of users not installed GL

### DIFF
--- a/skrobot/viewers/__init__.py
+++ b/skrobot/viewers/__init__.py
@@ -3,6 +3,32 @@
 import inspect
 
 
+def warn_gl(error_log):
+    if 'Library "GL" not found.' in str(error_log):
+        print(
+            '\x1b[31m'  # red
+            + 'Library "GL" not found. Please install it by running:\n'
+            + 'sudo apt-get install freeglut3-dev'
+            + '\x1b[39m'  # reset
+        )
+
+
+class DummyViewer(object):
+    def __init__(self, *args, **kwargs):
+        self.has_exit = True
+    def redraw(self):
+        pass
+    def show(self):
+        pass
+    def add(self, *args, **kwargs):
+        pass
+    def delete(self, *args, **kwargs):
+        pass
+    def set_camera(self, *args, **kwargs):
+        pass
+    def save_image(self, file_obj):
+        pass
+
 try:
     from ._trimesh import TrimeshSceneViewer
 except TypeError:
@@ -12,6 +38,10 @@ except TypeError:
             raise RuntimeError('TrimeshSceneViewer cannot be initialized. '
                                'This issue happens when the X window system '
                                'is not running.')
+except ImportError as error_log:
+    warn_gl(error_log)
+    class TrimeshSceneViewer(DummyViewer):
+        pass
 
 try:
     from ._pyrender import PyrenderViewer
@@ -26,7 +56,7 @@ try:
                     'please execute the following command:\n'
                     'pip uninstall -y pyrender && pip install git+https://github.com/mmatl/pyrender.git --no-cache-dir'
                 )
-except ImportError:
-    class PyrenderViewer(object):
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError('PyrenderViewer is not installed.')
+except ImportError as error_log:
+    warn_gl(error_log)
+    class PyrenderViewer(DummyViewer):
+        pass

--- a/skrobot/viewers/_pyrender.py
+++ b/skrobot/viewers/_pyrender.py
@@ -4,6 +4,7 @@ import collections
 import threading
 
 import numpy as np
+import pyglet
 import pyrender
 from pyrender.trackball import Trackball
 import trimesh
@@ -75,6 +76,13 @@ class PyrenderViewer(pyrender.Viewer):
         self.thread = threading.Thread(target=self._init_and_start_app)
         self.thread.daemon = True  # terminate when main thread exit
         self.thread.start()
+
+    def _init_and_start_app(self):
+        try:
+            super(PyrenderViewer, self)._init_and_start_app()
+        except pyglet.canvas.xlib.NoSuchDisplayException:
+            print('No display found. Viewer is disabled.')
+            self.has_exit = True
 
     def redraw(self):
         self._redraw = True

--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -102,6 +102,7 @@ class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
                 super(TrimeshSceneViewer, self).__init__(**self._kwargs)
             except pyglet.canvas.xlib.NoSuchDisplayException:
                 print('No display found. Viewer is disabled.')
+                self.has_exit = True
                 return
         pyglet.app.run()
 


### PR DESCRIPTION
Add warn print to install GL for users.

```
root@7dbd27c1c7a7:/scikit-robot/examples# python3 collision_free_trajectory.py --viewer pyrender
/usr/local/lib/python3.8/dist-packages/gdown/cached_download.py:102: FutureWarning: md5 is deprecated in favor of hash. Please use hash='md5:xxx...' instead.
  warnings.warn(
/usr/local/lib/python3.8/dist-packages/scikit_robot-0.1.0-py3.8.egg/skrobot/model/robot_model.py:1732: UserWarning: texture specified in URDF is not supported
  warnings.warn(
#<LinearJoint 0xfffe8a293d00 torso_lift_joint> :joint-angle(0.0) violate min-angle(0.0115)
#<RotationalJoint 0xfffe8a21db20 r_elbow_flex_joint> :joint-angle(0.0) violate max-angle(-0.15000005363462504)
#<RotationalJoint 0xfffe8a21dc40 r_wrist_flex_joint> :joint-angle(0.0) violate max-angle(-0.10000003575641671)
#<RotationalJoint 0xfffe8a2268e0 l_elbow_flex_joint> :joint-angle(0.0) violate max-angle(-0.15000005363462504)
#<RotationalJoint 0xfffe8a226a00 l_wrist_flex_joint> :joint-angle(0.0) violate max-angle(-0.10000003575641671)
Optimization terminated successfully    (Exit mode 0)
            Current function value: 0.003499027984200785
            Iterations: 22
            Function evaluations: 37
            Gradient evaluations: 22
solving time : 1.0583813190460205 sec
show trajectory
Library "GL" not found. Please install it by running:
sudo apt-get install freeglut3-dev
==> Press [q] to close window
```