### PR TITLE
Update pycollada required version for huge collada mesh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ numpy>=1.16.0;python_version<"3.8"
 numpy>=1.21.0;python_version>="3.8"
 ordered_set
 pillow
-pycollada!=0.7;python_version>="3.2"  # required for robot model using collada
 pycollada<0.9;python_version<"3.2"  # required for robot model using collada
+pycollada>=0.8;python_version>="3.2"  # required for robot model using collada
 pyglet<2.0
 pysdfgen>=0.2.0
 repoze.lru;python_version<"3.2"


### PR DESCRIPTION
Huge dae file may cause the following error.
```
Error: DaeMalformedError: XML Parsing Error: xmlSAX2Characters: huge text node, line 71, column 10001167 (<string>, line 7
```