### PR TITLE
fix: convert interval (sec) to rate (hz)

### DIFF
--- a/skrobot/viewers/_pyrender.py
+++ b/skrobot/viewers/_pyrender.py
@@ -66,6 +66,7 @@ class PyrenderViewer(pyrender.Viewer):
 
         self._redraw = True
 
+        refresh_rate = 1.0 / update_interval
         self._kwargs = dict(
             scene=pyrender.Scene(),
             viewport_size=resolution,
@@ -73,7 +74,7 @@ class PyrenderViewer(pyrender.Viewer):
             use_raymond_lighting=True,
             auto_start=False,
             render_flags=render_flags,
-            refresh_rate=update_interval,
+            refresh_rate=refresh_rate,
         )
         super(PyrenderViewer, self).__init__(**self._kwargs)
         self.viewer_flags['window_title'] = 'scikit-robot PyrenderViewer'


### PR DESCRIPTION
pyrender.viewer requires `refresh_rate` in hz
https://github.com/mmatl/pyrender/blob/a59963ef890891656fd17c90e12d663233dcaa99/pyrender/viewer.py#L157
So, we need to convert [s] to [hz]