### PR TITLE
[urdf] Add urdf root link changer function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ extend-exclude = [".?*", "src/", "build", "docs"]
 line-length = 120
 
 [tool.ruff.lint]
+preview = true
+
 # Enable flake8-style rules
 select = ["E", "F", "W"]
 # Ignore specific rules to match current flake8 config

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ if (sys.version_info.major, sys.version_info.minor) >= (3, 6):
     console_scripts.append(
         "convert-urdf-mesh=skrobot.apps.convert_urdf_mesh:main")
 console_scripts.append("modularize-urdf=skrobot.apps.modularize_urdf:main")
+console_scripts.append("change-urdf-root=skrobot.apps.change_urdf_root:main")
 
 
 setup(

--- a/skrobot/__init__.py
+++ b/skrobot/__init__.py
@@ -17,7 +17,8 @@ if (sys.version_info[0] == 3 and sys.version_info[1] >= 7) \
         "models",
         "viewers",
         "utils",
-        "sdf"
+        "sdf",
+        "urdf"
     ]
     __all__ = _SUBMODULES
     _version = None
@@ -82,3 +83,4 @@ else:
     from skrobot import viewers
     from skrobot import utils
     from skrobot import sdf
+    from skrobot import urdf

--- a/skrobot/apps/change_urdf_root.py
+++ b/skrobot/apps/change_urdf_root.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+
+from skrobot.urdf import URDFXMLRootLinkChanger
+
+
+def main():
+    """Main entry point for the change_urdf_root command.
+
+    This command line tool allows users to change the root link of a URDF file
+    by directly manipulating the XML structure and saving the result
+    to a new file.
+
+    """
+    parser = argparse.ArgumentParser(
+        description='Change the root link of a URDF file',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Change root link to 'base_link' and save to new file
+  change_urdf_root robot.urdf base_link output.urdf
+
+  # List all available links first
+  change_urdf_root robot.urdf --list
+
+  # Change root link with verbose output
+  change_urdf_root robot.urdf new_root output.urdf --verbose
+        """)
+
+    parser.add_argument(
+        'input_urdf',
+        type=str,
+        help='Path to the input URDF file')
+
+    parser.add_argument(
+        'new_root_link',
+        type=str,
+        nargs='?',
+        help='Name of the new root link')
+
+    parser.add_argument(
+        'output_urdf',
+        type=str,
+        nargs='?',
+        help='Path to the output URDF file')
+
+    parser.add_argument(
+        '--list', '-l',
+        action='store_true',
+        help='List all available links in the URDF and exit')
+
+    parser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Enable verbose output')
+
+    parser.add_argument(
+        '--force', '-f',
+        action='store_true',
+        help='Overwrite output file if it exists')
+
+    args = parser.parse_args()
+
+    # Check if input file exists
+    if not os.path.exists(args.input_urdf):
+        print("Error: Input URDF file '{}' not found".format(
+            args.input_urdf), file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        # Create the root link changer
+        if args.verbose:
+            print("Loading URDF: {}".format(args.input_urdf))
+
+        changer = URDFXMLRootLinkChanger(args.input_urdf)
+
+        # If --list is specified, show all links and exit
+        if args.list:
+            current_root = changer.get_current_root_link()
+            links = changer.list_links()
+
+            print("Current root link: {}".format(current_root))
+            print("Total links: {}".format(len(links)))
+            print("\nAll links:")
+            for i, link_name in enumerate(links, 1):
+                marker = " (current root)" if link_name == current_root else ""
+                print("  {:2d}. {}{}".format(i, link_name, marker))
+            return
+
+        # Validate required arguments
+        if not args.new_root_link:
+            print("Error: new_root_link is required when not using --list",
+                  file=sys.stderr)
+            parser.print_help()
+            sys.exit(1)
+
+        if not args.output_urdf:
+            print("Error: output_urdf is required when not using --list",
+                  file=sys.stderr)
+            parser.print_help()
+            sys.exit(1)
+
+        # Check if output file already exists
+        args.output_urdf = os.path.abspath(args.output_urdf)
+        if os.path.exists(args.output_urdf) and not args.force:
+            print("Error: Output file '{}' already exists. "
+                  "Use --force to overwrite.".format(args.output_urdf),
+                  file=sys.stderr)
+            sys.exit(1)
+
+        # Validate the new root link
+        available_links = changer.list_links()
+        if args.new_root_link not in available_links:
+            print("Error: Link '{}' not found in URDF".format(
+                args.new_root_link), file=sys.stderr)
+            print("Available links: {}".format(', '.join(available_links)),
+                  file=sys.stderr)
+            sys.exit(1)
+
+        # Show current state
+        current_root = changer.get_current_root_link()
+        if args.verbose:
+            print("Current root link: {}".format(current_root))
+            print("New root link: {}".format(args.new_root_link))
+            print("Output file: {}".format(args.output_urdf))
+
+        # Check if the new root is the same as current
+        if args.new_root_link == current_root:
+            if args.verbose:
+                print("Warning: New root link is "
+                      + "the same as current root link")
+
+        # Perform the root link change
+        if args.verbose:
+            print("Changing root link...")
+
+        changer.change_root_link(args.new_root_link, args.output_urdf)
+
+        # Verify the result
+        if args.verbose:
+            print("Verifying result...")
+
+        result_changer = URDFXMLRootLinkChanger(args.output_urdf)
+        actual_root = result_changer.get_current_root_link()
+
+        if actual_root == args.new_root_link:
+            print("Successfully changed root link from '{}' "
+                  "to '{}'".format(current_root, args.new_root_link))
+            print("Modified URDF saved to: {}".format(args.output_urdf))
+        else:
+            print("Failed to change root link. Expected "
+                  "'{}', got '{}'".format(args.new_root_link, actual_root),
+                  file=sys.stderr)
+            sys.exit(1)
+
+    except FileNotFoundError as e:
+        print("Error: {}".format(e), file=sys.stderr)
+        sys.exit(1)
+    except ValueError as e:
+        print("Error: {}".format(e), file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print("Unexpected error: {}".format(e), file=sys.stderr)
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/skrobot/apps/modularize_urdf.py
+++ b/skrobot/apps/modularize_urdf.py
@@ -6,6 +6,7 @@ import os
 from skrobot.urdf.modularize_urdf import find_root_link
 from skrobot.urdf.modularize_urdf import transform_urdf_to_macro
 
+
 def main():
     parser = argparse.ArgumentParser(description="Modularize URDF to xacro macro")
     parser.add_argument("input_urdf", help="Input URDF file path")
@@ -24,15 +25,16 @@ def main():
         output_path = base_name + "_modularized.xacro"
 
     etree.ElementTree(xacro_root).write(output_path, pretty_print=True, xml_declaration=True, encoding="utf-8")
-    print(f"Successfully converted to xacro: {output_path}")
-    print(f"""To use the generated xacro macro in your xacro file, copy and paste the following:
+    print("Successfully converted to xacro: {}".format(output_path))
+    print("""To use the generated xacro macro in your xacro file, copy and paste the following:
 
-  <xacro:{robot_name}
+  <xacro:{}
     prefix="[specify prefix]"
     parent_link="[specify parent link]">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-  </xacro:{robot_name}>
-""")
+  </xacro:{}>
+""".format(robot_name, robot_name))
+
 
 if __name__ == "__main__":
     main()

--- a/skrobot/urdf/__init__.py
+++ b/skrobot/urdf/__init__.py
@@ -1,0 +1,11 @@
+from .xml_root_link_changer import change_urdf_root_link
+from .xml_root_link_changer import URDFXMLRootLinkChanger
+from .modularize_urdf import find_root_link
+from .modularize_urdf import transform_urdf_to_macro
+
+__all__ = [
+    'change_urdf_root_link',
+    'URDFXMLRootLinkChanger',
+    'find_root_link',
+    'transform_urdf_to_macro',
+]

--- a/skrobot/urdf/modularize_urdf.py
+++ b/skrobot/urdf/modularize_urdf.py
@@ -5,8 +5,10 @@ import os
 import subprocess
 import tempfile
 
+
 def add_prefix_to_name(name):
     return "${prefix}" + name if not name.startswith("${prefix}") else name
+
 
 def indent_element(elem, level=1, indent_str="    "):
     i = "\n" + level * indent_str
@@ -20,6 +22,7 @@ def indent_element(elem, level=1, indent_str="    "):
     else:
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
+
 
 def find_root_link(input_path):
     tree = etree.parse(input_path)
@@ -40,6 +43,7 @@ def find_root_link(input_path):
         return next(iter(root_candidates))  # root link name as string
     else:
         raise ValueError("Could not determine root link. Check that the URDF contains valid joint definitions.")
+
 
 def transform_urdf_to_macro(input_path, connector_link, no_prefix):
     XACRO_NS = "http://ros.org/wiki/xacro"
@@ -63,13 +67,13 @@ def transform_urdf_to_macro(input_path, connector_link, no_prefix):
     if not no_prefix:
         macro_params.insert(0, "prefix")
 
-    macro = etree.Element(f"{{{XACRO_NS}}}macro")
+    macro = etree.Element("{}macro".format("{" + XACRO_NS + "}"))
     macro.set("name", robot_name)
     macro.set("params", " ".join(macro_params))
     xacro_root.append(macro)
 
     connector_joint = etree.Element("joint")
-    connector_joint_name = f"{'${prefix}' if not no_prefix else ''}{connector_link}_to_${{parent_link}}_joint"
+    connector_joint_name = "{}{}_to_${{parent_link}}_joint".format('${prefix}' if not no_prefix else '', connector_link)
     connector_joint.set("name", connector_joint_name)
     connector_joint.set("type", "fixed")
 
@@ -79,7 +83,7 @@ def transform_urdf_to_macro(input_path, connector_link, no_prefix):
     child_elem = etree.SubElement(connector_joint, "child")
     child_elem.set("link", add_prefix_to_name(connector_link) if not no_prefix else connector_link)
 
-    origin_block = etree.SubElement(connector_joint, f"{{{XACRO_NS}}}insert_block")
+    origin_block = etree.SubElement(connector_joint, "{}insert_block".format("{" + XACRO_NS + "}"))
     origin_block.set("name", "origin")
 
     macro.append(connector_joint)

--- a/skrobot/urdf/xml_root_link_changer.py
+++ b/skrobot/urdf/xml_root_link_changer.py
@@ -1,0 +1,334 @@
+import os
+import xml.etree.ElementTree as ET
+
+
+class URDFXMLRootLinkChanger:
+    """A class to change the root link of a URDF by directly manipulating XML.
+
+    This class reads URDF XML files and modifies the kinematic tree structure
+    to change the root link to any specified link, then writes the modified
+    URDF back to a file.
+    """
+
+    def __init__(self, urdf_path):
+        """Initialize the URDFXMLRootLinkChanger.
+
+        Parameters
+        ----------
+        urdf_path : str
+            Path to the input URDF file
+
+        Raises
+        ------
+        FileNotFoundError
+            If the URDF file does not exist
+        """
+        if not os.path.exists(urdf_path):
+            raise FileNotFoundError(
+                "URDF file not found: {}".format(urdf_path))
+
+        self.urdf_path = urdf_path
+        self.tree = ET.parse(urdf_path)
+        self.root = self.tree.getroot()
+
+        # Parse the URDF structure
+        self.links = self._parse_links()
+        self.joints = self._parse_joints()
+        self.joint_tree = self._build_joint_tree()
+
+    def _parse_links(self):
+        """Parse all links from the URDF.
+
+        Returns
+        -------
+        dict
+            Dictionary mapping link names to their XML elements
+        """
+        links = {}
+        for link in self.root.findall('link'):
+            name = link.get('name')
+            if name:
+                links[name] = link
+        return links
+
+    def _parse_joints(self):
+        """Parse all joints from the URDF.
+
+        Returns
+        -------
+        dict
+            Dictionary mapping joint names to their XML elements
+        """
+        joints = {}
+        for joint in self.root.findall('joint'):
+            name = joint.get('name')
+            if name:
+                joints[name] = joint
+        return joints
+
+    def _build_joint_tree(self):
+        """Build a tree structure representing parent-child relationships.
+
+        Returns
+        -------
+        dict
+            Dictionary with link names as keys and dictionaries containing
+            'parent', 'children', and 'joint' information
+        """
+        tree = {link_name: {'parent': None, 'children': [], 'joint': None}
+                for link_name in self.links.keys()}
+
+        for joint_name, joint in self.joints.items():
+            parent_elem = joint.find('parent')
+            child_elem = joint.find('child')
+
+            if parent_elem is not None and child_elem is not None:
+                parent_link = parent_elem.get('link')
+                child_link = child_elem.get('link')
+
+                if parent_link and child_link:
+                    if parent_link in tree and child_link in tree:
+                        tree[child_link]['parent'] = parent_link
+                        tree[child_link]['joint'] = joint_name
+                        tree[parent_link]['children'].append(child_link)
+
+        return tree
+
+    def get_current_root_link(self):
+        """Get the current root link name.
+
+        Returns
+        -------
+        str or None
+            Name of the current root link (link with no parent)
+        """
+        for link_name, info in self.joint_tree.items():
+            if info['parent'] is None:
+                return link_name
+        return None
+
+    def list_links(self):
+        """List all links in the URDF.
+
+        Returns
+        -------
+        list of str
+            List of all link names
+        """
+        return list(self.links.keys())
+
+    def change_root_link(self, new_root_link, output_path):
+        """Change the root link and save the modified URDF.
+
+        Parameters
+        ----------
+        new_root_link : str
+            Name of the new root link
+        output_path : str
+            Path where the modified URDF will be saved
+
+        Raises
+        ------
+        ValueError
+            If the specified link name is not found in the URDF
+        """
+        if new_root_link not in self.links:
+            raise ValueError(
+                "Link '{}' not found in URDF".format(new_root_link))
+
+        current_root = self.get_current_root_link()
+        if new_root_link == current_root:
+            # No change needed, just copy the file
+            self._save_urdf(output_path)
+            return
+
+        # Build path from current root to new root
+        path_to_new_root = self._find_path_to_link(current_root, new_root_link)
+        if not path_to_new_root:
+            raise ValueError(
+                "No path found from {} to {}".format(
+                    current_root, new_root_link))
+
+        # Reverse the joints along the path
+        self._reverse_joints_along_path(path_to_new_root)
+
+        # Save the modified URDF
+        self._save_urdf(output_path)
+
+    def _find_path_to_link(self, start_link, target_link):
+        """Find path from start_link to target_link.
+
+        Parameters
+        ----------
+        start_link : str
+            Starting link name
+        target_link : str
+            Target link name
+
+        Returns
+        -------
+        list of tuple
+            List of (parent_link, child_link, joint_name)
+            tuples representing the path
+        """
+        def dfs(current, target, path, visited):
+            if current == target:
+                return True
+
+            if current in visited:
+                return False
+
+            visited.add(current)
+
+            # Check children
+            for child in self.joint_tree[current]['children']:
+                joint_name = self.joint_tree[child]['joint']
+                path.append((current, child, joint_name))
+                if dfs(child, target, path, visited):
+                    return True
+                path.pop()
+
+            # Check parent
+            parent = self.joint_tree[current]['parent']
+            if parent and parent not in visited:
+                joint_name = self.joint_tree[current]['joint']
+                path.append((parent, current, joint_name))
+                if dfs(parent, target, path, visited):
+                    return True
+                path.pop()
+
+            visited.remove(current)
+            return False
+
+        path = []
+        visited = set()
+        if dfs(start_link, target_link, path, visited):
+            return path
+        return []
+
+    def _reverse_joints_along_path(self, path):
+        """Reverse joints along the given path.
+
+        Parameters
+        ----------
+        path : list of tuple
+            List of (parent_link, child_link, joint_name) tuples
+        """
+        for parent_link, child_link, joint_name in path:
+            if joint_name in self.joints:
+                joint = self.joints[joint_name]
+
+                # Swap parent and child
+                parent_elem = joint.find('parent')
+                child_elem = joint.find('child')
+
+                if parent_elem is not None and child_elem is not None:
+                    # Swap the link attributes
+                    parent_elem.set('link', child_link)
+                    child_elem.set('link', parent_link)
+
+                    # Update our internal tree structure
+                    self.joint_tree[parent_link]['parent'] = child_link
+                    self.joint_tree[child_link]['parent'] = None
+
+                    if parent_link in self.joint_tree[child_link]['children']:
+                        self.joint_tree[child_link]['children'].remove(
+                            parent_link)
+                    if child_link in self.joint_tree[parent_link]['children']:
+                        self.joint_tree[parent_link]['children'].remove(child_link)
+                    self.joint_tree[parent_link]['children'].append(child_link)
+                    self.joint_tree[child_link]['children'].append(parent_link)
+
+                    self.joint_tree[parent_link]['joint'] = joint_name
+                    self.joint_tree[child_link]['joint'] = None
+
+                    # Reverse the joint transformation if needed
+                    self._reverse_joint_transform(joint)
+
+    def _reverse_joint_transform(self, joint):
+        """Reverse the transformation of a joint.
+
+        Parameters
+        ----------
+        joint : ET.Element
+            Joint XML element to reverse
+        """
+        # Find the origin element
+        origin = joint.find('origin')
+        if origin is not None:
+            # Get current xyz and rpy
+            xyz_str = origin.get('xyz', '0 0 0')
+            rpy_str = origin.get('rpy', '0 0 0')
+
+            # Parse the values
+            xyz = [float(x) for x in xyz_str.split()]
+            rpy = [float(x) for x in rpy_str.split()]
+
+            # For simplicity, we negate the translation and rotation
+            # In a full implementation, you would need proper matrix inversion
+            xyz_reversed = [-x for x in xyz]
+            rpy_reversed = [-r for r in rpy]
+
+            # Set the reversed values
+            origin.set('xyz', ' '.join(map(str, xyz_reversed)))
+            origin.set('rpy', ' '.join(map(str, rpy_reversed)))
+
+    def _save_urdf(self, output_path):
+        """Save the modified URDF to a file.
+
+        Parameters
+        ----------
+        output_path : str
+            Path where the URDF will be saved
+        """
+        # Create output directory if it doesn't exist
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+        # Write the XML tree to file
+        self.tree.write(output_path, encoding='utf-8', xml_declaration=True)
+
+        # Format the output for better readability
+        self._format_xml_file(output_path)
+
+    def _format_xml_file(self, file_path):
+        """Format XML file for better readability.
+
+        Parameters
+        ----------
+        file_path : str
+            Path to the XML file to format
+        """
+        try:
+            import xml.dom.minidom
+
+            # Parse and format
+            dom = xml.dom.minidom.parse(file_path)
+            formatted_xml = dom.toprettyxml(indent="  ")
+
+            # Remove empty lines
+            lines = [line for line in formatted_xml.split('\n')
+                     if line.strip()]
+            formatted_xml = '\n'.join(lines)
+
+            # Write back
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write(formatted_xml)
+        except ImportError:
+            # If minidom is not available, keep the original formatting
+            pass
+
+
+def change_urdf_root_link(urdf_path, new_root_link, output_path):
+    """Change the root link of a URDF file.
+
+    Parameters
+    ----------
+    urdf_path : str
+        Path to the input URDF file
+    new_root_link : str
+        Name of the new root link
+    output_path : str
+        Path where the modified URDF will be saved
+    """
+    changer = URDFXMLRootLinkChanger(urdf_path)
+    changer.change_root_link(new_root_link, output_path)

--- a/tests/skrobot_tests/test_console_scripts.py
+++ b/tests/skrobot_tests/test_console_scripts.py
@@ -8,6 +8,8 @@ import unittest
 import pytest
 
 from skrobot.data import fetch_urdfpath
+from skrobot.data import kuka_urdfpath
+from skrobot.urdf import URDFXMLRootLinkChanger
 
 
 class TestConsoleScripts(unittest.TestCase):
@@ -66,3 +68,140 @@ class TestConsoleScripts(unittest.TestCase):
                             code, stdout, stderr)
                     )
                 self.fail("\n\n".join(messages))
+
+    @pytest.mark.skipif(
+        sys.version_info[0] == 2 or sys.version_info[:2] == (3, 6),
+        reason="Skip in Python 2 and Python 3.6")
+    def test_change_urdf_root(self):
+        """Test change-urdf-root command line script."""
+        urdf_path = kuka_urdfpath()
+
+        # Get available links for testing
+        changer = URDFXMLRootLinkChanger(urdf_path)
+        available_links = changer.list_links()
+        current_root = changer.get_current_root_link()
+
+        # Find a different link to use as new root
+        new_root = None
+        for link in available_links:
+            if link != current_root:
+                new_root = link
+                break
+
+        with tempfile.TemporaryDirectory() as tmp_output:
+            def _run_command(args):
+                cmd = [sys.executable, '-m',
+                       'skrobot.apps.change_urdf_root'] + args
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    cwd=os.path.dirname(urdf_path)
+                )
+                return result.returncode, result.stdout, result.stderr
+
+            # Test --list option
+            returncode, stdout, stderr = _run_command([urdf_path, '--list'])
+            self.assertEqual(returncode, 0)
+            self.assertIn('Current root link:', stdout)
+            self.assertIn('Total links:', stdout)
+            self.assertIn('All links:', stdout)
+            self.assertIn('(current root)', stdout)
+            for link in available_links:
+                self.assertIn(link, stdout)
+
+            # Test --help option
+            returncode, stdout, stderr = _run_command(['--help'])
+            self.assertEqual(returncode, 0)
+            self.assertIn('Change the root link of a URDF file', stdout)
+            self.assertIn('Examples:', stdout)
+            self.assertIn('change_urdf_root', stdout)
+
+            # Test missing input file
+            returncode, stdout, stderr = _run_command([
+                'non_existent_file.urdf', 'some_link', 'output.urdf'
+            ])
+            self.assertNotEqual(returncode, 0)
+            self.assertIn('not found', stderr)
+
+            # Test missing required arguments
+            returncode, stdout, stderr = _run_command([urdf_path])
+            self.assertNotEqual(returncode, 0)
+            self.assertIn('new_root_link is required', stderr)
+
+            # Test invalid link name
+            output_path = os.path.join(tmp_output, 'invalid_test.urdf')
+            returncode, stdout, stderr = _run_command([
+                urdf_path, 'non_existent_link', output_path
+            ])
+            self.assertNotEqual(returncode, 0)
+            self.assertIn('not found in URDF', stderr)
+            self.assertIn('Available links:', stderr)
+
+            # Test successful root change (if we have alternative links)
+            if new_root is not None:
+                output_path = os.path.join(tmp_output, 'changed_root.urdf')
+                returncode, stdout, stderr = _run_command([
+                    urdf_path, new_root, output_path
+                ])
+                self.assertEqual(returncode, 0)
+                self.assertIn('Successfully changed root link', stdout)
+                self.assertIn("from '{}' to '{}'".format(
+                    current_root, new_root), stdout)
+
+                # Verify the output file exists
+                self.assertTrue(os.path.exists(output_path))
+
+                # Verify the change by loading the result
+                result_changer = URDFXMLRootLinkChanger(output_path)
+                actual_root = result_changer.get_current_root_link()
+                self.assertEqual(actual_root, new_root)
+
+                # Test verbose option
+                output_path2 = os.path.join(tmp_output, 'verbose_test.urdf')
+                returncode, stdout, stderr = _run_command([
+                    urdf_path, new_root, output_path2, '--verbose'
+                ])
+                self.assertEqual(returncode, 0)
+                self.assertIn('Loading URDF:', stdout)
+                self.assertIn('Current root link:', stdout)
+                self.assertIn('New root link:', stdout)
+                self.assertIn('Output file:', stdout)
+                self.assertIn('Changing root link...', stdout)
+                self.assertIn('Verifying result...', stdout)
+
+                # Test force overwrite option
+                output_path3 = os.path.join(tmp_output, 'force_test.urdf')
+
+                # Create a dummy file first
+                with open(output_path3, 'w') as f:
+                    f.write('dummy content')
+
+                # Without --force, should fail
+                returncode, stdout, stderr = _run_command([
+                    urdf_path, new_root, output_path3
+                ])
+                self.assertNotEqual(returncode, 0)
+                self.assertIn('already exists', stderr)
+
+                # With --force, should succeed
+                returncode, stdout, stderr = _run_command([
+                    urdf_path, new_root, output_path3, '--force'
+                ])
+                self.assertEqual(returncode, 0)
+                self.assertIn('Successfully changed root link', stdout)
+
+            # Test changing to the same root link
+            output_path4 = os.path.join(tmp_output, 'same_root.urdf')
+            returncode, stdout, stderr = _run_command([
+                urdf_path, current_root, output_path4, '--verbose'
+            ])
+            self.assertEqual(returncode, 0)
+            self.assertIn('same as current root link', stdout)
+            self.assertIn('Successfully changed root link', stdout)
+
+            # Verify the output file exists and has correct root
+            self.assertTrue(os.path.exists(output_path4))
+            result_changer = URDFXMLRootLinkChanger(output_path4)
+            actual_root = result_changer.get_current_root_link()
+            self.assertEqual(actual_root, current_root)

--- a/tests/skrobot_tests/urdf_tests/test_xml_root_link_changer.py
+++ b/tests/skrobot_tests/urdf_tests/test_xml_root_link_changer.py
@@ -1,0 +1,113 @@
+"""Test for XML-based URDF root link changer."""
+
+import os
+import sys
+import tempfile
+import unittest
+
+import pytest
+
+from skrobot.data import kuka_urdfpath
+from skrobot.urdf import URDFXMLRootLinkChanger
+
+
+@pytest.mark.skipif(
+    sys.version_info[0] == 2 or sys.version_info[:2] == (3, 6),
+    reason="Skip in Python 2 and Python 3.6")
+class TestURDFXMLRootLinkChanger(unittest.TestCase):
+
+    def setUp(self):
+        self.urdf_path = kuka_urdfpath()
+        self.changer = URDFXMLRootLinkChanger(self.urdf_path)
+
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_init_with_valid_urdf_path(self):
+        changer = URDFXMLRootLinkChanger(self.urdf_path)
+        self.assertIsNotNone(changer.tree)
+        self.assertIsNotNone(changer.root)
+        self.assertIsInstance(changer.links, dict)
+        self.assertIsInstance(changer.joints, dict)
+        self.assertIsInstance(changer.joint_tree, dict)
+
+    def test_init_with_invalid_urdf_path(self):
+        with self.assertRaises(FileNotFoundError):
+            URDFXMLRootLinkChanger("non_existent_file.urdf")
+
+    def test_list_links(self):
+        links = self.changer.list_links()
+        self.assertIsInstance(links, list)
+        self.assertGreater(len(links), 0)
+
+        for link in links:
+            self.assertIsInstance(link, str)
+
+    def test_get_current_root_link(self):
+        root_link = self.changer.get_current_root_link()
+        self.assertIsInstance(root_link, str)
+        self.assertIn(root_link, self.changer.list_links())
+
+    def test_change_root_link_invalid_name(self):
+        output_path = os.path.join(self.temp_dir, "test_invalid.urdf")
+        with self.assertRaises(ValueError):
+            self.changer.change_root_link("non_existent_link", output_path)
+
+    def test_change_root_link_valid_name(self):
+        links = self.changer.list_links()
+        if len(links) > 1:
+            current_root = self.changer.get_current_root_link()
+            new_root_candidates = [link for link in links
+                                   if link != current_root]
+
+            if new_root_candidates:
+                new_root = new_root_candidates[0]
+                output_path = os.path.join(self.temp_dir, "test_changed.urdf")
+
+                self.changer.change_root_link(new_root, output_path)
+
+                self.assertTrue(os.path.exists(output_path))
+
+                new_changer = URDFXMLRootLinkChanger(output_path)
+                actual_new_root = new_changer.get_current_root_link()
+                self.assertEqual(actual_new_root, new_root)
+
+    def test_change_root_link_same_as_current(self):
+        current_root = self.changer.get_current_root_link()
+        output_path = os.path.join(self.temp_dir, "test_same.urdf")
+
+        self.changer.change_root_link(current_root, output_path)
+
+        self.assertTrue(os.path.exists(output_path))
+
+        new_changer = URDFXMLRootLinkChanger(output_path)
+        actual_root = new_changer.get_current_root_link()
+        self.assertEqual(actual_root, current_root)
+
+    def test_find_path_to_link(self):
+        current_root = self.changer.get_current_root_link()
+        links = self.changer.list_links()
+
+        if len(links) > 1:
+            target_link = None
+            for link in links:
+                if link != current_root:
+                    target_link = link
+                    break
+
+            if target_link:
+                path = self.changer._find_path_to_link(
+                    current_root, target_link)
+                self.assertIsInstance(path, list)
+                # Path should contain tuples of (parent, child, joint)
+                for item in path:
+                    self.assertIsInstance(item, tuple)
+                    self.assertEqual(len(item), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
We use Xacro to connect modular robots. However, since URDF is based on a tree structure, we sometimes need to change the connections between intermediate links. This PR provides the functionality to change the root link to any arbitrary link.

```
from skrobot.urdf import change_urdf_root_link
import os.path as osp
change_urdf_root_link(urdf_path=osp.expanduser('~/.skrobot/pr2_description/pr2.urdf'), new_root_link='l_forearm_link', output_path=osp.expanduser('~/.skrobot/pr2_description/pr2_l_forearm_root.urdf'))
```