### PR TITLE
Fixed a bug where the joint rotation axes would become incorrect when changing the root link.

### DIFF
--- a/skrobot/urdf/xml_root_link_changer.py
+++ b/skrobot/urdf/xml_root_link_changer.py
@@ -1,8 +1,7 @@
 import os
 import xml.etree.ElementTree as ET
-
-from skrobot.coordinates import Coordinates
-from skrobot.coordinates.math import rpy2quaternion
+import numpy as np
+from scipy.spatial.transform import Rotation as R
 
 
 class URDFXMLRootLinkChanger:
@@ -146,7 +145,9 @@ class URDFXMLRootLinkChanger:
             return
 
         # Build path from current root to new root
-        path_to_new_root = self._find_path_to_link(current_root, new_root_link)
+        # path_to_new_root = self._find_path_to_link(current_root, new_root_link)
+        # Build path from new root to current root
+        path_to_new_root = self._find_path_to_link(new_root_link, current_root)
         if not path_to_new_root:
             raise ValueError(
                 "No path found from {} to {}".format(
@@ -208,7 +209,7 @@ class URDFXMLRootLinkChanger:
         if dfs(start_link, target_link, path, visited):
             return path
         return []
-
+        
     def _reverse_joints_along_path(self, path):
         """Reverse joints along the given path.
 
@@ -217,6 +218,25 @@ class URDFXMLRootLinkChanger:
         path : list of tuple
             List of (parent_link, child_link, joint_name) tuples
         """
+
+        # Cache origin/xyz,rpy values of each joint
+        joint_xyz_rpy_cache = {}
+        for parent_link, child_link, joint_name in path:
+            if joint_name in self.joints:
+                joint = self.joints[joint_name]
+                origin = joint.find('origin')
+
+                # Get current xyz and rpy
+                xyz_str = origin.get('xyz', '0 0 0')
+                rpy_str = origin.get('rpy', '0 0 0')
+
+                # Parse the values
+                xyz = [float(x) for x in xyz_str.split()]
+                rpy = [float(x) for x in rpy_str.split()]
+
+                joint_xyz_rpy_cache[joint] = [xyz, rpy]
+
+        prev_joint = None
         for parent_link, child_link, joint_name in path:
             if joint_name in self.joints:
                 joint = self.joints[joint_name]
@@ -246,10 +266,39 @@ class URDFXMLRootLinkChanger:
                     self.joint_tree[child_link]['joint'] = None
 
                     # Reverse the joint transformation if needed
-                    joint_transform = self._reverse_joint_transform(joint)
-                    
-                    # Update the child link's visual/collision origins
-                    self._update_link_origins(child_link, joint_transform)
+                    prev_joint_xyz = None
+                    prev_joint_rpy = None
+                    if prev_joint is not None:
+                        prev_joint_xyz = joint_xyz_rpy_cache[prev_joint][0]
+                        prev_joint_rpy = joint_xyz_rpy_cache[prev_joint][1]
+                    self._reverse_joint_transform_2(joint, prev_joint_xyz, prev_joint_rpy)
+                    prev_joint = joint
+
+    def _get_inversed_joint_origin(self, xyz, rpy):
+        if xyz is not None and rpy is not None:
+            # Calculate inversed transform of origin
+            rot = R.from_euler('xyz', rpy)
+            rot_matrix = rot.as_matrix()
+            rot_matrix_inv = rot_matrix.T
+            xyz_reversed = -np.dot(rot_matrix_inv, xyz)
+            rpy_reversed = R.from_matrix(rot_matrix_inv).as_euler('xyz')
+            xyz_reversed.tolist()
+            rpy_reversed.tolist()
+
+            return xyz_reversed, rpy_reversed
+
+    # prev_joint is None: child of this joint is new root link
+    def _reverse_joint_transform_2(self, joint, prev_joint_xyz, prev_joint_rpy):
+        origin = joint.find('origin')
+        if prev_joint_xyz is None and prev_joint_rpy is None:
+            # Set origin of this joint to Zero
+            origin.set('xyz', ' '.join(map(str, [0, 0, 0])))
+            origin.set('rpy', ' '.join(map(str, [0, 0, 0])))
+        else:
+            # Set the reversed values of previous joint
+            xyz_reversed, rpy_reversed = self._get_inversed_joint_origin(prev_joint_xyz, prev_joint_rpy)
+            origin.set('xyz', ' '.join(map(str, xyz_reversed)))
+            origin.set('rpy', ' '.join(map(str, rpy_reversed)))
 
     def _reverse_joint_transform(self, joint):
         """Reverse the transformation of a joint.
@@ -258,16 +307,9 @@ class URDFXMLRootLinkChanger:
         ----------
         joint : ET.Element
             Joint XML element to reverse
-            
-        Returns
-        -------
-        original_transform : skrobot.coordinates.Coordinates
-            The original transformation before reversal (for updating link origins)
         """
         # Find the origin element
         origin = joint.find('origin')
-        original_transform = None
-        
         if origin is not None:
             # Get current xyz and rpy
             xyz_str = origin.get('xyz', '0 0 0')
@@ -277,87 +319,24 @@ class URDFXMLRootLinkChanger:
             xyz = [float(x) for x in xyz_str.split()]
             rpy = [float(x) for x in rpy_str.split()]
 
-            yaw_pitch_roll = rpy[::-1]
-            quaternion_wxyz = rpy2quaternion(yaw_pitch_roll)
-            original_transform = Coordinates(pos=xyz, rot=quaternion_wxyz)
-            
-            # Calculate inverse transformation
-            inverse_transform = original_transform.inverse_transformation()
-            xyz_reversed = inverse_transform.translation.tolist()
-            rpy_reversed = inverse_transform.rpy_angle()[0][::-1].tolist()
+            # For simplicity, we negate the translation and rotation
+            # In a full implementation, you would need proper matrix inversion
+            # xyz_reversed = [-x for x in xyz]
+            # rpy_reversed = [-r for r in rpy]
+
+            # ============
+            rot = R.from_euler('xyz', rpy)
+            rot_matrix = rot.as_matrix()
+            rot_matrix_inv = rot_matrix.T
+            xyz_reversed = -np.dot(rot_matrix_inv, xyz)
+            rpy_reversed = R.from_matrix(rot_matrix_inv).as_euler('xyz')
+            xyz_reversed.tolist()
+            rpy_reversed.tolist()
+            # ============
 
             # Set the reversed values
             origin.set('xyz', ' '.join(map(str, xyz_reversed)))
             origin.set('rpy', ' '.join(map(str, rpy_reversed)))
-            
-        return original_transform
-
-    def _update_link_origins(self, link_name, joint_transform):
-        """Update visual and collision origins for a link whose coordinate frame changed.
-        
-        When a joint is reversed, the child link's coordinate frame changes.
-        The visual and collision origins need to be transformed by the inverse
-        of the original joint transformation to maintain correct geometry.
-        
-        Parameters
-        ----------
-        link_name : str
-            Name of the link to update
-        joint_transform : skrobot.coordinates.Coordinates
-            The original joint transformation before reversal
-        """
-        if joint_transform is None or link_name not in self.links:
-            return
-            
-        link = self.links[link_name]
-        inverse_transform = joint_transform.inverse_transformation()
-        
-        # Update visual origins
-        for visual in link.findall('visual'):
-            self._transform_origin_element(visual, inverse_transform)
-            
-        # Update collision origins  
-        for collision in link.findall('collision'):
-            self._transform_origin_element(collision, inverse_transform)
-    
-    def _transform_origin_element(self, element, transform):
-        """Transform an origin element by the given transformation.
-        
-        Parameters
-        ----------
-        element : ET.Element
-            Element containing origin (visual or collision)
-        transform : skrobot.coordinates.Coordinates
-            Transformation to apply
-        """
-        origin = element.find('origin')
-        if origin is None:
-            # Create origin element if it doesn't exist (default is identity)
-            origin = ET.SubElement(element, 'origin')
-            origin.set('xyz', '0 0 0')
-            origin.set('rpy', '0 0 0')
-        
-        # Get current origin transformation
-        xyz_str = origin.get('xyz', '0 0 0')
-        rpy_str = origin.get('rpy', '0 0 0')
-        
-        xyz = [float(x) for x in xyz_str.split()]
-        rpy = [float(x) for x in rpy_str.split()]
-        
-        # Create coordinates for current origin
-        yaw_pitch_roll = rpy[::-1]
-        quaternion_wxyz = rpy2quaternion(yaw_pitch_roll)
-        current_origin = Coordinates(pos=xyz, rot=quaternion_wxyz)
-        
-        # Apply the transformation
-        transformed_origin = transform.transform(current_origin)
-        
-        # Update the origin element
-        new_xyz = transformed_origin.translation.tolist()
-        new_rpy = transformed_origin.rpy_angle()[0][::-1].tolist()
-        
-        origin.set('xyz', ' '.join(map(str, new_xyz)))
-        origin.set('rpy', ' '.join(map(str, new_rpy)))
 
     def _save_urdf(self, output_path):
         """Save the modified URDF to a file.

--- a/skrobot/urdf/xml_root_link_changer.py
+++ b/skrobot/urdf/xml_root_link_changer.py
@@ -269,7 +269,7 @@ class URDFXMLRootLinkChanger:
                     if prev_joint is not None:
                         prev_joint_xyz = joint_xyz_rpy_cache[prev_joint][0]
                         prev_joint_rpy = joint_xyz_rpy_cache[prev_joint][1]
-                    self._reverse_joint_transform_2(joint, prev_joint_xyz, prev_joint_rpy, path)
+                    self._reverse_joint_transform(joint, prev_joint_xyz, prev_joint_rpy, path)
                     prev_joint = joint
 
     def _get_inversed_joint_origin(self, xyz, rpy):
@@ -285,7 +285,7 @@ class URDFXMLRootLinkChanger:
             return xyz_reversed, rpy_reversed
 
     # When the prev_joint_xyz and rpy is None, the child of this joint is the new root link
-    def _reverse_joint_transform_2(self, joint, prev_joint_xyz, prev_joint_rpy, path_to_current_root):
+    def _reverse_joint_transform(self, joint, prev_joint_xyz, prev_joint_rpy, path_to_current_root):
         origin = joint.find('origin')
 
         # Cache current xyz and rpy
@@ -401,44 +401,6 @@ class URDFXMLRootLinkChanger:
             if joint_name == target_joint_name:
                 return True
         return False
-
-    def _reverse_joint_transform(self, joint):
-        """Reverse the transformation of a joint.
-
-        Parameters
-        ----------
-        joint : ET.Element
-            Joint XML element to reverse
-        """
-        # Find the origin element
-        origin = joint.find('origin')
-        if origin is not None:
-            # Get current xyz and rpy
-            xyz_str = origin.get('xyz', '0 0 0')
-            rpy_str = origin.get('rpy', '0 0 0')
-
-            # Parse the values
-            xyz = [float(x) for x in xyz_str.split()]
-            rpy = [float(x) for x in rpy_str.split()]
-
-            # For simplicity, we negate the translation and rotation
-            # In a full implementation, you would need proper matrix inversion
-            # xyz_reversed = [-x for x in xyz]
-            # rpy_reversed = [-r for r in rpy]
-
-            # ============
-            rot = R.from_euler('xyz', rpy)
-            rot_matrix = rot.as_matrix()
-            rot_matrix_inv = rot_matrix.T
-            xyz_reversed = -np.dot(rot_matrix_inv, xyz)
-            rpy_reversed = R.from_matrix(rot_matrix_inv).as_euler('xyz')
-            xyz_reversed.tolist()
-            rpy_reversed.tolist()
-            # ============
-
-            # Set the reversed values
-            origin.set('xyz', ' '.join(map(str, xyz_reversed)))
-            origin.set('rpy', ' '.join(map(str, rpy_reversed)))
 
     def _save_urdf(self, output_path):
         """Save the modified URDF to a file.


### PR DESCRIPTION
Fixed a bug in the ```change-urdf-root``` command where the positions of joint rotation axes between the original root link and the new root link became misaligned after changing the root.

Additionally, the orientation of the rotation axes, as well as the origins of visual and collision elements, are now correctly updated.