### PR TITLE
Fixed xacro namespace loss when applying change-urdf-root to xacro file with macro

### DIFF
--- a/skrobot/urdf/xml_root_link_changer.py
+++ b/skrobot/urdf/xml_root_link_changer.py
@@ -36,6 +36,8 @@ class URDFXMLRootLinkChanger:
         self.tree = ET.parse(urdf_path)
         self.root = self.tree.getroot()
 
+        ET.register_namespace('xacro', "http://ros.org/wiki/xacro")
+
         # Parse the URDF structure
         self.links = self._parse_links()
         self.joints = self._parse_joints()


### PR DESCRIPTION
Fixed a bug where the xacro namespace would be lost when running the change-urdf-root command on a Xacro file containing macros, by explicitly adding the xacro namespace.