### PR TITLE
Add texture-preserving mesh decimation functionality

### DIFF
--- a/skrobot/apps/convert_urdf_mesh.py
+++ b/skrobot/apps/convert_urdf_mesh.py
@@ -51,6 +51,12 @@ resulting in less simplification. Default is None."""
         'it is used as the voxel size in the function to perform '
         'mesh simplification. This process reduces the complexity'
         ' of the mesh by clustering vertices within the specified voxel size.')
+    parser.add_argument(
+        '--target-triangles', type=int, default=None,
+        help='Target number of triangles for texture-preserving decimation. '
+        'When specified, uses enhanced decimation that preserves texture '
+        'colors by converting them to vertex colors, performing decimation, '
+        'and converting back to texture format. Default is None.')
 
     args = parser.parse_args()
 
@@ -60,14 +66,14 @@ resulting in less simplification. Default is None."""
             '[WARNING] With `trimesh` < 4.0.10, the output dae is not '
             + 'colored. Please `pip install trimesh -U`')
         sys.exit(1)
-    if args.decimation_area_ratio_threshold:
+    if args.decimation_area_ratio_threshold or args.target_triangles:
         disable_decimation = False
         if is_package_installed('open3d') is False:
             print("[ERROR] open3d is not installed. "
                   + "Please install it as 'pip install scikit-robot[all]' "
                   + "to include open3d or 'pip install open3d'")
             disable_decimation = True
-        if is_package_installed('fast-simplification') is False:
+        if args.decimation_area_ratio_threshold and is_package_installed('fast-simplification') is False:
             print("[ERROR] fast-simplification is not installed. "
                   + "Please install it with 'pip install fast-simplification'")
             disable_decimation = True
@@ -108,6 +114,7 @@ resulting in less simplification. Default is None."""
             '.' + args.format,
             decimation_area_ratio_threshold=args.decimation_area_ratio_threshold,  # NOQA
             simplify_vertex_clustering_voxel_size=args.voxel_size,
+            target_triangles=args.target_triangles,
             overwrite_mesh=args.overwrite_mesh):
         r.urdf_robot_model.save(str(base_path / output_path))
 

--- a/skrobot/utils/mesh.py
+++ b/skrobot/utils/mesh.py
@@ -35,6 +35,171 @@ def split_mesh_by_face_color(mesh):
     return submeshes
 
 
+def create_vertex_colors_from_texture(mesh, verbose=False):
+    """Create vertex colors from texture information.
+
+    Parameters
+    ----------
+    mesh : trimesh.Trimesh
+        Mesh with texture information.
+    verbose : bool, optional
+        Whether to print progress information.
+
+    Returns
+    -------
+    numpy.ndarray
+        Vertex colors as (n_vertices, 3) array.
+    """
+    vertex_colors = np.zeros((len(mesh.vertices), 3), dtype=np.float64)
+
+    if verbose:
+        print("Creating vertex colors, please wait...")
+
+    # Check if mesh has texture information
+    if not (hasattr(mesh, 'visual') and mesh.visual.kind == 'texture'):
+        if verbose:
+            print("No texture information found, using default colors")
+        return np.ones((len(mesh.vertices), 3)) * 0.5
+
+    # Get texture image and UV coordinates
+    texture_image = None
+    uv_coords = None
+
+    if hasattr(mesh.visual, 'material') and mesh.visual.material is not None:
+        if hasattr(mesh.visual.material, 'image') and mesh.visual.material.image is not None:
+            texture_image = mesh.visual.material.image
+        elif (hasattr(mesh.visual.material, 'baseColorTexture') and
+              mesh.visual.material.baseColorTexture is not None and
+              hasattr(mesh.visual.material.baseColorTexture, 'image')):
+            texture_image = mesh.visual.material.baseColorTexture.image
+
+    if hasattr(mesh.visual, 'uv') and mesh.visual.uv is not None:
+        uv_coords = mesh.visual.uv
+
+    if texture_image is None:
+        if verbose:
+            print("No texture image found, using material colors")
+        # Try to use material main color if available
+        if (hasattr(mesh.visual, 'material') and
+            mesh.visual.material is not None and
+            hasattr(mesh.visual.material, 'main_color')):
+            main_color = np.array(mesh.visual.material.main_color[:3]) / 255.0
+            return np.tile(main_color, (len(mesh.vertices), 1))
+        else:
+            return np.ones((len(mesh.vertices), 3)) * 0.5
+
+    if uv_coords is None:
+        if verbose:
+            print("No UV coordinates found, using default colors")
+        return np.ones((len(mesh.vertices), 3)) * 0.5
+
+    # Convert texture image to numpy array
+    texture_np = np.array(texture_image)
+    if len(texture_np.shape) == 2:
+        # Grayscale image, convert to RGB
+        texture_np = np.stack([texture_np] * 3, axis=-1)
+    height, width = texture_np.shape[:2]
+
+    # UV coordinates are per triangle vertex, so we have 3 * num_faces UV coordinates
+    num_triangles = len(mesh.faces)
+    progress_step = max(1, num_triangles // 100)
+
+    for triangle_index in range(num_triangles):
+        # Process each vertex of the triangle
+        for local_vertex in range(3):
+            uv_index = triangle_index * 3 + local_vertex
+            if uv_index >= len(uv_coords):
+                continue
+
+            u, v = uv_coords[uv_index]
+            # Clamp UV coordinates to [0, 1] range
+            u = max(0, min(1, u))
+            v = max(0, min(1, v))
+
+            # Convert UV to pixel coordinates
+            x = int(u * (width - 1))
+            y = int(v * (height - 1))
+
+            # Get the global vertex index
+            global_vertex_index = mesh.faces[triangle_index][local_vertex]
+
+            # Sample the texture at this UV coordinate
+            vertex_colors[global_vertex_index] = texture_np[y, x][:3] / 255.0
+
+        if verbose and (triangle_index % progress_step) == 0:
+            print('#', end='', flush=True)
+
+    if verbose:
+        print()
+
+    return vertex_colors
+
+
+def create_texture_from_vertex_colors(mesh):
+    """Create texture from vertex colors.
+
+    Parameters
+    ----------
+    mesh : trimesh.Trimesh
+        Mesh with vertex colors.
+
+    Returns
+    -------
+    trimesh.Trimesh
+        Mesh with texture created from vertex colors.
+    """
+    # Get vertex colors
+    if hasattr(mesh.visual, 'vertex_colors'):
+        vertex_colors = np.asarray(mesh.visual.vertex_colors)[:, :3] / 255.0
+    else:
+        # Use default colors if no vertex colors
+        vertex_colors = np.ones((len(mesh.vertices), 3)) * 0.5
+
+    # Calculate texture dimension to hold all triangle vertex colors
+    texture_dimension = int(np.ceil(np.sqrt(len(mesh.faces) * 3)))
+
+    # Create texture array
+    texture = np.full((texture_dimension, texture_dimension, 3), 0, dtype=np.uint8)
+    triangle_uvs = np.full((len(mesh.faces) * 3, 2), 0, dtype=np.float32)
+
+    # Fill texture with vertex colors
+    for triangle_index, triangle in enumerate(mesh.faces):
+        for vertex_sub_index in range(3):
+            UV_index = 3 * triangle_index + vertex_sub_index
+            U = UV_index % texture_dimension
+            V = UV_index // texture_dimension
+
+            # Store vertex color in texture
+            color = vertex_colors[triangle[vertex_sub_index]]
+            texture[V, U] = (color * 255).astype(np.uint8)
+
+            # Set UV coordinates
+            triangle_uvs[UV_index] = [
+                (U + 0.5) / texture_dimension,
+                (V + 0.5) / texture_dimension
+            ]
+
+    # Create new mesh with same geometry
+    result_mesh = trimesh.Trimesh(vertices=mesh.vertices, faces=mesh.faces)
+
+    # Create PIL Image from texture
+    from PIL import Image
+    texture_img = Image.fromarray(texture, mode='RGB')
+
+    # Create material with texture
+    material = trimesh.visual.material.PBRMaterial(
+        baseColorTexture=texture_img
+    )
+
+    # Create texture visual
+    result_mesh.visual = trimesh.visual.TextureVisuals(
+        uv=triangle_uvs,
+        material=material
+    )
+
+    return result_mesh
+
+
 def to_open3d(mesh):
     import open3d
     o3d_mesh = open3d.geometry.TriangleMesh()
@@ -55,8 +220,94 @@ def simplify_vertex_clustering(
     simplify_meshes = []
     for mesh in meshes:
         if mesh.visual.kind == 'texture':
-            simplify_meshes.append(mesh)
+            # Check if mesh has actual texture images (not just material colors)
+            has_actual_texture = False
+            if (hasattr(mesh.visual, 'material') and
+                mesh.visual.material is not None):
+                if (hasattr(mesh.visual.material, 'baseColorTexture') and
+                    mesh.visual.material.baseColorTexture is not None):
+                    has_actual_texture = True
+                elif (hasattr(mesh.visual.material, 'image') and
+                      mesh.visual.material.image is not None):
+                    has_actual_texture = True
+
+            # For meshes with only material colors, use Open3D directly
+            if not has_actual_texture:
+                import open3d as o3d
+
+                # Get material color directly
+                material_color = mesh.visual.material.main_color[:3]  # RGB only
+
+                # Convert to Open3D directly
+                o3d_mesh = o3d.geometry.TriangleMesh()
+                o3d_mesh.vertices = o3d.utility.Vector3dVector(mesh.vertices)
+                o3d_mesh.triangles = o3d.utility.Vector3iVector(mesh.faces)
+
+                # Set vertex colors directly in Open3D (normalized)
+                vertex_colors_normalized = np.tile(material_color / 255.0, (len(mesh.vertices), 1))
+                o3d_mesh.vertex_colors = o3d.utility.Vector3dVector(vertex_colors_normalized)
+
+                # Use Open3D clustering
+                simple = o3d_mesh.simplify_vertex_clustering(simplify_vertex_clustering_voxel_size)
+
+                # Convert back to trimesh with vertex colors in constructor
+                if simple.has_vertex_colors():
+                    vertex_colors_back = np.asarray(simple.vertex_colors)
+                    vertex_colors_rgba = np.column_stack([
+                        (vertex_colors_back * 255).astype(np.uint8),
+                        np.full(len(vertex_colors_back), 255, dtype=np.uint8)
+                    ])
+
+                    # Use constructor with vertex_colors to preserve exact colors
+                    simplified_mesh = trimesh.Trimesh(
+                        vertices=np.asarray(simple.vertices),
+                        faces=np.asarray(simple.triangles),
+                        vertex_colors=vertex_colors_rgba
+                    )
+                else:
+                    simplified_mesh = trimesh.Trimesh(
+                        vertices=np.asarray(simple.vertices),
+                        faces=np.asarray(simple.triangles)
+                    )
+
+                simplify_meshes.append(simplified_mesh)
+                continue
+
+            # For actual texture meshes, use texture preservation
+            import open3d as o3d
+
+            # Convert texture to vertex colors
+            vertex_colors = create_vertex_colors_from_texture(mesh, verbose=False)
+
+            # Convert to open3d
+            o3d_mesh = o3d.geometry.TriangleMesh()
+            o3d_mesh.vertices = o3d.utility.Vector3dVector(mesh.vertices)
+            o3d_mesh.triangles = o3d.utility.Vector3iVector(mesh.faces)
+            o3d_mesh.vertex_colors = o3d.utility.Vector3dVector(vertex_colors)
+
+            # Perform vertex clustering
+            simplified_o3d_mesh = o3d_mesh.simplify_vertex_clustering(
+                simplify_vertex_clustering_voxel_size)
+
+            # Convert back to trimesh
+            vertices = np.asarray(simplified_o3d_mesh.vertices)
+            faces = np.asarray(simplified_o3d_mesh.triangles)
+            simplified_mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+
+            # Set vertex colors
+            if simplified_o3d_mesh.has_vertex_colors():
+                vertex_colors_simplified = np.asarray(simplified_o3d_mesh.vertex_colors)
+                vertex_colors_rgba = np.column_stack([
+                    (vertex_colors_simplified * 255).astype(np.uint8),
+                    np.full(len(vertex_colors_simplified), 255, dtype=np.uint8)
+                ])
+                simplified_mesh.visual.vertex_colors = vertex_colors_rgba
+
+            # Convert vertex colors back to texture
+            simplified_mesh = create_texture_from_vertex_colors(simplified_mesh)
+            simplify_meshes.append(simplified_mesh)
             continue
+
         simple = to_open3d(mesh).simplify_vertex_clustering(
             simplify_vertex_clustering_voxel_size)
         mesh = trimesh.Trimesh(
@@ -67,12 +318,164 @@ def simplify_vertex_clustering(
     return simplify_meshes
 
 
+def auto_simplify_quadric_decimation_with_texture_preservation(
+        meshes, target_number_of_triangles=50000, verbose=False):
+    """Simplify meshes using quadric decimation while preserving texture colors.
+
+    This function converts texture information to vertex colors, performs
+    decimation, and then converts the vertex colors back to texture format.
+    Only creates textures when the original mesh has actual texture images.
+
+    Parameters
+    ----------
+    meshes : list or trimesh.Trimesh
+        Meshes to be simplified.
+    target_number_of_triangles : int, optional
+        Target number of triangles after decimation. Default is 50000.
+    verbose : bool, optional
+        Whether to print progress information. Default is False.
+
+    Returns
+    -------
+    list
+        List of simplified meshes with preserved color information.
+    """
+    import open3d as o3d
+
+    if not isinstance(meshes, list):
+        meshes = [meshes]
+
+    mesh_simplified_list = []
+    for mesh in meshes:
+        if verbose:
+            print(f"Processing mesh with {len(mesh.faces)} faces...")
+
+        # Check if mesh has actual texture images (not just material colors)
+        has_actual_texture = False
+        if mesh.visual.kind == 'texture':
+            if (hasattr(mesh.visual, 'material') and
+                mesh.visual.material is not None):
+                if (hasattr(mesh.visual.material, 'baseColorTexture') and
+                    mesh.visual.material.baseColorTexture is not None):
+                    has_actual_texture = True
+                elif (hasattr(mesh.visual.material, 'image') and
+                      mesh.visual.material.image is not None):
+                    has_actual_texture = True
+
+        # For meshes with only material colors (no texture images),
+        # use Open3D directly to avoid trimesh ColorVisuals issues
+        if mesh.visual.kind == 'texture' and not has_actual_texture:
+            if verbose:
+                print("Processing material-only mesh with Open3D...")
+
+            # Get material color directly
+            material_color = mesh.visual.material.main_color[:3]  # RGB only
+
+            # Convert to Open3D directly
+            o3d_mesh = o3d.geometry.TriangleMesh()
+            o3d_mesh.vertices = o3d.utility.Vector3dVector(mesh.vertices)
+            o3d_mesh.triangles = o3d.utility.Vector3iVector(mesh.faces)
+
+            # Set vertex colors directly in Open3D (normalized)
+            vertex_colors_normalized = np.tile(material_color / 255.0, (len(mesh.vertices), 1))
+            o3d_mesh.vertex_colors = o3d.utility.Vector3dVector(vertex_colors_normalized)
+
+            # Perform Open3D decimation
+            simplified_o3d_mesh = o3d_mesh.simplify_quadric_decimation(
+                target_number_of_triangles=min(target_number_of_triangles, len(mesh.faces)))
+
+            # Convert back to trimesh with vertex colors in constructor
+            vertices = np.asarray(simplified_o3d_mesh.vertices)
+            faces = np.asarray(simplified_o3d_mesh.triangles)
+
+            if simplified_o3d_mesh.has_vertex_colors():
+                vertex_colors_back = np.asarray(simplified_o3d_mesh.vertex_colors)
+                vertex_colors_rgba = np.column_stack([
+                    (vertex_colors_back * 255).astype(np.uint8),
+                    np.full(len(vertex_colors_back), 255, dtype=np.uint8)
+                ])
+
+                # Use constructor with vertex_colors to preserve exact colors
+                simplified_mesh = trimesh.Trimesh(
+                    vertices=vertices,
+                    faces=faces,
+                    vertex_colors=vertex_colors_rgba
+                )
+            else:
+                simplified_mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+
+            mesh_simplified_list.append(simplified_mesh)
+
+            if verbose:
+                print(f"Simplified mesh has {len(simplified_mesh.faces)} faces")
+            continue
+
+        # For meshes with actual textures, use texture preservation
+        o3d_mesh = o3d.geometry.TriangleMesh()
+        o3d_mesh.vertices = o3d.utility.Vector3dVector(mesh.vertices)
+        o3d_mesh.triangles = o3d.utility.Vector3iVector(mesh.faces)
+
+        # Handle texture meshes by converting to vertex colors
+        if mesh.visual.kind == 'texture':
+            if verbose:
+                print("Converting texture to vertex colors...")
+            vertex_colors = create_vertex_colors_from_texture(mesh, verbose=verbose)
+            o3d_mesh.vertex_colors = o3d.utility.Vector3dVector(vertex_colors)
+        else:
+            # Use existing vertex/face colors
+            if hasattr(mesh.visual, 'vertex_colors'):
+                vertex_colors = np.array(mesh.visual.vertex_colors)[:, :3] / 255.0
+                o3d_mesh.vertex_colors = o3d.utility.Vector3dVector(vertex_colors)
+
+        # Perform decimation
+        if verbose:
+            print(f"Performing decimation to {target_number_of_triangles} triangles...")
+
+        simplified_o3d_mesh = o3d_mesh.simplify_quadric_decimation(
+            target_number_of_triangles=target_number_of_triangles)
+
+        # Convert back to trimesh
+        vertices = np.asarray(simplified_o3d_mesh.vertices)
+        faces = np.asarray(simplified_o3d_mesh.triangles)
+        simplified_mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+
+        # Set vertex colors on the simplified mesh
+        if simplified_o3d_mesh.has_vertex_colors():
+            vertex_colors = np.asarray(simplified_o3d_mesh.vertex_colors)
+            # Convert to RGBA format (add alpha channel)
+            vertex_colors_rgba = np.column_stack([
+                (vertex_colors * 255).astype(np.uint8),
+                np.full(len(vertex_colors), 255, dtype=np.uint8)  # full alpha
+            ])
+            simplified_mesh.visual.vertex_colors = vertex_colors_rgba
+
+        # Convert vertex colors back to texture only if original had actual textures
+        if mesh.visual.kind == 'texture' and has_actual_texture:
+            if verbose:
+                print("Converting vertex colors back to texture...")
+            simplified_mesh = create_texture_from_vertex_colors(simplified_mesh)
+
+        mesh_simplified_list.append(simplified_mesh)
+
+        if verbose:
+            print(f"Simplified mesh has {len(simplified_mesh.faces)} faces")
+
+    return mesh_simplified_list
+
+
 def auto_simplify_quadric_decimation(meshes, area_ratio_threshold=0.98):
     if not isinstance(meshes, list):
         meshes = [meshes]
 
     mesh_simplified_list = []
     for mesh in meshes:
+        # For texture meshes, use the texture-preserving decimation method
+        if mesh.visual.kind == 'texture':
+            simplified_meshes = auto_simplify_quadric_decimation_with_texture_preservation(
+                [mesh], target_number_of_triangles=int(len(mesh.faces) * area_ratio_threshold))
+            mesh_simplified_list.extend(simplified_meshes)
+            continue
+
         n_face = len(mesh.faces)
         for f in [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]:
             n_face_reduced = int(n_face * f)

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -45,6 +45,7 @@ _CONFIGURABLE_VALUES = {"mesh_simplify_factor": np.inf,
                         'export_mesh_format': None,
                         'decimation_area_ratio_threshold': None,
                         'simplify_vertex_clustering_voxel_size': None,
+                        'target_triangles': None,
                         'enable_mesh_cache': False,
                         'force_visual_mesh_origin_to_zero': False,
                         'overwrite_mesh': False,
@@ -71,17 +72,20 @@ def export_mesh_format(
         mesh_format,
         decimation_area_ratio_threshold=None,
         simplify_vertex_clustering_voxel_size=None,
+        target_triangles=None,
         overwrite_mesh=False):
     _CONFIGURABLE_VALUES["export_mesh_format"] = mesh_format
     _CONFIGURABLE_VALUES["decimation_area_ratio_threshold"] = \
         decimation_area_ratio_threshold
     _CONFIGURABLE_VALUES["simplify_vertex_clustering_voxel_size"] = \
         simplify_vertex_clustering_voxel_size
+    _CONFIGURABLE_VALUES["target_triangles"] = target_triangles
     _CONFIGURABLE_VALUES["overwrite_mesh"] = overwrite_mesh
     yield
     _CONFIGURABLE_VALUES["export_mesh_format"] = None
     _CONFIGURABLE_VALUES["decimation_area_ratio_threshold"] = None
     _CONFIGURABLE_VALUES["simplify_vertex_clustering_voxel_size"] = None
+    _CONFIGURABLE_VALUES["target_triangles"] = None
     _CONFIGURABLE_VALUES["overwrite_mesh"] = False
 
 
@@ -935,7 +939,12 @@ class Mesh(URDFType):
 
         # Export the meshes as a single file
         meshes = self.meshes
-        if _CONFIGURABLE_VALUES[
+        if _CONFIGURABLE_VALUES["target_triangles"] is not None:
+            from skrobot.utils.mesh import auto_simplify_quadric_decimation_with_texture_preservation
+            meshes = auto_simplify_quadric_decimation_with_texture_preservation(
+                meshes, target_number_of_triangles=_CONFIGURABLE_VALUES[
+                    "target_triangles"], verbose=True)
+        elif _CONFIGURABLE_VALUES[
                 "decimation_area_ratio_threshold"] is not None:
             from skrobot.utils.mesh import auto_simplify_quadric_decimation
             meshes = auto_simplify_quadric_decimation(


### PR DESCRIPTION
This commit implements texture-preserving mesh decimation for URDF mesh processing with enhanced color accuracy:

- Add auto_simplify_quadric_decimation_with_texture_preservation function that converts textures to vertex colors, performs decimation, and converts back while preserving exact color values
- Add create_vertex_colors_from_texture and create_texture_from_vertex_colors helper functions for texture-to-vertex color conversion
- Add --target-triangles parameter to convert-urdf-mesh command for specifying target triangle count with texture preservation
- Update simplify_vertex_clustering to support texture meshes with material colors using Open3D directly for better color preservation
- Modify auto_simplify_quadric_decimation to use texture-preserving method for texture meshes automatically
- Fix color preservation issues by using trimesh constructor with vertex_colors parameter instead of post-creation assignment

The implementation handles both actual texture images and material-only meshes, using optimized approaches for each case to maintain color accuracy and reduce file sizes efficiently.