### PR TITLE
Handle single-link URDF without joints

### DIFF
--- a/skrobot/urdf/modularize_urdf.py
+++ b/skrobot/urdf/modularize_urdf.py
@@ -43,7 +43,6 @@ def find_root_link(input_path):
     if root_candidates:
         return next(iter(root_candidates))  # root link name as string
     else:
-        if len(root.findall("link")) == 1:
         root_links = root.findall("link")
         if len(root_links) == 1:
             return root_links[0].attrib["name"]

--- a/skrobot/urdf/modularize_urdf.py
+++ b/skrobot/urdf/modularize_urdf.py
@@ -44,7 +44,9 @@ def find_root_link(input_path):
         return next(iter(root_candidates))  # root link name as string
     else:
         if len(root.findall("link")) == 1:
-            return root.findall("link")[0].attrib["name"]
+        root_links = root.findall("link")
+        if len(root_links) == 1:
+            return root_links[0].attrib["name"]
         raise ValueError("Could not determine root link. Check that the URDF contains valid joint definitions.")
 
 

--- a/skrobot/urdf/modularize_urdf.py
+++ b/skrobot/urdf/modularize_urdf.py
@@ -43,6 +43,8 @@ def find_root_link(input_path):
     if root_candidates:
         return next(iter(root_candidates))  # root link name as string
     else:
+        if len(root.findall("link")) == 1:
+            return root.findall("link")[0].attrib["name"]
         raise ValueError("Could not determine root link. Check that the URDF contains valid joint definitions.")
 
 


### PR DESCRIPTION
This PR fixes a bug where the find_root_link function would raise a ValueError when parsing a valid URDF file that contains only a single link and no joints, such as a module used at the end of a robot.