### PR TITLE
Suppress velocity warnings for mimic joints and update URDF visualization

### DIFF
--- a/skrobot/apps/visualize_urdf.py
+++ b/skrobot/apps/visualize_urdf.py
@@ -5,7 +5,7 @@ import os.path as osp
 import time
 
 import skrobot
-from skrobot.models.urdf import RobotModelFromURDF
+from skrobot.model import RobotModel
 
 
 def main():
@@ -26,8 +26,8 @@ def main():
         viewer = skrobot.viewers.TrimeshSceneViewer(update_interval=0.1)
     elif args.viewer == 'pyrender':
         viewer = skrobot.viewers.PyrenderViewer(update_interval=0.1)
-    robot_model = RobotModelFromURDF(
-        urdf_file=osp.abspath(args.input_urdfpath))
+    robot_model = RobotModel.from_urdf(
+        osp.abspath(args.input_urdfpath))
     viewer.add(robot_model)
     viewer.show()
     if args.interactive:

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -2018,6 +2018,10 @@ class RobotModel(CascadedLink):
                     parent_link=link_maps[j.parent],
                     child_link=link_maps[j.child])
             elif j.joint_type == 'revolute':
+                # For mimic joints, set a default velocity if not specified to avoid warnings
+                velocity = j.limit.velocity
+                if j.mimic is not None and velocity <= 0:
+                    velocity = np.deg2rad(5)  # Default velocity for mimic joints
                 joint = RotationalJoint(
                     axis=j.axis,
                     name=j.name,
@@ -2026,8 +2030,12 @@ class RobotModel(CascadedLink):
                     min_angle=j.limit.lower,
                     max_angle=j.limit.upper,
                     max_joint_torque=j.limit.effort,
-                    max_joint_velocity=j.limit.velocity)
+                    max_joint_velocity=velocity)
             elif j.joint_type == 'continuous':
+                # For mimic joints, set a default velocity if not specified to avoid warnings
+                velocity = j.limit.velocity
+                if j.mimic is not None and velocity <= 0:
+                    velocity = np.deg2rad(5)  # Default velocity for mimic joints
                 joint = RotationalJoint(
                     axis=j.axis,
                     name=j.name,
@@ -2036,10 +2044,14 @@ class RobotModel(CascadedLink):
                     min_angle=-np.inf,
                     max_angle=np.inf,
                     max_joint_torque=j.limit.effort,
-                    max_joint_velocity=j.limit.velocity)
+                    max_joint_velocity=velocity)
             elif j.joint_type == 'prismatic':
                 # http://wiki.ros.org/urdf/XML/joint
                 # meters for prismatic joints
+                # For mimic joints, set a default velocity if not specified to avoid warnings
+                velocity = j.limit.velocity
+                if j.mimic is not None and velocity <= 0:
+                    velocity = np.pi / 4.0  # Default velocity for mimic joints
                 joint = LinearJoint(
                     axis=j.axis,
                     name=j.name,
@@ -2048,7 +2060,7 @@ class RobotModel(CascadedLink):
                     min_angle=j.limit.lower,
                     max_angle=j.limit.upper,
                     max_joint_torque=j.limit.effort,
-                    max_joint_velocity=j.limit.velocity)
+                    max_joint_velocity=velocity)
 
             is_mimic = j.name in mimic_joint_names
             if j.joint_type != 'fixed':


### PR DESCRIPTION

- Add default velocity values for mimic joints to prevent unnecessary warnings
- Update visualize_urdf.py to use RobotModel.from_urdf() API
- Maintain backward compatibility while cleaning up console output