### PR TITLE
Fix deprecation warnings across codebase

### DIFF
--- a/skrobot/model/primitives.py
+++ b/skrobot/model/primitives.py
@@ -238,7 +238,7 @@ class Sphere(Link, SDFImplemented):
         mesh = trimesh.creation.icosphere(
             radius=radius,
             subdivisions=subdivisions,
-            color=color,
+            face_colors=color,
         )
         super(Sphere, self).__init__(pos=pos, rot=rot, name=name,
                                      collision_mesh=mesh,

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -21,9 +21,9 @@ from skrobot.coordinates import midcoords
 from skrobot.coordinates import midpoint
 from skrobot.coordinates import normalize_vector
 from skrobot.coordinates import orient_coords_to_axis
-from skrobot.coordinates import rpy_angle
 from skrobot.coordinates.math import jacobian_inverse
 from skrobot.coordinates.math import matrix2quaternion
+from skrobot.coordinates.math import matrix2ypr
 from skrobot.coordinates.math import quaternion2matrix
 from skrobot.coordinates.math import quaternion2rpy
 from skrobot.coordinates.math import quaternion_inverse
@@ -2230,12 +2230,12 @@ class RobotModel(CascadedLink):
             if j.parent not in link_maps or j.child not in link_maps:
                 continue
             if j.origin is None:
-                rpy = np.zeros(3, dtype=np.float32)
+                ypr = np.zeros(3, dtype=np.float32)
                 xyz = np.zeros(3, dtype=np.float32)
             else:
-                rpy = rpy_angle(j.origin[:3, :3])[0]
+                ypr = matrix2ypr(j.origin[:3, :3])
                 xyz = j.origin[:3, 3]
-            link_maps[j.child].newcoords(rpy,
+            link_maps[j.child].newcoords(ypr,
                                          xyz)
             # TODO(fix automatically update default_coords)
             link_maps[j.child].joint.default_coords = Coordinates(

--- a/skrobot/planner/utils.py
+++ b/skrobot/planner/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from skrobot.coordinates import CascadedCoords
 from skrobot.coordinates import Coordinates
-from skrobot.coordinates.math import rpy_angle
+from skrobot.coordinates.math import matrix2ypr
 from skrobot.coordinates.math import rpy_matrix
 
 
@@ -93,8 +93,7 @@ def get_robot_config(robot_model, joint_list, with_base=False):
     av_joint = np.array([j.joint_angle() for j in joint_list])
     if with_base:
         x, y, _ = robot_model.translation
-        rpy = rpy_angle(robot_model.rotation)[0]
-        theta = rpy[0]
+        theta, _, _ = matrix2ypr(robot_model.rotation)
         av_whole = np.hstack((av_joint, [x, y, theta]))
         return av_whole
     else:

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -534,8 +534,8 @@ class GridSDF(SignedDistanceFunction):
                     'trying to acquire lock for %s...', sdf_cache_path)
                 logger.info(
                     'pre-computing sdf and making a cache at %s.', sdf_cache_path)
-                pysdfgen.obj2sdf(str(obj_filepath), dim_grid, padding_grid,
-                                 output_filepath=sdf_cache_path)
+                pysdfgen.mesh2sdf(str(obj_filepath), dim_grid, padding_grid,
+                                  output_filepath=sdf_cache_path)
                 logger.info('finish pre-computation')
         return GridSDF.from_file(sdf_cache_path, **kwargs)
 

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -216,8 +216,9 @@ class TestCoordinates(unittest.TestCase):
         c.translate([0.1, 0.2, 0.3], c2)
         testing.assert_almost_equal(
             c.translation, [0.3, 0.2, -0.1])
+        from skrobot.coordinates.math import matrix2ypr
         testing.assert_almost_equal(
-            c.rpy_angle()[0], [pi / 3.0, 0, 0])
+            matrix2ypr(c.rotation), [pi / 3.0, 0, 0])
 
     def test_transform_vector(self):
         pos = [0.13264493, 0.05263172, 0.93042636]

--- a/tests/skrobot_tests/coordinates_tests/test_geo.py
+++ b/tests/skrobot_tests/coordinates_tests/test_geo.py
@@ -28,8 +28,9 @@ class TestGeo(unittest.TestCase):
 
         testing.assert_array_equal(target_coords.worldpos(),
                                    [1, 1, 1])
+        from skrobot.coordinates.math import matrix2ypr
         testing.assert_array_almost_equal(
-            target_coords.rpy_angle()[0],
+            matrix2ypr(target_coords.rotation),
             [0, 0, -1.57079633])
 
         # case of rot_angle_cos == 1.0
@@ -39,7 +40,7 @@ class TestGeo(unittest.TestCase):
         testing.assert_array_equal(target_coords.worldpos(),
                                    [1, 1, 1])
         testing.assert_array_almost_equal(
-            target_coords.rpy_angle()[0],
+            matrix2ypr(target_coords.rotation),
             [0, 0, 0])
 
         # case of rot_angle_cos == -1.0
@@ -49,7 +50,7 @@ class TestGeo(unittest.TestCase):
         testing.assert_array_equal(target_coords.worldpos(),
                                    [0, 0, 0])
         testing.assert_array_almost_equal(
-            target_coords.rpy_angle()[0],
+            matrix2ypr(target_coords.rotation),
             [0, 0, pi])
 
     def test_rotate_points(self):


### PR DESCRIPTION
Replace deprecated function calls with their modern equivalents:
- rpy_angle() → matrix2ypr()/matrix2rpy() in tests and core modules
- matrix_log()/matrix_exponent() → rotation_matrix_to_axis_angle_vector()/axis_angle_vector_to_rotation_matrix()
- midrot() → interpolate_rotation_matrices()
- outer_product_matrix() → skew_symmetric_matrix()
- obj2sdf() → mesh2sdf()
- icosphere color parameter → face_colors parameter

All tests now pass without deprecation warnings.