### PR TITLE
Solve base pose alongside joint angles in inverse_kinematics

### DIFF
--- a/examples/griphis_wall_climb.py
+++ b/examples/griphis_wall_climb.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python
+"""Griphis alternating wall-climbing gait using fullbody IK.
+
+Griphis is a two-gripper climbing robot with suction-pad ends.  This
+example drives it up a vertical wall with an alternating gait: one
+gripper stays stuck while the other swings along an arc to a higher
+contact point, then the roles swap.  The whole thing is one repeated
+multi-end-effector IK call with ``use_base='6dof'`` so that ``base_link``
+is free to translate and rotate while both hands are constrained.
+
+Assumptions
+-----------
+- Wall is a vertical plane (normal = +Y, surface = xz-plane) at y = WALL_Y.
+- Robot climbs toward +Z (up) along the wall.
+- Suction pads on both grippers; the nail-closing joints are kept open
+  (worm_rotate = 15 rad) throughout, so adhesion is modelled as pure
+  pose contact.
+- Fullbody IK (``use_base='6dof'``) is used so ``base_link`` can
+  translate/rotate freely in space while stance/swing constraints pin the
+  supporting hand and move the swing hand to its next wall target.
+
+The URDF + meshes are fetched on first use via
+``skrobot.models.Griphis`` (downloaded to ``~/.skrobot/griphis_description/``),
+which also attaches ``gripper_1_end_coords`` / ``gripper_2_end_coords`` at
+the centroid of each gripper's four nail tips with +X pointing forward.
+"""
+import argparse
+import time
+
+import numpy as np
+
+from skrobot.collision import RobotCollisionChecker
+from skrobot.coordinates import Coordinates
+from skrobot.model.primitives import Axis
+from skrobot.model.primitives import Box
+from skrobot.models import Griphis
+
+
+# Collision-proxy tuning.  The default swept-sphere radii for Griphis's
+# stubby links are too conservative and report "collisions" at known-safe
+# straight-extended poses.  Scaling radii to 0.4 gives the two-column
+# gait ~1cm margin without missing real cross-arm contacts; intra-arm
+# pairs are ignored because the 4-DoF arm chain can never physically
+# fold into itself.
+COLLISION_RADIUS_SCALE = 0.4
+ARM_LINK_TEMPLATES = ('mid_pitch_{gid}_link', 'pitch_{gid}_link',
+                      'yaw_{gid}_link', 'roll_{gid}_link',
+                      'worm_{gid}_link')
+
+# Wall geometry: xz-plane at y = WALL_Y, normal pointing back toward the robot.
+WALL_Y = 0.20
+WALL_NORMAL = np.array([0.0, -1.0, 0.0])   # from wall surface toward robot
+WALL_UP = np.array([0.0, 0.0, 1.0])        # "up" along the wall
+
+# Worm open angle: nails retracted, suction pad active.
+WORM_OPEN_RAD = 15.0
+
+# Per-step climb distance (swing hand moves this far along WALL_UP each step).
+STEP_LENGTH = 0.10
+
+# Arc trajectory: the hand lifts off the wall by ARC_HEIGHT along
+# +WALL_NORMAL in a half-sine peaking at the midpoint, split into
+# ARC_SUBSTEPS IK-solved waypoints so the viewer can animate the swing.
+ARC_HEIGHT = 0.06
+ARC_SUBSTEPS = 20
+
+# Initial wall-contact xz positions (symmetric left/right).
+END1_START_XZ = np.array([0.10, 0.00])   # (x, z)
+END2_START_XZ = np.array([-0.10, 0.00])
+
+_FULL_MASK_PAIR = [np.array([1, 1, 1]), np.array([1, 1, 1])]
+
+
+# ---------------------------------------------------------------------------
+# Wall / link-list / IK helpers
+# ---------------------------------------------------------------------------
+
+def wall_contact_coords(xz):
+    """Coordinates on the wall at (xz[0], WALL_Y, xz[1]) with end_coords'
+    +X into the wall (along -WALL_NORMAL) and +Z along world +Z.
+    """
+    ex = -WALL_NORMAL
+    ez = WALL_UP
+    ey = np.cross(ez, ex)
+    rot = np.column_stack([ex, ey, ez])
+    return Coordinates(pos=np.array([xz[0], WALL_Y, xz[1]]), rot=rot)
+
+
+def arm_link_list(robot, gripper_id):
+    """Joints from base_link to roll_{gid}_link (worm/nail excluded)."""
+    return [getattr(robot, f'mid_pitch_{gripper_id}_link'),
+            getattr(robot, f'pitch_{gripper_id}_link'),
+            getattr(robot, f'yaw_{gripper_id}_link'),
+            getattr(robot, f'roll_{gripper_id}_link')]
+
+
+def set_suction_open(robot):
+    """Fix both worm_rotate joints at WORM_OPEN_RAD (suction-pad mode)."""
+    robot.worm_rotate_1.joint_angle(WORM_OPEN_RAD)
+    robot.worm_rotate_2.joint_angle(WORM_OPEN_RAD)
+
+
+def build_self_collision_checker(robot):
+    """Self-collision checker covering cross-arm and arm-vs-base pairs only.
+
+    Intra-arm pairs are excluded because the 4-DoF arm chain cannot
+    physically self-overlap; the swept-sphere proxies would report false
+    positives otherwise.
+    """
+    checker = RobotCollisionChecker(robot)
+    groups = {1: [], 2: []}
+    for gid in (1, 2):
+        for tmpl in ARM_LINK_TEMPLATES:
+            name = tmpl.format(gid=gid)
+            link = getattr(robot, name, None)
+            if link is None:
+                continue
+            checker.add_link(link, radius_scale=COLLISION_RADIUS_SCALE)
+            groups[gid].append(name)
+    checker.add_link(robot.base_link, radius_scale=COLLISION_RADIUS_SCALE)
+    ignore = []
+    for grp in groups.values():
+        for i in range(len(grp)):
+            for j in range(i + 1, len(grp)):
+                ignore.append((grp[i], grp[j]))
+    checker.setup_self_collision_pairs(min_link_distance=2,
+                                       ignore_pairs=ignore)
+    return checker
+
+
+def self_collision_summary(checker):
+    d = checker.compute_self_collision_distances()
+    if len(d) == 0:
+        return 0, float('inf')
+    return int(np.sum(d < 0.0)), float(np.min(d))
+
+
+def solve_initial_pose(robot, end1, end2):
+    """Place both grippers on the wall at their starting xz positions.
+
+    Seeds the yaw joints with ±90° so each gripper already faces the wall
+    (+X → +Y) before the solver runs; without this seed the solver tends
+    to stall in a local minimum with both arms extended sideways (±X).
+    """
+    robot.yaw_1.joint_angle(-np.pi / 2)
+    robot.yaw_2.joint_angle(np.pi / 2)
+
+    t1 = wall_contact_coords(END1_START_XZ)
+    t2 = wall_contact_coords(END2_START_XZ)
+    link_list = [arm_link_list(robot, 1), arm_link_list(robot, 2)]
+    return robot.inverse_kinematics(
+        target_coords=[t1, t2],
+        move_target=[end1, end2],
+        link_list=link_list,
+        use_base='6dof',
+        base_weight=1.0,
+        position_mask=_FULL_MASK_PAIR,
+        rotation_mask=_FULL_MASK_PAIR,
+        stop=200,
+    )
+
+
+def _ik_once(robot, end_swing, end_stance, swing_target, link_list,
+             thre, rthre, stop):
+    stance_hold = end_stance.copy_worldcoords()
+    return robot.inverse_kinematics(
+        target_coords=[swing_target, stance_hold],
+        move_target=[end_swing, end_stance],
+        link_list=link_list,
+        use_base='6dof',
+        # base_weight > 1 lets the base absorb the step so the stance arm
+        # stays near its held configuration.
+        base_weight=3.0,
+        position_mask=_FULL_MASK_PAIR,
+        rotation_mask=_FULL_MASK_PAIR,
+        thre=[thre, thre],
+        rthre=[rthre, rthre],
+        revert_if_fail=False,
+        stop=stop,
+    )
+
+
+def arc_waypoints(start_pos, goal_pos, goal_rot,
+                  n=ARC_SUBSTEPS, height=ARC_HEIGHT):
+    """N (position, rotation) waypoints from start_pos to goal_pos.
+
+    xz interpolates linearly; the hand lifts off the wall by a half-sine
+    of amplitude ``height`` along +WALL_NORMAL (robot-side of the wall)
+    so the swing arc never penetrates.  Rotation stays at goal_rot so
+    the gripper keeps facing the wall, ready for the next suction contact.
+    Skips t=0 (== current pose) and includes t=1 (final goal pose).
+    """
+    ts = np.linspace(0.0, 1.0, n + 1)[1:]
+    pts = []
+    for t in ts:
+        xz = start_pos + t * (goal_pos - start_pos)
+        lift = WALL_NORMAL * height * np.sin(np.pi * t)
+        pts.append((xz + lift, goal_rot))
+    return pts
+
+
+def step_swing(robot, end_swing, end_stance, swing_target, link_list,
+               thre=0.0005, rthre_deg=0.5, stop=3000, on_substep=None,
+               substep_thre=0.003, substep_rthre_deg=2.0,
+               substep_stop=400):
+    """Move swing to swing_target while holding stance, animating through
+    an arc that lifts off the wall and lands back on it at the goal.
+    ``on_substep(sub_target)`` is invoked after every sub-IK solve.
+
+    Intermediate arc waypoints use the looser (substep_thre,
+    substep_rthre_deg, substep_stop) tolerance so the animation runs
+    fast; only the final waypoint (the actual wall-contact goal) is
+    solved with the tight (thre, rthre_deg, stop) tolerance so the
+    gripper lands precisely.
+
+    Returns (final_swing_pos_err, stance_pos_drift) in metres.
+    """
+    rthre = np.deg2rad(rthre_deg)
+    sub_rthre = np.deg2rad(substep_rthre_deg)
+    start_pos = end_swing.worldpos().copy()
+    goal_pos = swing_target.worldpos().copy()
+    goal_rot = swing_target.worldrot()
+    stance_pos_start = end_stance.worldpos().copy()
+
+    waypoints = list(arc_waypoints(start_pos, goal_pos, goal_rot))
+    n = len(waypoints)
+    for i, (sub_pos, sub_rot) in enumerate(waypoints):
+        is_final = (i == n - 1)
+        sub_target = Coordinates(pos=sub_pos, rot=sub_rot)
+        _ik_once(robot, end_swing, end_stance, sub_target, link_list,
+                 thre if is_final else substep_thre,
+                 rthre if is_final else sub_rthre,
+                 stop if is_final else substep_stop)
+        if on_substep is not None:
+            on_substep(sub_target)
+
+    swing_err = float(np.linalg.norm(end_swing.worldpos() - goal_pos))
+    stance_drift = float(
+        np.linalg.norm(end_stance.worldpos() - stance_pos_start))
+    return swing_err, stance_drift
+
+
+def next_wall_target_above(end_swing):
+    """Swing climbs its own x-column by STEP_LENGTH along WALL_UP."""
+    p = end_swing.worldpos()
+    xz_on_wall = np.array([p[0], p[2] + STEP_LENGTH * WALL_UP[2]])
+    return wall_contact_coords(xz_on_wall)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main(num_steps=40, interactive=True, step_pause=0.05,
+         substep_pause=0.0):
+    robot = Griphis()
+    end1 = robot.gripper_1_end_coords
+    end2 = robot.gripper_2_end_coords
+    set_suction_open(robot)
+
+    print('--- solving initial pose ---')
+    ok = solve_initial_pose(robot, end1, end2)
+    print(f'initial IK: {"OK" if ok is not False else "FAIL"}')
+    print(f'  end1 @ {end1.worldpos().round(4)}  end2 @ {end2.worldpos().round(4)}')
+    print(f'  base  @ {robot.base_link.worldpos().round(4)}')
+
+    checker = build_self_collision_checker(robot)
+    n0, md0 = self_collision_summary(checker)
+    print(f'  self_collision: n={n0} min_dist={md0 * 1000:+.1f}mm')
+    assert n0 == 0, (
+        f'initial pose is self-colliding ({n0} pairs, min={md0 * 1000:.1f}mm) '
+        'before any step — refuse to start the gait')
+
+    viewer = None
+    axis_swing = None
+    if interactive:
+        try:
+            from skrobot.viewers import PyrenderViewer
+            viewer = PyrenderViewer()
+            viewer.add(robot)
+            # Ground at z = 0, spanning the robot side of the wall so it
+            # visually anchors where the climb starts from.
+            ground = Box(extents=[2.0, 2.0, 0.01],
+                         face_colors=[180, 180, 180, 200])
+            ground.translate([0.0, WALL_Y - 1.0, -0.005])
+            viewer.add(ground)
+            wall_box = Box(extents=[2.0, 0.005, 4.0],
+                           face_colors=[150, 200, 255, 120])
+            wall_box.translate([0, WALL_Y, 1.5])
+            viewer.add(wall_box)
+            axis_swing = Axis(axis_radius=0.003, axis_length=0.05)
+            viewer.add(axis_swing)
+            viewer.show()
+        except Exception as e:
+            print(f'viewer skipped: {e}')
+            viewer = None
+
+    # link_list is a constant [arm1, arm2]; the IK solver auto-pairs each
+    # chain with its move_target via kinematic-chain membership, so we do
+    # not have to reorder even when swing/stance swap each iteration.
+    link_list_both = [arm_link_list(robot, 1), arm_link_list(robot, 2)]
+    stance_id = 2
+    for step in range(num_steps):
+        swing_id = 1 if stance_id == 2 else 2
+        end_swing = end1 if swing_id == 1 else end2
+        end_stance = end2 if stance_id == 2 else end1
+        target = next_wall_target_above(end_swing)
+
+        if axis_swing is not None:
+            axis_swing.newcoords(target)
+            viewer.redraw()
+
+        def _on_substep(sub_target):
+            if viewer is None:
+                return
+            if axis_swing is not None:
+                axis_swing.newcoords(sub_target)
+            viewer.redraw()
+            if substep_pause > 0:
+                time.sleep(substep_pause)
+
+        swing_err, stance_drift = step_swing(
+            robot, end_swing, end_stance, target, link_list_both,
+            on_substep=_on_substep)
+        n_coll, min_dist = self_collision_summary(checker)
+        tag = 'COLLIDE' if n_coll > 0 else 'ok'
+        print(f'step {step:02d}  swing=G{swing_id}  '
+              f'target_z={target.worldpos()[2]:.3f}  '
+              f'swing_err={swing_err * 1000:.1f}mm  '
+              f'stance_drift={stance_drift * 1000:.1f}mm  '
+              f'coll={n_coll:d} min_d={min_dist * 1000:+.1f}mm {tag}  '
+              f'end{swing_id} @ {end_swing.worldpos().round(4)}')
+
+        if viewer is not None:
+            viewer.redraw()
+            time.sleep(step_pause)
+
+        stance_id, swing_id = swing_id, stance_id
+
+    if viewer is not None:
+        print('==> Press [q] to close window')
+        while viewer.is_active:
+            time.sleep(0.1)
+            viewer.redraw()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--steps', type=int, default=None,
+        help='number of alternating swing steps (default: 40 interactive, '
+             '3 with --no-interactive)')
+    parser.add_argument(
+        '--no-interactive', action='store_true',
+        help='skip the PyrenderViewer and exit as soon as the gait finishes; '
+             'also reduces --steps default to 3 so smoke tests finish fast')
+    parser.add_argument('--pause', type=float, default=0.05,
+                        help='seconds to pause between steps in viewer')
+    parser.add_argument('--substep-pause', type=float, default=0.0,
+                        help='seconds to pause between arc waypoints')
+    args = parser.parse_args()
+    steps = args.steps if args.steps is not None else (
+        3 if args.no_interactive else 40)
+    main(num_steps=steps,
+         interactive=not args.no_interactive,
+         step_pause=args.pause,
+         substep_pause=args.substep_pause)

--- a/examples/pr2_inverse_kinematics.py
+++ b/examples/pr2_inverse_kinematics.py
@@ -143,6 +143,108 @@ def demonstrate_revert_if_fail(robot_model, target_coords, link_list, viewer,
     print("=" * 60)
 
 
+def demonstrate_fullbody_ik(robot_model, link_list, viewer,
+                            no_ik_visualization):
+    """Demonstrate fullbody IK (use_base) reaching a target that is
+    out of arm range without moving the mobile base."""
+    print("\n" + "=" * 60)
+    print("Fullbody IK: reaching a far target by moving the base")
+    print("=" * 60)
+
+    # Reset to a clean pose so the demo starts deterministic.
+    robot_model.reset_pose()
+    viewer.redraw()
+
+    ee_pos0 = robot_model.right_arm_end_coords.worldpos().copy()
+    base_pos0 = robot_model.root_link.worldpos().copy()
+
+    # Target 0.8 m forward from the current end-effector pose — beyond
+    # the right arm's reach without base motion.
+    far_target_pos = ee_pos0 + np.array([0.8, 0.0, 0.0])
+    far_target = skrobot.coordinates.Coordinates(far_target_pos, [0, 0, 0])
+    print("Far target position: {}".format(far_target_pos))
+    print("Initial base position: {}".format(base_pos0))
+
+    far_target_axis = skrobot.model.Axis(
+        axis_radius=0.012,
+        axis_length=0.18,
+        pos=far_target.translation,
+        rot=far_target.rotation,
+    )
+    far_target_axis.set_color([255, 128, 0])  # orange
+    viewer.add(far_target_axis)
+    viewer.redraw()
+
+    # 1) Arm-only IK — expected to fail because target is out of reach.
+    print("\n1. Arm-only IK (use_base=False):")
+    result_armonly = robot_model.inverse_kinematics(
+        far_target,
+        link_list=link_list,
+        move_target=robot_model.right_arm_end_coords,
+        rotation_mask=False,
+        stop=100,
+    )
+    success_armonly = result_armonly is not False \
+        and result_armonly is not None
+    ee_armonly = robot_model.right_arm_end_coords.worldpos()
+    err_armonly = np.linalg.norm(ee_armonly - far_target_pos)
+    print("   Result: {}".format(
+        "Success" if success_armonly else "Failed"))
+    print("   End-effector position: {}".format(ee_armonly))
+    print("   Distance to target: {:.3f}m".format(err_armonly))
+
+    # Reset between attempts.
+    robot_model.reset_pose()
+    viewer.redraw()
+
+    # 2) Fullbody IK with planar base — base translates/rotates on
+    # the ground so the arm can reach.
+    print("\n2. Fullbody IK (use_base='planar'):")
+    if not no_ik_visualization:
+        with ik_visualization(viewer, sleep_time=0.5):
+            result_fullbody = robot_model.inverse_kinematics(
+                far_target,
+                link_list=link_list,
+                move_target=robot_model.right_arm_end_coords,
+                rotation_mask=False,
+                stop=100,
+                use_base='planar',
+            )
+    else:
+        result_fullbody = robot_model.inverse_kinematics(
+            far_target,
+            link_list=link_list,
+            move_target=robot_model.right_arm_end_coords,
+            rotation_mask=False,
+            stop=100,
+            use_base='planar',
+        )
+    success_fullbody = result_fullbody is not False \
+        and result_fullbody is not None
+    ee_fullbody = robot_model.right_arm_end_coords.worldpos()
+    base_fullbody = robot_model.root_link.worldpos()
+    err_fullbody = np.linalg.norm(ee_fullbody - far_target_pos)
+    base_moved = np.linalg.norm(base_fullbody - base_pos0)
+    print("   Result: {}".format(
+        "Success" if success_fullbody else "Failed"))
+    print("   End-effector position: {}".format(ee_fullbody))
+    print("   Distance to target: {:.3f}m".format(err_fullbody))
+    print("   Base moved by: {:.3f}m".format(base_moved))
+
+    viewer.redraw()
+    print("\n" + "-" * 50)
+    print("Comparison:")
+    print("   Arm-only distance to target: {:.3f}m".format(err_armonly))
+    print("   Fullbody  distance to target: {:.3f}m".format(err_fullbody))
+    if err_fullbody < err_armonly:
+        print("   [OK] Fullbody IK reached the target by moving the base.")
+    print("\n" + "=" * 60)
+    print("VISUALIZATION LEGEND (fullbody demo):")
+    print("=" * 60)
+    print("Orange coordinate frame: Far target (out of arm-only reach)")
+    print("=" * 60)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Simple PR2 inverse kinematics example.')
@@ -164,6 +266,11 @@ def main():
         '--skip-revert-demo',
         action='store_true',
         help="Skip the revert_if_fail demonstration"
+    )
+    parser.add_argument(
+        '--skip-fullbody-demo',
+        action='store_true',
+        help="Skip the fullbody IK (use_base) demonstration"
     )
     parser.add_argument(
         '--translation-tolerance', '--translation_tolerance',
@@ -263,6 +370,11 @@ def main():
     if not args.skip_revert_demo:
         demonstrate_revert_if_fail(robot_model, target_coords, link_list, viewer,
                                    args.no_ik_visualization)
+
+    # Demonstrate fullbody IK with a far target
+    if not args.skip_fullbody_demo:
+        demonstrate_fullbody_ik(robot_model, link_list, viewer,
+                                args.no_ik_visualization)
 
     if not args.no_interactive:
         print('==> Press [q] to close window')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,8 @@ default.extend-ignore-re = [
 default.extend-ignore-identifiers-re = [
     "iy",  # y-index variable (ix, iy, iz pattern)
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -494,9 +494,25 @@ def sr_inverse(J, k=1.0, weight_vector=None):
     if weight_vector is None:
         return sr_inverse_org(J, k)
 
-    # k=0 => sr-inverse = pseudo-inverse
+    # k=0 with uniform weight degenerates to the plain pseudo-inverse.
+    # With a non-uniform weight we must still respect it, otherwise any
+    # per-DoF weighting is silently dropped when the Jacobian is
+    # well-conditioned (pre-existing bug that breaks fullbody IK
+    # base_weight and joint-limit weighting at high manipulability).
     if k == 0.0:
-        return np.linalg.pinv(J)
+        w0 = weight_vector[0]
+        if np.all(weight_vector == w0):
+            return np.linalg.pinv(J)
+        if not np.all(np.isfinite(weight_vector)) \
+                or np.any(np.asarray(weight_vector) < 0):
+            raise ValueError(
+                'weight_vector must be finite and non-negative, got {}'
+                .format(weight_vector))
+        weight_matrix = np.diag(weight_vector)
+        return np.matmul(
+            weight_matrix,
+            np.matmul(J.T, np.linalg.pinv(
+                np.matmul(J, np.matmul(weight_matrix, J.T)))))
 
     # with weight
     weight_matrix = np.diag(weight_vector)

--- a/skrobot/data/__init__.py
+++ b/skrobot/data/__init__.py
@@ -118,6 +118,20 @@ def fetch_urdfpath():
     return path
 
 
+def griphis_urdfpath():
+    path = osp.join(get_cache_dir(),
+                    'griphis_description', 'urdf', 'griphis.urdf')
+    if osp.exists(path):
+        return path
+    _retrieve(
+        url='https://github.com/iory/scikit-robot-models/raw/main/griphis_description.tar.gz',  # NOQA
+        fname='griphis_description.tar.gz',
+        md5='e74a5e9887b51a918227b4fc185a6a33',
+        extract=True,
+    )
+    return path
+
+
 def kuka_urdfpath():
     return osp.join(data_dir, 'kuka_description', 'kuka.urdf')
 

--- a/skrobot/kinematics/differentiable.py
+++ b/skrobot/kinematics/differentiable.py
@@ -1818,6 +1818,27 @@ def _create_numpy_multi_ee_solver(fk_params_list, union_info):
     for t, fk_params in enumerate(fk_params_list):
         (m_parent, m_mult, m_off, non_mimic, n_opt) = _get_mimic_joint_info(
             fk_params)
+        # Precompute vectorized-expansion indices. URDF disallows
+        # mimic-of-mimic, which matches the assumption that every mimic
+        # joint's parent is a non-mimic joint; verify and surface a clear
+        # error otherwise so downstream gather/scatter remains safe.
+        m_parent_int = np.asarray(m_parent, dtype=np.int64)
+        mimic_mask = m_parent_int >= 0
+        mimic_child_idx = np.where(mimic_mask)[0]
+        if mimic_child_idx.size > 0:
+            parent_of_mimic = m_parent_int[mimic_child_idx]
+            if np.any(mimic_mask[parent_of_mimic]):
+                bad = mimic_child_idx[mimic_mask[parent_of_mimic]]
+                raise ValueError(
+                    "Multi-EE batch IK does not support mimic-of-mimic "
+                    "chains (task {}, child indices {}).".format(
+                        t, bad.tolist()))
+            mimic_mult_for_children = np.asarray(m_mult)[mimic_child_idx]
+            mimic_off_for_children = np.asarray(m_off)[mimic_child_idx]
+        else:
+            parent_of_mimic = np.empty(0, dtype=np.int64)
+            mimic_mult_for_children = np.empty(0, dtype=np.float64)
+            mimic_off_for_children = np.empty(0, dtype=np.float64)
         task_info.append({
             'fk_params': fk_params,
             'mimic_parent_indices': m_parent,
@@ -1827,22 +1848,29 @@ def _create_numpy_multi_ee_solver(fk_params_list, union_info):
             'n_opt': n_opt,
             'n_joints': fk_params['n_joints'],
             'union_mapping': task_mappings[t],
+            'mimic_child_idx': mimic_child_idx,
+            'mimic_parent_idx_flat': parent_of_mimic,
+            'mimic_mult_flat': mimic_mult_for_children,
+            'mimic_off_flat': mimic_off_for_children,
         })
 
     def _expand_task_full_angles(task_opt_angles, info):
-        """Expand task's opt angles to full angles for that task's link_list."""
+        """Expand task's opt angles to full angles for that task's link_list.
+
+        Mimic joints are resolved in one vectorized pass; their parents are
+        guaranteed non-mimic by the solver-setup check above, so reading
+        parent slots after the non-mimic fill is safe.
+        """
         batch_size = task_opt_angles.shape[0]
         n_joints = info['n_joints']
         full_angles = np.zeros((batch_size, n_joints))
         full_angles[:, info['non_mimic_indices']] = task_opt_angles
-        m_parent = info['mimic_parent_indices']
-        m_mult = info['mimic_multipliers']
-        m_off = info['mimic_offsets']
-        for i in range(n_joints):
-            p = int(m_parent[i])
-            if p >= 0:
-                full_angles[:, i] = (
-                    full_angles[:, p] * m_mult[i] + m_off[i])
+        child_idx = info['mimic_child_idx']
+        if child_idx.size > 0:
+            parent_vals = full_angles[:, info['mimic_parent_idx_flat']]
+            full_angles[:, child_idx] = (
+                parent_vals * info['mimic_mult_flat']
+                + info['mimic_off_flat'])
         return full_angles
 
     def _compute_task_jacobian_local(union_opt_angles, info):

--- a/skrobot/kinematics/differentiable.py
+++ b/skrobot/kinematics/differentiable.py
@@ -1845,18 +1845,13 @@ def _create_numpy_multi_ee_solver(fk_params_list, union_info):
                     full_angles[:, p] * m_mult[i] + m_off[i])
         return full_angles
 
-    def _compute_task_jacobian_and_pose(union_opt_angles, info):
-        """Compute (J_union, pos, rot) for a task given union-level opt angles.
+    def _compute_task_jacobian_local(union_opt_angles, info):
+        """Compute (J_opt_task, pos, rot) in the task's local opt space.
 
-        Returns
-        -------
-        J_union : np.ndarray
-            Shape (batch, 6, union_n_opt) with columns for this task's joints
-            scattered into their union positions; other columns are zero.
-        pos : np.ndarray
-            End-effector positions (batch, 3).
-        rot : np.ndarray
-            End-effector rotations (batch, 3, 3).
+        Unlike an earlier version, this does not allocate a per-task union
+        scatter buffer; callers are expected to write the returned
+        task-local Jacobian directly into a preallocated stacked buffer
+        using ``info['union_mapping']`` for the column indices.
         """
         mapping = info['union_mapping']
         task_opt = union_opt_angles[:, mapping]
@@ -1866,10 +1861,7 @@ def _create_numpy_multi_ee_solver(fk_params_list, union_info):
             non_mimic_indices=info['non_mimic_indices'],
             mimic_parent_indices=info['mimic_parent_indices'],
             mimic_multipliers=info['mimic_multipliers'])
-        batch = pos.shape[0]
-        J_union = np.zeros((batch, 6, union_n_opt))
-        J_union[:, :, mapping] = J_opt
-        return J_union, pos, rot
+        return J_opt, pos, rot
 
     def solve(target_positions_list, target_rotations_list,
               initial_angles=None,
@@ -2015,6 +2007,16 @@ def _create_numpy_multi_ee_solver(fk_params_list, union_info):
                 "to solve: every task is either fully masked out or has "
                 "task_weight == 0.")
 
+        # Precompute the DLS stack layout once: for each contributing task,
+        # record its contiguous row slice in the stacked Jacobian.
+        contrib_tasks = [t for t in range(n_tasks) if contributes[t]]
+        row_ranges = {}
+        cursor = 0
+        for t in contrib_tasks:
+            nrows = len(active_rows_per_task[t])
+            row_ranges[t] = (cursor, cursor + nrows)
+            cursor += nrows
+
         damping_eye = damping * np.eye(total_active)
 
         # Handle attempts_per_pose
@@ -2094,28 +2096,31 @@ def _create_numpy_multi_ee_solver(fk_params_list, union_info):
                 rot_err_world = np.zeros_like(pos_err)
             return np.concatenate([pos_err, rot_err_world], axis=1)
 
+        # Preallocate the stacked Jacobian and residual buffers. Column
+        # positions not in any contributing task's mapping stay zero for the
+        # life of the solve; per task, each iteration only overwrites its
+        # own (row-slice, mapped-column) cells.
+        J_stack = np.zeros((n_expanded, total_active, union_n_opt))
+        err_stack = np.zeros((n_expanded, total_active))
+
         # Main DLS iteration
         for _iter in range(max_iterations):
-            J_rows = []
-            err_rows = []
-            for t in range(n_tasks):
-                if not contributes[t]:
-                    continue
-                J_union_t, pos_t, rot_t = _compute_task_jacobian_and_pose(
-                    opt_angles, task_info[t])
+            for t in contrib_tasks:
+                info = task_info[t]
+                mapping = info['union_mapping']
+                J_opt_t, pos_t, rot_t = _compute_task_jacobian_local(
+                    opt_angles, info)
                 full_err_t = _compute_task_err(
                     rot_t, pos_t,
                     target_pos_expanded[t], target_rot_expanded[t],
                     pos_mask_arrs[t], rot_mask_arrs[t], mirror_rots[t])
                 rows_t = active_rows_per_task[t]
-                J_sel = J_union_t[:, rows_t, :]  # (batch, len(rows), union)
-                e_sel = full_err_t[:, rows_t]    # (batch, len(rows))
+                rs, re_ = row_ranges[t]
                 w = sqrt_weights[t]
-                J_rows.append(w * J_sel)
-                err_rows.append(w * e_sel)
-
-            J_stack = np.concatenate(J_rows, axis=1)
-            err_stack = np.concatenate(err_rows, axis=1)
+                # Scatter task-local Jacobian into this task's row slice at
+                # its union column positions; weights are folded in here.
+                J_stack[:, rs:re_, mapping] = w * J_opt_t[:, rows_t, :]
+                err_stack[:, rs:re_] = w * full_err_t[:, rows_t]
 
             JJT = np.matmul(
                 J_stack, np.transpose(J_stack, (0, 2, 1))) + damping_eye

--- a/skrobot/kinematics/differentiable.py
+++ b/skrobot/kinematics/differentiable.py
@@ -1529,6 +1529,7 @@ def _create_numpy_optimized_solver(fk_params):
               attempts_per_pose=1,
               use_current_angles=True,
               select_closest_to_initial=False,
+              joint_weights=None,
               **kwargs):
         """Solve batch IK using Jacobian-based damped least-squares in NumPy.
 
@@ -1548,6 +1549,12 @@ def _create_numpy_optimized_solver(fk_params):
             Position error threshold for success.
         rot_threshold : float
             Rotation error threshold for success.
+        joint_weights : array-like of shape (n_opt,), optional
+            Per-opt-variable weights in the damped least-squares update.
+            Larger entries make the corresponding opt variable "lighter"
+            (preferred for motion); smaller entries make it "heavier"
+            (discouraged). None (default) is uniform weighting (identity).
+            Applied as ``δq = W J^T (J W J^T + λI)^{-1} e``.
         position_mask, rotation_mask, rotation_mirror, attempts_per_pose,
         use_current_angles, select_closest_to_initial : same as JAX solver.
         """
@@ -1629,6 +1636,20 @@ def _create_numpy_optimized_solver(fk_params):
         # Precompute damping matrix
         damping_eye = damping * np.eye(n_active)
 
+        # Resolve optional per-opt-variable weights for a weighted DLS.
+        if joint_weights is None:
+            weight_diag = None
+        else:
+            weight_diag = np.asarray(joint_weights, dtype=np.float64)
+            if weight_diag.shape != (n_opt,):
+                raise ValueError(
+                    "joint_weights must have shape ({},), got {}".format(
+                        n_opt, weight_diag.shape))
+            if np.any(weight_diag <= 0):
+                raise ValueError("joint_weights must be strictly positive")
+            if np.allclose(weight_diag, 1.0):
+                weight_diag = None  # identity: fast-path to unweighted
+
         # Jacobian-based damped least-squares optimization loop
         opt_angles = init_opt_angles.copy()
 
@@ -1685,14 +1706,24 @@ def _create_numpy_optimized_solver(fk_params):
             err = full_err[:, active_rows]           # (batch, n_active)
             J = J_opt[:, active_rows, :]             # (batch, n_active, n_opt)
 
-            # Damped least squares: Δq = J^T (J J^T + λI)^{-1} e
-            # (batch, n_active, n_active)
-            JJT = np.matmul(J, np.transpose(J, (0, 2, 1))) + damping_eye
-            # (batch, n_active, 1) -> solve -> (batch, n_active, 1) -> squeeze
-            solved = np.linalg.solve(
-                JJT, err[..., np.newaxis]).squeeze(-1)
-            # (batch, n_opt)
-            delta_q = np.einsum('bji,bj->bi', J, solved)
+            if weight_diag is None:
+                # Damped least squares: Δq = J^T (J J^T + λI)^{-1} e
+                JJT = np.matmul(
+                    J, np.transpose(J, (0, 2, 1))) + damping_eye
+                solved = np.linalg.solve(
+                    JJT, err[..., np.newaxis]).squeeze(-1)
+                delta_q = np.einsum('bji,bj->bi', J, solved)
+            else:
+                # Weighted DLS: Δq = W J^T (J W J^T + λI)^{-1} e, where W
+                # is the diagonal of per-opt-variable weights. Larger W
+                # entries are "lighter" and move more; smaller entries
+                # are "heavier" and move less.
+                JW = J * weight_diag  # broadcast over columns
+                JWJT = np.matmul(
+                    JW, np.transpose(J, (0, 2, 1))) + damping_eye
+                solved = np.linalg.solve(
+                    JWJT, err[..., np.newaxis]).squeeze(-1)
+                delta_q = np.einsum('bji,bj->bi', JW, solved)
 
             opt_angles = opt_angles + delta_q
             opt_angles = np.clip(opt_angles, joint_limits_lower, joint_limits_upper)
@@ -1901,6 +1932,7 @@ def _create_numpy_multi_ee_solver(fk_params_list, union_info):
               rotation_masks=True,
               rotation_mirrors=None,
               task_weights=None,
+              joint_weights=None,
               attempts_per_pose=1,
               use_current_angles=True,
               select_closest_to_initial=False,
@@ -2045,6 +2077,21 @@ def _create_numpy_multi_ee_solver(fk_params_list, union_info):
             row_ranges[t] = (cursor, cursor + nrows)
             cursor += nrows
 
+        # Per-opt-variable weights for weighted DLS; None skips the fast-
+        # path allocation and uses the plain unweighted update.
+        if joint_weights is None:
+            weight_diag = None
+        else:
+            weight_diag = np.asarray(joint_weights, dtype=np.float64)
+            if weight_diag.shape != (union_n_opt,):
+                raise ValueError(
+                    "joint_weights must have shape ({},), got {}".format(
+                        union_n_opt, weight_diag.shape))
+            if np.any(weight_diag <= 0):
+                raise ValueError("joint_weights must be strictly positive")
+            if np.allclose(weight_diag, 1.0):
+                weight_diag = None
+
         damping_eye = damping * np.eye(total_active)
 
         # Handle attempts_per_pose
@@ -2150,11 +2197,22 @@ def _create_numpy_multi_ee_solver(fk_params_list, union_info):
                 J_stack[:, rs:re_, mapping] = w * J_opt_t[:, rows_t, :]
                 err_stack[:, rs:re_] = w * full_err_t[:, rows_t]
 
-            JJT = np.matmul(
-                J_stack, np.transpose(J_stack, (0, 2, 1))) + damping_eye
-            solved = np.linalg.solve(
-                JJT, err_stack[..., np.newaxis]).squeeze(-1)
-            delta_q = np.einsum('bji,bj->bi', J_stack, solved)
+            if weight_diag is None:
+                JJT = np.matmul(
+                    J_stack, np.transpose(J_stack, (0, 2, 1))) + damping_eye
+                solved = np.linalg.solve(
+                    JJT, err_stack[..., np.newaxis]).squeeze(-1)
+                delta_q = np.einsum('bji,bj->bi', J_stack, solved)
+            else:
+                # Weighted DLS: Δq = W J^T (J W J^T + λI)^{-1} e. JW
+                # column-scales J_stack by weight_diag; J^T @ y then
+                # equals (JW)^T @ y applied via einsum below.
+                JW = J_stack * weight_diag
+                JWJT = np.matmul(
+                    JW, np.transpose(J_stack, (0, 2, 1))) + damping_eye
+                solved = np.linalg.solve(
+                    JWJT, err_stack[..., np.newaxis]).squeeze(-1)
+                delta_q = np.einsum('bji,bj->bi', JW, solved)
 
             opt_angles = opt_angles + delta_q
             opt_angles = np.clip(

--- a/skrobot/kinematics/differentiable.py
+++ b/skrobot/kinematics/differentiable.py
@@ -2430,8 +2430,14 @@ def _create_jax_multi_ee_solver(fk_params_list, union_info):
 
     def _create_solver_fn(max_iterations, damping, pos_threshold,
                           rot_threshold, pos_mask_arrs, rot_mask_arrs,
-                          rotation_mirrors, task_weights_tuple):
-        """Create a JIT-compiled multi-EE solver for a given configuration."""
+                          rotation_mirrors, task_weights_tuple,
+                          weight_diag_tuple=None):
+        """Create a JIT-compiled multi-EE solver for a given configuration.
+
+        ``weight_diag_tuple`` is either None or a tuple of floats of length
+        ``union_n_opt`` specifying per-opt-variable weights for a weighted
+        DLS ``Δq = W J^T (J W J^T + λI)^-1 e``.
+        """
         # Per-task mask arrays as JAX (static at graph build)
         pos_masks = [jnp.array(m) for m in pos_mask_arrs]
         rot_masks = [jnp.array(m) for m in rot_mask_arrs]
@@ -2491,6 +2497,12 @@ def _create_jax_multi_ee_solver(fk_params_list, union_info):
         }
 
         damping_eye = damping * jnp.eye(total_active)
+
+        if weight_diag_tuple is None:
+            weight_diag_jax = None
+        else:
+            weight_diag_jax = jnp.array(
+                np.asarray(weight_diag_tuple, dtype=np.float64))
 
         def _compute_task_jac_local(opt_angles_batch, ts):
             """Task-local Jacobian + pose from union opt angles."""
@@ -2628,11 +2640,20 @@ def _create_jax_multi_ee_solver(fk_params_list, union_info):
                 J_stack = jnp.concatenate(J_rows, axis=1)
                 err_stack = jnp.concatenate(err_rows, axis=1)
 
-                JJT = jnp.matmul(
-                    J_stack, jnp.transpose(J_stack, (0, 2, 1))) + damping_eye
-                solved = jnp.linalg.solve(
-                    JJT, err_stack[..., jnp.newaxis]).squeeze(-1)
-                delta_q = jnp.einsum('bji,bj->bi', J_stack, solved)
+                if weight_diag_jax is None:
+                    JJT = jnp.matmul(
+                        J_stack, jnp.transpose(J_stack, (0, 2, 1))
+                    ) + damping_eye
+                    solved = jnp.linalg.solve(
+                        JJT, err_stack[..., jnp.newaxis]).squeeze(-1)
+                    delta_q = jnp.einsum('bji,bj->bi', J_stack, solved)
+                else:
+                    JW = J_stack * weight_diag_jax
+                    JWJT = jnp.matmul(
+                        JW, jnp.transpose(J_stack, (0, 2, 1))) + damping_eye
+                    solved = jnp.linalg.solve(
+                        JWJT, err_stack[..., jnp.newaxis]).squeeze(-1)
+                    delta_q = jnp.einsum('bji,bj->bi', JW, solved)
                 new_opt = opt_angles + delta_q
                 new_opt = jnp.clip(
                     new_opt, joint_limits_lower, joint_limits_upper)
@@ -2701,6 +2722,7 @@ def _create_jax_multi_ee_solver(fk_params_list, union_info):
               rotation_masks=True,
               rotation_mirrors=None,
               task_weights=None,
+              joint_weights=None,
               attempts_per_pose=1,
               use_current_angles=True,
               select_closest_to_initial=False,
@@ -2818,18 +2840,35 @@ def _create_jax_multi_ee_solver(fk_params_list, union_info):
             axis=0)
         init_opt_jax = jnp.array(init_opt.astype(np.float64))
 
+        if joint_weights is None:
+            weight_diag_tuple = None
+        else:
+            weight_diag_arr = np.asarray(joint_weights, dtype=np.float64)
+            if weight_diag_arr.shape != (union_n_opt,):
+                raise ValueError(
+                    "joint_weights must have shape ({},), got {}".format(
+                        union_n_opt, weight_diag_arr.shape))
+            if np.any(weight_diag_arr <= 0):
+                raise ValueError("joint_weights must be strictly positive")
+            if np.allclose(weight_diag_arr, 1.0):
+                weight_diag_tuple = None
+            else:
+                weight_diag_tuple = tuple(float(w) for w in weight_diag_arr)
+
         cache_key = (
             max_iterations, damping, pos_threshold, rot_threshold,
             tuple(tuple(pm) for pm in pos_mask_arrs),
             tuple(tuple(rm) for rm in rot_mask_arrs),
             tuple(rot_mirrors_per_task),
             tuple(float(w) for w in weights),
+            weight_diag_tuple,
         )
         if cache_key not in _jit_cache:
             _jit_cache[cache_key] = _create_solver_fn(
                 max_iterations, damping, pos_threshold, rot_threshold,
                 pos_mask_arrs, rot_mask_arrs, rot_mirrors_per_task,
-                tuple(weights.tolist()))
+                tuple(weights.tolist()),
+                weight_diag_tuple=weight_diag_tuple)
         solver_fn = _jit_cache[cache_key]
 
         final_opt, success, combined_err = solver_fn(
@@ -3197,9 +3236,15 @@ def _create_jax_jacobian_solver(fk_params, backend):
     # JIT cache for different parameters
     _jit_cache = {}
 
-    def _create_batched_solver_fn(max_iterations, damping, pos_threshold, rot_threshold,
-                                  pos_mask_arr, rot_mask_arr, rotation_mirror):
-        """Create JIT-compiled batched Jacobian solver using fori_loop."""
+    def _create_batched_solver_fn(max_iterations, damping, pos_threshold,
+                                  rot_threshold, pos_mask_arr, rot_mask_arr,
+                                  rotation_mirror, weight_diag_tuple=None):
+        """Create JIT-compiled batched Jacobian solver using fori_loop.
+
+        ``weight_diag_tuple`` is either None (unweighted DLS) or a tuple
+        of floats of length ``n_opt`` specifying the per-opt-variable
+        weights for a weighted DLS update ``Δq = W J^T (J W J^T + λI)^-1 e``.
+        """
         pos_mask = jnp.array(pos_mask_arr)
         rot_mask = jnp.array(rot_mask_arr)
 
@@ -3224,6 +3269,13 @@ def _create_jax_jacobian_solver(fk_params, backend):
         n_active = len(active_rows)
 
         damping_eye = damping * jnp.eye(n_active)
+
+        # Per-opt-variable weight vector for weighted DLS (None = uniform).
+        if weight_diag_tuple is None:
+            weight_diag_jax = None
+        else:
+            weight_diag_jax = jnp.array(np.asarray(
+                weight_diag_tuple, dtype=np.float64))
 
         # Precompute FK constants as JAX arrays for use inside JIT
         _translations = [jnp.array(fk_params['link_translations'][i])
@@ -3383,12 +3435,21 @@ def _create_jax_jacobian_solver(fk_params, backend):
                 err = full_err[:, active_rows_jax]
                 J = J_opt[:, active_rows_jax, :]
 
-                # Damped least squares: (batch, n_opt)
-                JJT = jnp.matmul(
-                    J, jnp.transpose(J, (0, 2, 1))) + damping_eye
-                solved = jnp.linalg.solve(
-                    JJT, err[..., jnp.newaxis]).squeeze(-1)
-                delta_q = jnp.einsum('bji,bj->bi', J, solved)
+                if weight_diag_jax is None:
+                    # Damped least squares: (batch, n_opt)
+                    JJT = jnp.matmul(
+                        J, jnp.transpose(J, (0, 2, 1))) + damping_eye
+                    solved = jnp.linalg.solve(
+                        JJT, err[..., jnp.newaxis]).squeeze(-1)
+                    delta_q = jnp.einsum('bji,bj->bi', J, solved)
+                else:
+                    # Weighted DLS: Δq = W J^T (J W J^T + λI)^{-1} e.
+                    JW = J * weight_diag_jax
+                    JWJT = jnp.matmul(
+                        JW, jnp.transpose(J, (0, 2, 1))) + damping_eye
+                    solved = jnp.linalg.solve(
+                        JWJT, err[..., jnp.newaxis]).squeeze(-1)
+                    delta_q = jnp.einsum('bji,bj->bi', JW, solved)
 
                 new_opt = opt_angles + delta_q
                 new_opt = jnp.clip(
@@ -3460,6 +3521,7 @@ def _create_jax_jacobian_solver(fk_params, backend):
               attempts_per_pose=1,
               use_current_angles=True,
               select_closest_to_initial=False,
+              joint_weights=None,
               **kwargs):
         """Solve batch IK using Jacobian-based method.
 
@@ -3539,13 +3601,32 @@ def _create_jax_jacobian_solver(fk_params, backend):
         pos_mask_arr = normalize_axis_mask(position_mask)
         rot_mask_arr = normalize_axis_mask(rotation_mask)
 
+        # Resolve optional joint_weights into a hashable tuple; None or
+        # uniform-1 collapses to the unweighted fast path.
+        if joint_weights is None:
+            weight_diag_tuple = None
+        else:
+            weight_diag_arr = np.asarray(joint_weights, dtype=np.float64)
+            if weight_diag_arr.shape != (n_opt,):
+                raise ValueError(
+                    "joint_weights must have shape ({},), got {}".format(
+                        n_opt, weight_diag_arr.shape))
+            if np.any(weight_diag_arr <= 0):
+                raise ValueError("joint_weights must be strictly positive")
+            if np.allclose(weight_diag_arr, 1.0):
+                weight_diag_tuple = None
+            else:
+                weight_diag_tuple = tuple(float(w) for w in weight_diag_arr)
+
         # Get or create JIT-compiled solver
         cache_key = (max_iterations, damping, pos_threshold, rot_threshold,
-                     tuple(pos_mask_arr), tuple(rot_mask_arr), rotation_mirror)
+                     tuple(pos_mask_arr), tuple(rot_mask_arr),
+                     rotation_mirror, weight_diag_tuple)
         if cache_key not in _jit_cache:
             _jit_cache[cache_key] = _create_batched_solver_fn(
                 max_iterations, damping, pos_threshold, rot_threshold,
-                pos_mask_arr, rot_mask_arr, rotation_mirror)
+                pos_mask_arr, rot_mask_arr, rotation_mirror,
+                weight_diag_tuple=weight_diag_tuple)
 
         solver_fn = _jit_cache[cache_key]
 

--- a/skrobot/kinematics/differentiable.py
+++ b/skrobot/kinematics/differentiable.py
@@ -1382,6 +1382,105 @@ def create_dynamic_limit_mask(fk_params, angles):
     return mask
 
 
+def _build_union_joint_mapping(link_lists, fk_params_list):
+    """Build a union joint space across multiple IK tasks.
+
+    For multi-end-effector batch IK, each task has its own kinematic chain
+    (``link_list``) with its own non-mimic joints. The optimization variables
+    are the union (in joint-object identity) of all non-mimic joints across
+    tasks. This helper builds that union and the per-task index mappings.
+
+    Parameters
+    ----------
+    link_lists : list of list
+        ``link_lists[t]`` is the link list for task ``t``. Each link has a
+        ``.joint`` attribute whose object identity is used for deduplication.
+    fk_params_list : list of dict
+        ``fk_params_list[t]`` is the FK parameter dict for task ``t``.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys:
+
+        - ``'task_mappings'``: list of ``np.ndarray[n_opt_task]``. For task t,
+          ``task_mappings[t][k]`` is the union opt index corresponding to the
+          task's k-th non-mimic joint.
+        - ``'task_non_mimic_indices'``: list of ``np.ndarray[n_opt_task]``.
+          Indices into the task's own link_list (i.e. into fk_params['n_joints']).
+        - ``'union_n_opt'``: int, size of the union optimization space.
+        - ``'union_joint_limits_lower'``: ``np.ndarray[union_n_opt]``.
+        - ``'union_joint_limits_upper'``: ``np.ndarray[union_n_opt]``.
+        - ``'union_joint_refs'``: list of joint objects (length union_n_opt).
+          Exposed for callers that need to map back to the robot's joint list.
+    """
+    union_joint_refs = []
+    union_joint_limits_lower = []
+    union_joint_limits_upper = []
+    seen = {}  # id(joint_obj) -> union index
+    task_mappings = []
+    task_non_mimic_indices = []
+    for link_list, fk_params in zip(link_lists, fk_params_list):
+        n_joints = fk_params['n_joints']
+        mimic_parent_indices = fk_params.get(
+            'mimic_parent_indices',
+            np.array([-1] * n_joints, dtype=np.int32))
+        non_mimic = np.array(
+            [i for i in range(n_joints) if mimic_parent_indices[i] < 0],
+            dtype=np.int32)
+        mapping = np.zeros(len(non_mimic), dtype=np.int32)
+        for k, full_idx in enumerate(non_mimic):
+            joint = link_list[int(full_idx)].joint
+            key = id(joint)
+            if key in seen:
+                mapping[k] = seen[key]
+                # Limits: take the tighter bound if multiple tasks reference
+                # the same joint and disagree (shouldn't happen unless the
+                # model is inconsistent, but be defensive).
+                uidx = seen[key]
+                lo = fk_params['joint_limits_lower'][int(full_idx)]
+                hi = fk_params['joint_limits_upper'][int(full_idx)]
+                if lo > union_joint_limits_lower[uidx]:
+                    union_joint_limits_lower[uidx] = lo
+                if hi < union_joint_limits_upper[uidx]:
+                    union_joint_limits_upper[uidx] = hi
+            else:
+                uidx = len(union_joint_refs)
+                seen[key] = uidx
+                union_joint_refs.append(joint)
+                union_joint_limits_lower.append(
+                    fk_params['joint_limits_lower'][int(full_idx)])
+                union_joint_limits_upper.append(
+                    fk_params['joint_limits_upper'][int(full_idx)])
+                mapping[k] = uidx
+        task_mappings.append(mapping)
+        task_non_mimic_indices.append(non_mimic)
+    lower = np.asarray(union_joint_limits_lower, dtype=np.float64)
+    upper = np.asarray(union_joint_limits_upper, dtype=np.float64)
+    # After tightening, detect cross-task limit disagreement that inverts
+    # a joint's range. If lo > hi, the joint is infeasible under the shared
+    # constraint and np.clip would silently collapse all iterates onto a
+    # corner — report it instead.
+    inverted = lower > upper
+    if np.any(inverted):
+        bad = [
+            "{} ([{:.4f}, {:.4f}])".format(
+                union_joint_refs[i].name, lower[i], upper[i])
+            for i in np.where(inverted)[0]
+        ]
+        raise ValueError(
+            "Inconsistent joint limits across tasks for shared joint(s): "
+            + ", ".join(bad))
+    return {
+        'task_mappings': task_mappings,
+        'task_non_mimic_indices': task_non_mimic_indices,
+        'union_n_opt': len(union_joint_refs),
+        'union_joint_limits_lower': lower,
+        'union_joint_limits_upper': upper,
+        'union_joint_refs': union_joint_refs,
+    }
+
+
 def _create_numpy_optimized_solver(fk_params):
     """Create an optimized batch IK solver using pure NumPy with Jacobian method.
 
@@ -1680,6 +1779,442 @@ def _create_numpy_optimized_solver(fk_params):
     solve.joint_limits_upper = fk_params['joint_limits_upper']
     solve.fk_params = fk_params
     solve.backend_name = 'numpy'
+
+    return solve
+
+
+def _create_numpy_multi_ee_solver(fk_params_list, union_info):
+    """Create a NumPy batch IK solver for multiple end-effectors.
+
+    Each task has its own ``fk_params`` (extracted from its own link_list and
+    move_target). Optimization variables live in a shared union joint space
+    so that overlapping joints (e.g. a shared torso) are solved jointly.
+
+    The per-iteration update is a weighted damped-least-squares on the stacked
+    system ``[J_1; J_2; ...] dq = [e_1; e_2; ...]`` where per-task rows are
+    scaled by ``sqrt(task_weights[t])``.
+
+    Parameters
+    ----------
+    fk_params_list : list of dict
+        One entry per task.
+    union_info : dict
+        Output of :func:`_build_union_joint_mapping`.
+
+    Returns
+    -------
+    callable
+        ``solve(target_positions_list, target_rotations_list, ...) ->
+        (solutions_full_union, success, errors)``.
+    """
+    n_tasks = len(fk_params_list)
+    task_mappings = union_info['task_mappings']
+    union_n_opt = union_info['union_n_opt']
+    joint_limits_lower = union_info['union_joint_limits_lower']
+    joint_limits_upper = union_info['union_joint_limits_upper']
+
+    # Per-task mimic info and expansion helpers
+    task_info = []
+    for t, fk_params in enumerate(fk_params_list):
+        (m_parent, m_mult, m_off, non_mimic, n_opt) = _get_mimic_joint_info(
+            fk_params)
+        task_info.append({
+            'fk_params': fk_params,
+            'mimic_parent_indices': m_parent,
+            'mimic_multipliers': m_mult,
+            'mimic_offsets': m_off,
+            'non_mimic_indices': non_mimic,
+            'n_opt': n_opt,
+            'n_joints': fk_params['n_joints'],
+            'union_mapping': task_mappings[t],
+        })
+
+    def _expand_task_full_angles(task_opt_angles, info):
+        """Expand task's opt angles to full angles for that task's link_list."""
+        batch_size = task_opt_angles.shape[0]
+        n_joints = info['n_joints']
+        full_angles = np.zeros((batch_size, n_joints))
+        full_angles[:, info['non_mimic_indices']] = task_opt_angles
+        m_parent = info['mimic_parent_indices']
+        m_mult = info['mimic_multipliers']
+        m_off = info['mimic_offsets']
+        for i in range(n_joints):
+            p = int(m_parent[i])
+            if p >= 0:
+                full_angles[:, i] = (
+                    full_angles[:, p] * m_mult[i] + m_off[i])
+        return full_angles
+
+    def _compute_task_jacobian_and_pose(union_opt_angles, info):
+        """Compute (J_union, pos, rot) for a task given union-level opt angles.
+
+        Returns
+        -------
+        J_union : np.ndarray
+            Shape (batch, 6, union_n_opt) with columns for this task's joints
+            scattered into their union positions; other columns are zero.
+        pos : np.ndarray
+            End-effector positions (batch, 3).
+        rot : np.ndarray
+            End-effector rotations (batch, 3, 3).
+        """
+        mapping = info['union_mapping']
+        task_opt = union_opt_angles[:, mapping]
+        task_full = _expand_task_full_angles(task_opt, info)
+        J_opt, pos, rot = compute_geometric_jacobian_batched_numpy(
+            task_full, info['fk_params'],
+            non_mimic_indices=info['non_mimic_indices'],
+            mimic_parent_indices=info['mimic_parent_indices'],
+            mimic_multipliers=info['mimic_multipliers'])
+        batch = pos.shape[0]
+        J_union = np.zeros((batch, 6, union_n_opt))
+        J_union[:, :, mapping] = J_opt
+        return J_union, pos, rot
+
+    def solve(target_positions_list, target_rotations_list,
+              initial_angles=None,
+              max_iterations=30,
+              damping=0.01,
+              pos_threshold=0.001,
+              rot_threshold=0.1,
+              position_masks=True,
+              rotation_masks=True,
+              rotation_mirrors=None,
+              task_weights=None,
+              attempts_per_pose=1,
+              use_current_angles=True,
+              select_closest_to_initial=False,
+              **kwargs):
+        """Solve multi-EE batch IK.
+
+        Parameters
+        ----------
+        target_positions_list : list of array-like
+            ``target_positions_list[t]`` has shape ``(N, 3)`` for task t.
+        target_rotations_list : list of array-like
+            ``target_rotations_list[t]`` has shape ``(N, 3, 3)``.
+        initial_angles : np.ndarray, optional
+            Either ``(n_targets, union_n_opt)`` or ``(union_n_opt,)``. If
+            None, random within union joint limits.
+        max_iterations : int
+        damping : float
+        pos_threshold, rot_threshold : float
+            Per-task thresholds used for success determination. A solve is
+            successful when **all** tasks meet their thresholds.
+        position_masks, rotation_masks : bool | str | list | per-task list
+            If a single mask, applied to all tasks. If list with length
+            n_tasks, per-task masks.
+        rotation_mirrors : None | str | list
+        task_weights : None | array-like of length n_tasks
+            Per-task weights. Default uniform 1.0.
+        attempts_per_pose, use_current_angles, select_closest_to_initial :
+            As in single-EE solvers.
+
+        Returns
+        -------
+        solutions : np.ndarray
+            Shape ``(n_targets, union_n_opt)``. Maps back to the robot's full
+            angle vector via ``union_joint_refs``.
+        success : np.ndarray of bool
+            Shape ``(n_targets,)``.
+        errors : np.ndarray
+            Shape ``(n_targets,)`` - weighted combined error across tasks.
+        """
+        # Normalize inputs to arrays.
+        target_pos_arrays = [
+            np.asarray(tp, dtype=np.float64) for tp in target_positions_list]
+        target_rot_arrays = [
+            np.asarray(tr, dtype=np.float64) for tr in target_rotations_list]
+        if len(target_pos_arrays) != n_tasks:
+            raise ValueError(
+                "target_positions_list length {} does not match n_tasks={}"
+                .format(len(target_pos_arrays), n_tasks))
+        n_targets = target_pos_arrays[0].shape[0]
+        for t in range(n_tasks):
+            if target_pos_arrays[t].shape != (n_targets, 3):
+                raise ValueError(
+                    "target_positions_list[{}] must be shape (N, 3), got {}"
+                    .format(t, target_pos_arrays[t].shape))
+            if target_rot_arrays[t].shape != (n_targets, 3, 3):
+                raise ValueError(
+                    "target_rotations_list[{}] must be shape (N, 3, 3), got {}"
+                    .format(t, target_rot_arrays[t].shape))
+
+        # Per-task masks. Treat as per-task when ``val`` is a list of length
+        # n_tasks AND is not interpretable as a single 3-axis mask. A flat
+        # list of 3 scalar bools/ints when n_tasks == 3 is ambiguous; we
+        # favor the single-mask interpretation for back-compat and require
+        # callers to wrap per-task masks in a nested list in that case.
+        _scalar_types = (
+            bool, int, float, np.integer, np.floating, np.bool_)
+
+        def _to_per_task(val, default):
+            if val is None:
+                return [default] * n_tasks
+            if isinstance(val, list) and len(val) == n_tasks:
+                if n_tasks == 3 and all(
+                        isinstance(v, _scalar_types) for v in val):
+                    # Looks like a single 3-axis mask; broadcast to tasks.
+                    return [val] * n_tasks
+                return list(val)
+            return [val] * n_tasks
+        pos_masks_per_task = _to_per_task(position_masks, True)
+        rot_masks_per_task = _to_per_task(rotation_masks, True)
+        if rotation_mirrors is None:
+            rot_mirrors_per_task = [None] * n_tasks
+        elif (isinstance(rotation_mirrors, list)
+              and len(rotation_mirrors) == n_tasks):
+            rot_mirrors_per_task = list(rotation_mirrors)
+        else:
+            rot_mirrors_per_task = [rotation_mirrors] * n_tasks
+
+        pos_mask_arrs = [normalize_axis_mask(m) for m in pos_masks_per_task]
+        rot_mask_arrs = [normalize_axis_mask(m) for m in rot_masks_per_task]
+        mirror_rots = [
+            _create_mirror_rotation_matrix(m) for m in rot_mirrors_per_task]
+
+        # Task weights
+        if task_weights is None:
+            weights = np.ones(n_tasks, dtype=np.float64)
+        else:
+            weights = np.asarray(task_weights, dtype=np.float64)
+            if weights.shape != (n_tasks,):
+                raise ValueError(
+                    "task_weights must have shape ({},), got {}"
+                    .format(n_tasks, weights.shape))
+            if np.any(weights < 0):
+                raise ValueError("task_weights must be non-negative")
+        sqrt_weights = np.sqrt(weights)
+
+        # Per-task active rows
+        active_rows_per_task = []
+        for t in range(n_tasks):
+            rows = []
+            pm = pos_mask_arrs[t]
+            rm = rot_mask_arrs[t]
+            if np.sum(pm) > 0:
+                for i in range(3):
+                    if pm[i] > 0:
+                        rows.append(i)
+            if np.sum(rm) > 0:
+                rows.extend([3, 4, 5])
+            active_rows_per_task.append(np.array(rows, dtype=np.int32))
+
+        # A task contributes to the DLS update only when it has both active
+        # rows and a non-zero weight. Zero-weight tasks are retained for
+        # success bookkeeping but skipped during optimization.
+        contributes = np.array(
+            [len(active_rows_per_task[t]) > 0 and weights[t] > 0
+             for t in range(n_tasks)], dtype=bool)
+        total_active = int(sum(
+            len(active_rows_per_task[t])
+            for t in range(n_tasks) if contributes[t]))
+        if total_active == 0:
+            raise ValueError(
+                "Multi-EE batch IK has no active, non-zero-weight tasks "
+                "to solve: every task is either fully masked out or has "
+                "task_weight == 0.")
+
+        damping_eye = damping * np.eye(total_active)
+
+        # Handle attempts_per_pose
+        if attempts_per_pose > 1:
+            target_pos_expanded = [
+                np.repeat(tp, attempts_per_pose, axis=0)
+                for tp in target_pos_arrays]
+            target_rot_expanded = [
+                np.repeat(tr, attempts_per_pose, axis=0)
+                for tr in target_rot_arrays]
+            n_expanded = n_targets * attempts_per_pose
+            if initial_angles is not None and use_current_angles:
+                init_angles = np.asarray(initial_angles)
+                if init_angles.ndim == 1:
+                    init_angles = np.tile(init_angles, (n_targets, 1))
+                init_opt = np.zeros((n_expanded, union_n_opt))
+                for it in range(n_targets):
+                    init_opt[it * attempts_per_pose] = init_angles[it]
+                    for a in range(1, attempts_per_pose):
+                        idx = it * attempts_per_pose + a
+                        init_opt[idx] = np.random.uniform(
+                            joint_limits_lower, joint_limits_upper)
+            else:
+                init_opt = np.random.uniform(
+                    joint_limits_lower, joint_limits_upper,
+                    (n_expanded, union_n_opt))
+        else:
+            target_pos_expanded = target_pos_arrays
+            target_rot_expanded = target_rot_arrays
+            n_expanded = n_targets
+            if initial_angles is not None:
+                init_angles = np.asarray(initial_angles)
+                if init_angles.ndim == 1:
+                    init_angles = np.tile(init_angles, (n_targets, 1))
+                if init_angles.shape != (n_targets, union_n_opt):
+                    raise ValueError(
+                        "initial_angles must have shape ({}, {}), got {}"
+                        .format(n_targets, union_n_opt, init_angles.shape))
+                init_opt = init_angles.copy()
+            else:
+                init_opt = np.random.uniform(
+                    joint_limits_lower, joint_limits_upper,
+                    (n_expanded, union_n_opt))
+
+        opt_angles = init_opt.copy()
+
+        def _compute_task_err(rot, pos, target_pos, target_rot, pos_mask,
+                              rot_mask, mirror_rot):
+            """Compute 6D error (batch, 6) for one task at world frame."""
+            pos_err = (target_pos - pos) * pos_mask
+            has_rot = np.sum(rot_mask) > 0
+            if has_rot:
+                rot_T = np.transpose(rot, axes=(0, 2, 1))
+                r_diff = np.matmul(rot_T, target_rot)
+                rot_err_local = 0.5 * np.stack([
+                    r_diff[:, 2, 1] - r_diff[:, 1, 2],
+                    r_diff[:, 0, 2] - r_diff[:, 2, 0],
+                    r_diff[:, 1, 0] - r_diff[:, 0, 1]
+                ], axis=1)
+                if mirror_rot is not None:
+                    target_rot_m = target_rot @ mirror_rot
+                    r_diff_m = np.matmul(rot_T, target_rot_m)
+                    rot_err_local_m = 0.5 * np.stack([
+                        r_diff_m[:, 2, 1] - r_diff_m[:, 1, 2],
+                        r_diff_m[:, 0, 2] - r_diff_m[:, 2, 0],
+                        r_diff_m[:, 1, 0] - r_diff_m[:, 0, 1]
+                    ], axis=1)
+                    frob_direct = np.sum((target_rot - rot) ** 2, axis=(1, 2))
+                    frob_mirror = np.sum(
+                        (target_rot_m - rot) ** 2, axis=(1, 2))
+                    use_mirror = (frob_mirror < 0.8 * frob_direct)[:, None]
+                    rot_err_local = np.where(
+                        use_mirror, rot_err_local_m, rot_err_local)
+                rot_err_local *= rot_mask
+                rot_err_world = np.einsum('bij,bj->bi', rot, rot_err_local)
+            else:
+                rot_err_world = np.zeros_like(pos_err)
+            return np.concatenate([pos_err, rot_err_world], axis=1)
+
+        # Main DLS iteration
+        for _iter in range(max_iterations):
+            J_rows = []
+            err_rows = []
+            for t in range(n_tasks):
+                if not contributes[t]:
+                    continue
+                J_union_t, pos_t, rot_t = _compute_task_jacobian_and_pose(
+                    opt_angles, task_info[t])
+                full_err_t = _compute_task_err(
+                    rot_t, pos_t,
+                    target_pos_expanded[t], target_rot_expanded[t],
+                    pos_mask_arrs[t], rot_mask_arrs[t], mirror_rots[t])
+                rows_t = active_rows_per_task[t]
+                J_sel = J_union_t[:, rows_t, :]  # (batch, len(rows), union)
+                e_sel = full_err_t[:, rows_t]    # (batch, len(rows))
+                w = sqrt_weights[t]
+                J_rows.append(w * J_sel)
+                err_rows.append(w * e_sel)
+
+            J_stack = np.concatenate(J_rows, axis=1)
+            err_stack = np.concatenate(err_rows, axis=1)
+
+            JJT = np.matmul(
+                J_stack, np.transpose(J_stack, (0, 2, 1))) + damping_eye
+            solved = np.linalg.solve(
+                JJT, err_stack[..., np.newaxis]).squeeze(-1)
+            delta_q = np.einsum('bji,bj->bi', J_stack, solved)
+
+            opt_angles = opt_angles + delta_q
+            opt_angles = np.clip(
+                opt_angles, joint_limits_lower, joint_limits_upper)
+
+        # Final error evaluation per task (unweighted) for success determination
+        pos_errs = np.zeros((n_expanded, n_tasks))
+        rot_errs = np.zeros((n_expanded, n_tasks))
+        combined_weighted = np.zeros(n_expanded)
+        per_task_success = np.ones((n_expanded, n_tasks), dtype=bool)
+        for t in range(n_tasks):
+            info = task_info[t]
+            mapping = info['union_mapping']
+            task_opt = opt_angles[:, mapping]
+            task_full = _expand_task_full_angles(task_opt, info)
+            pos_f, rot_f = forward_kinematics_ee_batched_numpy(
+                task_full, info['fk_params'])
+            pm = pos_mask_arrs[t]
+            rm = rot_mask_arrs[t]
+            mirror_rot = mirror_rots[t]
+            has_pos = np.sum(pm) > 0
+            has_rot = np.sum(rm) > 0
+            if has_pos:
+                pe = np.sqrt(np.sum(
+                    ((target_pos_expanded[t] - pos_f) * pm) ** 2, axis=1))
+            else:
+                pe = np.zeros(n_expanded)
+            if has_rot:
+                rot_T = np.transpose(rot_f, axes=(0, 2, 1))
+                r_diff = np.matmul(rot_T, target_rot_expanded[t])
+                rel = 0.5 * np.stack([
+                    r_diff[:, 2, 1] - r_diff[:, 1, 2],
+                    r_diff[:, 0, 2] - r_diff[:, 2, 0],
+                    r_diff[:, 1, 0] - r_diff[:, 0, 1]
+                ], axis=1) * rm
+                re = np.sqrt(np.sum(rel ** 2, axis=1))
+                if mirror_rot is not None:
+                    target_rot_m = target_rot_expanded[t] @ mirror_rot
+                    r_diff_m = np.matmul(rot_T, target_rot_m)
+                    rel_m = 0.5 * np.stack([
+                        r_diff_m[:, 2, 1] - r_diff_m[:, 1, 2],
+                        r_diff_m[:, 0, 2] - r_diff_m[:, 2, 0],
+                        r_diff_m[:, 1, 0] - r_diff_m[:, 0, 1]
+                    ], axis=1) * rm
+                    re_m = np.sqrt(np.sum(rel_m ** 2, axis=1))
+                    re = np.minimum(re, re_m)
+            else:
+                re = np.zeros(n_expanded)
+            pos_errs[:, t] = pe
+            rot_errs[:, t] = re
+            combined_weighted += weights[t] * (pe + re)
+            if weights[t] == 0:
+                # Zero-weighted tasks do not participate in optimization and
+                # should not gate success either.
+                continue
+            if has_pos and has_rot:
+                per_task_success[:, t] = (
+                    (pe < pos_threshold) & (re < rot_threshold))
+            elif has_pos:
+                per_task_success[:, t] = pe < pos_threshold
+            elif has_rot:
+                per_task_success[:, t] = re < rot_threshold
+            # else: stays True
+
+        success = np.all(per_task_success, axis=1)
+
+        # Attempts-per-pose selection
+        if attempts_per_pose > 1:
+            opt_rs = opt_angles.reshape(n_targets, attempts_per_pose, union_n_opt)
+            success_rs = success.reshape(n_targets, attempts_per_pose)
+            err_rs = combined_weighted.reshape(n_targets, attempts_per_pose)
+            best_idx = np.zeros(n_targets, dtype=np.int32)
+            for i in range(n_targets):
+                if np.any(success_rs[i]):
+                    cands = np.where(success_rs[i])[0]
+                    best_idx[i] = cands[np.argmin(err_rs[i, cands])]
+                else:
+                    best_idx[i] = np.argmin(err_rs[i])
+            solutions_out = opt_rs[np.arange(n_targets), best_idx]
+            success_out = success_rs[np.arange(n_targets), best_idx]
+            errors_out = err_rs[np.arange(n_targets), best_idx]
+            return solutions_out, success_out, errors_out
+
+        return opt_angles, success, combined_weighted
+
+    solve.union_n_opt = union_n_opt
+    solve.joint_limits_lower = joint_limits_lower
+    solve.joint_limits_upper = joint_limits_upper
+    solve.fk_params_list = fk_params_list
+    solve.union_info = union_info
+    solve.n_tasks = n_tasks
+    solve.backend_name = 'numpy'
+    solve.multi_ee = True
 
     return solve
 
@@ -2446,6 +2981,29 @@ def create_batch_ik_solver(robot_model, link_list, move_target,
     import numpy as np
 
     from skrobot.backend import get_backend
+
+    # Detect multi-EE mode: link_list is a list of link_lists and
+    # move_target is a list of end-effector coords (same length).
+    is_multi_ee = (isinstance(link_list, list) and len(link_list) > 0
+                   and isinstance(link_list[0], list))
+    if is_multi_ee:
+        if not (isinstance(move_target, list)
+                and len(move_target) == len(link_list)):
+            raise ValueError(
+                "For multi-EE batch IK, move_target must be a list of the "
+                "same length as link_list (got move_target type "
+                "{} with length {}, link_list length {})"
+                .format(type(move_target).__name__,
+                        len(move_target) if hasattr(move_target, '__len__') else 'N/A',
+                        len(link_list)))
+        fk_params_list = [extract_fk_parameters(robot_model, ll, mt)
+                          for ll, mt in zip(link_list, move_target)]
+        union_info = _build_union_joint_mapping(link_list, fk_params_list)
+        if backend_name == 'numpy':
+            return _create_numpy_multi_ee_solver(fk_params_list, union_info)
+        raise NotImplementedError(
+            "Multi-EE batch IK on backend {!r} is not yet implemented; "
+            "use backend_name='numpy'.".format(backend_name))
 
     # Extract FK parameters
     fk_params = extract_fk_parameters(robot_model, link_list, move_target)

--- a/skrobot/kinematics/differentiable.py
+++ b/skrobot/kinematics/differentiable.py
@@ -2252,6 +2252,567 @@ def _create_numpy_multi_ee_solver(fk_params_list, union_info):
     return solve
 
 
+def _create_jax_multi_ee_solver(fk_params_list, union_info):
+    """Create a JAX multi-end-effector batch IK solver.
+
+    Structural twin of :func:`_create_numpy_multi_ee_solver` that performs
+    the per-iteration damped least-squares update under JIT compilation
+    with ``jax.lax.fori_loop``. Task count, per-task kinematic chains, and
+    per-task masks are static at trace time, so the per-task work unrolls
+    into the JIT graph the same way the single-EE JAX solver unrolls its
+    per-joint loops.
+
+    Parameters
+    ----------
+    fk_params_list : list of dict
+        One FK parameter dict per task (from :func:`extract_fk_parameters`).
+    union_info : dict
+        Output of :func:`_build_union_joint_mapping`.
+
+    Returns
+    -------
+    callable
+        ``solve(target_positions_list, target_rotations_list, ...)`` with
+        the same signature and return shapes as the NumPy multi-EE solver.
+    """
+    import jax
+    from jax import lax
+    import jax.numpy as jnp
+
+    n_tasks = len(fk_params_list)
+    task_mappings = union_info['task_mappings']
+    union_n_opt = union_info['union_n_opt']
+    joint_limits_lower = jnp.array(union_info['union_joint_limits_lower'])
+    joint_limits_upper = jnp.array(union_info['union_joint_limits_upper'])
+
+    # Per-task precomputed structural constants. Everything below depends
+    # only on the kinematic chain (link_list, move_target) and is safe to
+    # capture in JIT closures.
+    task_static = []
+    for t, fk_params in enumerate(fk_params_list):
+        n_joints = fk_params['n_joints']
+        (m_parent, m_mult, m_off, non_mimic, n_opt) = _get_mimic_joint_info(
+            fk_params)
+        # Precompute vectorized mimic expansion indices; disallow
+        # mimic-of-mimic chains (URDF does not permit them).
+        m_parent_int = np.asarray(m_parent, dtype=np.int64)
+        mimic_mask = m_parent_int >= 0
+        mimic_child_idx = np.where(mimic_mask)[0]
+        if mimic_child_idx.size > 0:
+            parent_of_mimic = m_parent_int[mimic_child_idx]
+            if np.any(mimic_mask[parent_of_mimic]):
+                bad = mimic_child_idx[mimic_mask[parent_of_mimic]]
+                raise ValueError(
+                    "Multi-EE batch IK (JAX) does not support mimic-of-"
+                    "mimic chains (task {}, child indices {}).".format(
+                        t, bad.tolist()))
+
+        # JAX arrays of per-joint FK constants
+        translations = [jnp.array(fk_params['link_translations'][i])
+                        for i in range(n_joints)]
+        local_rotations = [jnp.array(fk_params['link_rotations'][i])
+                           for i in range(n_joints)]
+        axes = [jnp.array(fk_params['joint_axes'][i])
+                for i in range(n_joints)]
+        base_pos = jnp.array(fk_params['base_position'])
+        base_rot = jnp.array(fk_params['base_rotation'])
+        ref_angles = fk_params['ref_angles']
+        joint_types = fk_params['joint_types']
+        ee_offset_pos = jnp.array(fk_params['ee_offset_position'])
+        ee_offset_rot = jnp.array(fk_params['ee_offset_rotation'])
+
+        # Precompute Rodrigues rotation-axis basis matrices per joint
+        joint_K = []
+        joint_K2 = []
+        for i in range(n_joints):
+            axis = np.array(fk_params['joint_axes'][i])
+            axis_norm = axis / (np.linalg.norm(axis) + 1e-10)
+            K = np.array([
+                [0, -axis_norm[2], axis_norm[1]],
+                [axis_norm[2], 0, -axis_norm[0]],
+                [-axis_norm[1], axis_norm[0], 0]
+            ])
+            joint_K.append(jnp.array(K))
+            joint_K2.append(jnp.array(K @ K))
+
+        # Static Python copies for trace-time conditionals
+        mimic_parents_py = [int(m_parent[i]) for i in range(n_joints)]
+        mimic_mults_py = [float(m_mult[i]) for i in range(n_joints)]
+        mimic_offs_py = [float(m_off[i]) for i in range(n_joints)]
+        full_to_opt = {}
+        for opt_idx, full_idx in enumerate(non_mimic):
+            full_to_opt[int(full_idx)] = opt_idx
+
+        non_mimic_jax = jnp.array(non_mimic.astype(np.int32))
+        mapping_jax = jnp.array(task_mappings[t].astype(np.int32))
+
+        task_static.append({
+            'n_joints': n_joints,
+            'n_opt': n_opt,
+            'translations': translations,
+            'local_rotations': local_rotations,
+            'axes': axes,
+            'base_pos': base_pos,
+            'base_rot': base_rot,
+            'ref_angles': ref_angles,
+            'joint_types': joint_types,
+            'ee_offset_pos': ee_offset_pos,
+            'ee_offset_rot': ee_offset_rot,
+            'joint_K': joint_K,
+            'joint_K2': joint_K2,
+            'mimic_parents_py': mimic_parents_py,
+            'mimic_mults_py': mimic_mults_py,
+            'mimic_offs_py': mimic_offs_py,
+            'full_to_opt': full_to_opt,
+            'non_mimic_jax': non_mimic_jax,
+            'mapping_jax': mapping_jax,
+        })
+
+    _jit_cache = {}
+
+    def _create_solver_fn(max_iterations, damping, pos_threshold,
+                          rot_threshold, pos_mask_arrs, rot_mask_arrs,
+                          rotation_mirrors, task_weights_tuple):
+        """Create a JIT-compiled multi-EE solver for a given configuration."""
+        # Per-task mask arrays as JAX (static at graph build)
+        pos_masks = [jnp.array(m) for m in pos_mask_arrs]
+        rot_masks = [jnp.array(m) for m in rot_mask_arrs]
+
+        # Per-task mirror rotations (may be None)
+        mirror_rots = []
+        for m in rotation_mirrors:
+            mr_np = _create_mirror_rotation_matrix(m)
+            mirror_rots.append(jnp.array(mr_np) if mr_np is not None else None)
+
+        # Derive per-task active Jacobian rows (static at graph build)
+        active_rows_per_task = []
+        has_pos_per_task = []
+        has_rot_per_task = []
+        for t in range(n_tasks):
+            pm = pos_mask_arrs[t]
+            rm = rot_mask_arrs[t]
+            has_pos = float(np.sum(pm)) > 0
+            has_rot = float(np.sum(rm)) > 0
+            rows = []
+            if has_pos:
+                for i in range(3):
+                    if pm[i] > 0:
+                        rows.append(i)
+            if has_rot:
+                rows.extend([3, 4, 5])
+            active_rows_per_task.append(rows)
+            has_pos_per_task.append(has_pos)
+            has_rot_per_task.append(has_rot)
+
+        weights = np.asarray(task_weights_tuple, dtype=np.float64)
+        sqrt_weights = [float(np.sqrt(w)) for w in weights]
+
+        # A task contributes only if it has both active rows and weight > 0.
+        contrib_tasks = [
+            t for t in range(n_tasks)
+            if len(active_rows_per_task[t]) > 0 and weights[t] > 0]
+        total_active = sum(
+            len(active_rows_per_task[t]) for t in contrib_tasks)
+        if total_active == 0:
+            raise ValueError(
+                "Multi-EE batch IK (JAX) has no active, non-zero-weight "
+                "tasks to solve: every task is either fully masked out or "
+                "has task_weight == 0.")
+
+        # Per-contributing-task row slice in the stacked system
+        row_ranges = {}
+        cursor = 0
+        for t in contrib_tasks:
+            nrows = len(active_rows_per_task[t])
+            row_ranges[t] = (cursor, cursor + nrows)
+            cursor += nrows
+
+        active_rows_jax = {
+            t: jnp.array(active_rows_per_task[t], dtype=jnp.int32)
+            for t in contrib_tasks
+        }
+
+        damping_eye = damping * jnp.eye(total_active)
+
+        def _compute_task_jac_local(opt_angles_batch, ts):
+            """Task-local Jacobian + pose from union opt angles."""
+            batch_size = opt_angles_batch.shape[0]
+            n_joints = ts['n_joints']
+            n_opt = ts['n_opt']
+
+            # Expand union opt -> task full angles.
+            task_opt = opt_angles_batch[:, ts['mapping_jax']]
+            full_angles = jnp.zeros((batch_size, n_joints))
+            full_angles = full_angles.at[:, ts['non_mimic_jax']].set(task_opt)
+            for i in range(n_joints):
+                if ts['mimic_parents_py'][i] >= 0:
+                    full_angles = full_angles.at[:, i].set(
+                        full_angles[:, ts['mimic_parents_py'][i]]
+                        * ts['mimic_mults_py'][i]
+                        + ts['mimic_offs_py'][i])
+
+            current_pos = jnp.tile(ts['base_pos'], (batch_size, 1))
+            current_rot = jnp.tile(ts['base_rot'], (batch_size, 1, 1))
+            joint_positions = []
+            joint_axes_world = []
+            for i in range(n_joints):
+                current_pos = current_pos + jnp.einsum(
+                    'bij,j->bi', current_rot, ts['translations'][i])
+                current_rot = jnp.einsum(
+                    'bij,jk->bik', current_rot, ts['local_rotations'][i])
+                joint_positions.append(current_pos)
+                joint_axes_world.append(jnp.einsum(
+                    'bij,j->bi', current_rot, ts['axes'][i]))
+                delta = full_angles[:, i] - ts['ref_angles'][i]
+                if ts['joint_types'][i] == 'prismatic':
+                    current_pos = current_pos + jnp.einsum(
+                        'bij,j,b->bi', current_rot, ts['axes'][i], delta)
+                else:
+                    c = jnp.cos(delta)[:, None, None]
+                    s = jnp.sin(delta)[:, None, None]
+                    joint_rots = (jnp.eye(3) + s * ts['joint_K'][i]
+                                  + (1 - c) * ts['joint_K2'][i])
+                    current_rot = jnp.einsum(
+                        'bij,bjk->bik', current_rot, joint_rots)
+
+            ee_pos = current_pos + jnp.einsum(
+                'bij,j->bi', current_rot, ts['ee_offset_pos'])
+            ee_rot = jnp.einsum(
+                'bij,jk->bik', current_rot, ts['ee_offset_rot'])
+
+            J_v = jnp.zeros((batch_size, 3, n_joints))
+            J_w = jnp.zeros((batch_size, 3, n_joints))
+            for i in range(n_joints):
+                z_i = joint_axes_world[i]
+                p_i = joint_positions[i]
+                if ts['joint_types'][i] in ('revolute', 'continuous'):
+                    jv = jnp.cross(z_i, ee_pos - p_i)
+                    jw = z_i
+                else:
+                    jv = z_i
+                    jw = jnp.zeros_like(z_i)
+                J_v = J_v.at[:, :, i].set(jv)
+                J_w = J_w.at[:, :, i].set(jw)
+            J_full = jnp.concatenate([J_v, J_w], axis=1)
+
+            # Fold mimic contributions into opt columns
+            J_opt = jnp.zeros((batch_size, 6, n_opt))
+            for i in range(n_joints):
+                if ts['mimic_parents_py'][i] < 0:
+                    opt_idx = ts['full_to_opt'][i]
+                    J_opt = J_opt.at[:, :, opt_idx].add(J_full[:, :, i])
+                else:
+                    parent = ts['mimic_parents_py'][i]
+                    if parent in ts['full_to_opt']:
+                        opt_idx = ts['full_to_opt'][parent]
+                        J_opt = J_opt.at[:, :, opt_idx].add(
+                            ts['mimic_mults_py'][i] * J_full[:, :, i])
+            return J_opt, ee_pos, ee_rot
+
+        def _task_world_err(pos, rot, target_pos, target_rot,
+                            pos_mask, rot_mask, mirror_rot, has_rot):
+            """6D world-frame residual (batch, 6) for one task."""
+            pos_err = (target_pos - pos) * pos_mask
+            if has_rot:
+                rot_err_local = rotation_error_so3_log_batch(rot, target_rot)
+                if mirror_rot is not None:
+                    target_rot_m = target_rot @ mirror_rot
+                    rot_err_local_m = rotation_error_so3_log_batch(
+                        rot, target_rot_m)
+                    frob_direct = jnp.sum((target_rot - rot) ** 2, axis=(1, 2))
+                    frob_mirror = jnp.sum(
+                        (target_rot_m - rot) ** 2, axis=(1, 2))
+                    use_mirror = (frob_mirror < 0.8 * frob_direct)[:, None]
+                    rot_err_local = jnp.where(
+                        use_mirror, rot_err_local_m, rot_err_local)
+                rot_err_local_masked = rot_err_local * rot_mask
+                rot_err_world = jnp.einsum(
+                    'bij,bj->bi', rot, rot_err_local_masked)
+            else:
+                rot_err_world = jnp.zeros_like(pos_err)
+            return jnp.concatenate([pos_err, rot_err_world], axis=1)
+
+        def solve_batched(init_opt_angles, target_positions_stack,
+                          target_rotations_stack):
+            """Run the DLS loop.
+
+            target_positions_stack: (n_tasks, batch, 3)
+            target_rotations_stack: (n_tasks, batch, 3, 3)
+            """
+
+            def body_fn(_, opt_angles):
+                J_rows = []
+                err_rows = []
+                for t in contrib_tasks:
+                    ts = task_static[t]
+                    J_opt_t, pos_t, rot_t = _compute_task_jac_local(
+                        opt_angles, ts)
+                    target_pos_t = target_positions_stack[t]
+                    target_rot_t = target_rotations_stack[t]
+                    full_err_t = _task_world_err(
+                        pos_t, rot_t, target_pos_t, target_rot_t,
+                        pos_masks[t], rot_masks[t], mirror_rots[t],
+                        has_rot_per_task[t])
+                    rows_idx = active_rows_jax[t]
+                    J_sel = J_opt_t[:, rows_idx, :]
+                    e_sel = full_err_t[:, rows_idx]
+                    w = sqrt_weights[t]
+                    # Scatter task-local Jacobian columns into the union
+                    # column positions.
+                    batch = J_sel.shape[0]
+                    n_rows = J_sel.shape[1]
+                    J_slice_union = jnp.zeros((batch, n_rows, union_n_opt))
+                    J_slice_union = J_slice_union.at[:, :, ts['mapping_jax']].set(
+                        w * J_sel)
+                    J_rows.append(J_slice_union)
+                    err_rows.append(w * e_sel)
+
+                J_stack = jnp.concatenate(J_rows, axis=1)
+                err_stack = jnp.concatenate(err_rows, axis=1)
+
+                JJT = jnp.matmul(
+                    J_stack, jnp.transpose(J_stack, (0, 2, 1))) + damping_eye
+                solved = jnp.linalg.solve(
+                    JJT, err_stack[..., jnp.newaxis]).squeeze(-1)
+                delta_q = jnp.einsum('bji,bj->bi', J_stack, solved)
+                new_opt = opt_angles + delta_q
+                new_opt = jnp.clip(
+                    new_opt, joint_limits_lower, joint_limits_upper)
+                return new_opt
+
+            final_opt = lax.fori_loop(
+                0, max_iterations, body_fn, init_opt_angles)
+
+            # Per-task final error for success/error reporting.
+            batch = init_opt_angles.shape[0]
+            combined_weighted = jnp.zeros(batch)
+            per_task_success_stack = []
+            for t in range(n_tasks):
+                ts = task_static[t]
+                _, pos_f, rot_f = _compute_task_jac_local(final_opt, ts)
+                target_pos_t = target_positions_stack[t]
+                target_rot_t = target_rotations_stack[t]
+                has_pos = has_pos_per_task[t]
+                has_rot = has_rot_per_task[t]
+                if has_pos:
+                    pe = jnp.sqrt(jnp.sum(
+                        ((target_pos_t - pos_f) * pos_masks[t]) ** 2, axis=1))
+                else:
+                    pe = jnp.zeros(batch)
+                if has_rot:
+                    rel = rotation_error_so3_log_batch(rot_f, target_rot_t)
+                    rel_masked = rel * rot_masks[t]
+                    re = jnp.sqrt(jnp.sum(rel_masked ** 2, axis=1))
+                    if mirror_rots[t] is not None:
+                        target_rot_m = target_rot_t @ mirror_rots[t]
+                        rel_m = rotation_error_so3_log_batch(
+                            rot_f, target_rot_m)
+                        re_m = jnp.sqrt(jnp.sum(
+                            (rel_m * rot_masks[t]) ** 2, axis=1))
+                        re = jnp.minimum(re, re_m)
+                else:
+                    re = jnp.zeros(batch)
+                combined_weighted = combined_weighted + float(weights[t]) * (pe + re)
+                if weights[t] == 0:
+                    per_task_success_stack.append(
+                        jnp.ones(batch, dtype=bool))
+                    continue
+                if has_pos and has_rot:
+                    ok = (pe < pos_threshold) & (re < rot_threshold)
+                elif has_pos:
+                    ok = pe < pos_threshold
+                elif has_rot:
+                    ok = re < rot_threshold
+                else:
+                    ok = jnp.ones(batch, dtype=bool)
+                per_task_success_stack.append(ok)
+
+            success = jnp.all(
+                jnp.stack(per_task_success_stack, axis=0), axis=0)
+            return final_opt, success, combined_weighted
+
+        return jax.jit(solve_batched)
+
+    def solve(target_positions_list, target_rotations_list,
+              initial_angles=None,
+              max_iterations=30,
+              damping=0.01,
+              pos_threshold=0.001,
+              rot_threshold=0.1,
+              position_masks=True,
+              rotation_masks=True,
+              rotation_mirrors=None,
+              task_weights=None,
+              attempts_per_pose=1,
+              use_current_angles=True,
+              select_closest_to_initial=False,
+              **kwargs):
+        """Solve multi-EE batch IK on JAX.
+
+        Signature mirrors :func:`_create_numpy_multi_ee_solver`'s ``solve``.
+        """
+        # Normalize inputs.
+        target_pos_arrays = [
+            np.asarray(tp, dtype=np.float64) for tp in target_positions_list]
+        target_rot_arrays = [
+            np.asarray(tr, dtype=np.float64) for tr in target_rotations_list]
+        if len(target_pos_arrays) != n_tasks:
+            raise ValueError(
+                "target_positions_list length {} does not match n_tasks={}"
+                .format(len(target_pos_arrays), n_tasks))
+        n_targets = target_pos_arrays[0].shape[0]
+        for t in range(n_tasks):
+            if target_pos_arrays[t].shape != (n_targets, 3):
+                raise ValueError(
+                    "target_positions_list[{}] must be shape (N, 3), got {}"
+                    .format(t, target_pos_arrays[t].shape))
+            if target_rot_arrays[t].shape != (n_targets, 3, 3):
+                raise ValueError(
+                    "target_rotations_list[{}] must be shape (N, 3, 3), got {}"
+                    .format(t, target_rot_arrays[t].shape))
+
+        # Per-task masks / mirrors (same rule as NumPy path).
+        _scalar_types = (
+            bool, int, float, np.integer, np.floating, np.bool_)
+
+        def _to_per_task(val, default):
+            if val is None:
+                return [default] * n_tasks
+            if isinstance(val, list) and len(val) == n_tasks:
+                if n_tasks == 3 and all(
+                        isinstance(v, _scalar_types) for v in val):
+                    return [val] * n_tasks
+                return list(val)
+            return [val] * n_tasks
+
+        pos_masks_per_task = _to_per_task(position_masks, True)
+        rot_masks_per_task = _to_per_task(rotation_masks, True)
+        if rotation_mirrors is None:
+            rot_mirrors_per_task = [None] * n_tasks
+        elif (isinstance(rotation_mirrors, list)
+              and len(rotation_mirrors) == n_tasks):
+            rot_mirrors_per_task = list(rotation_mirrors)
+        else:
+            rot_mirrors_per_task = [rotation_mirrors] * n_tasks
+
+        pos_mask_arrs = [normalize_axis_mask(m) for m in pos_masks_per_task]
+        rot_mask_arrs = [normalize_axis_mask(m) for m in rot_masks_per_task]
+
+        if task_weights is None:
+            weights = np.ones(n_tasks, dtype=np.float64)
+        else:
+            weights = np.asarray(task_weights, dtype=np.float64)
+            if weights.shape != (n_tasks,):
+                raise ValueError(
+                    "task_weights must have shape ({},), got {}"
+                    .format(n_tasks, weights.shape))
+            if np.any(weights < 0):
+                raise ValueError("task_weights must be non-negative")
+
+        # Resolve initial angles in union opt space.
+        lower_np = np.asarray(union_info['union_joint_limits_lower'])
+        upper_np = np.asarray(union_info['union_joint_limits_upper'])
+
+        if attempts_per_pose > 1:
+            target_pos_expanded = [
+                np.repeat(tp, attempts_per_pose, axis=0)
+                for tp in target_pos_arrays]
+            target_rot_expanded = [
+                np.repeat(tr, attempts_per_pose, axis=0)
+                for tr in target_rot_arrays]
+            n_expanded = n_targets * attempts_per_pose
+            if initial_angles is not None and use_current_angles:
+                init_angles = np.asarray(initial_angles)
+                if init_angles.ndim == 1:
+                    init_angles = np.tile(init_angles, (n_targets, 1))
+                init_opt = np.zeros((n_expanded, union_n_opt))
+                for it in range(n_targets):
+                    init_opt[it * attempts_per_pose] = init_angles[it]
+                    for a in range(1, attempts_per_pose):
+                        idx = it * attempts_per_pose + a
+                        init_opt[idx] = np.random.uniform(lower_np, upper_np)
+            else:
+                init_opt = np.random.uniform(
+                    lower_np, upper_np, (n_expanded, union_n_opt))
+        else:
+            target_pos_expanded = target_pos_arrays
+            target_rot_expanded = target_rot_arrays
+            n_expanded = n_targets
+            if initial_angles is not None:
+                init_angles = np.asarray(initial_angles)
+                if init_angles.ndim == 1:
+                    init_angles = np.tile(init_angles, (n_targets, 1))
+                if init_angles.shape != (n_targets, union_n_opt):
+                    raise ValueError(
+                        "initial_angles must have shape ({}, {}), got {}"
+                        .format(n_targets, union_n_opt, init_angles.shape))
+                init_opt = init_angles.copy()
+            else:
+                init_opt = np.random.uniform(
+                    lower_np, upper_np, (n_expanded, union_n_opt))
+
+        # Stack targets for JAX: (n_tasks, batch, 3) and (n_tasks, batch, 3, 3)
+        target_pos_stack = jnp.stack(
+            [jnp.array(p.astype(np.float64)) for p in target_pos_expanded],
+            axis=0)
+        target_rot_stack = jnp.stack(
+            [jnp.array(r.astype(np.float64)) for r in target_rot_expanded],
+            axis=0)
+        init_opt_jax = jnp.array(init_opt.astype(np.float64))
+
+        cache_key = (
+            max_iterations, damping, pos_threshold, rot_threshold,
+            tuple(tuple(pm) for pm in pos_mask_arrs),
+            tuple(tuple(rm) for rm in rot_mask_arrs),
+            tuple(rot_mirrors_per_task),
+            tuple(float(w) for w in weights),
+        )
+        if cache_key not in _jit_cache:
+            _jit_cache[cache_key] = _create_solver_fn(
+                max_iterations, damping, pos_threshold, rot_threshold,
+                pos_mask_arrs, rot_mask_arrs, rot_mirrors_per_task,
+                tuple(weights.tolist()))
+        solver_fn = _jit_cache[cache_key]
+
+        final_opt, success, combined_err = solver_fn(
+            init_opt_jax, target_pos_stack, target_rot_stack)
+
+        # Attempts-per-pose selection back on host.
+        if attempts_per_pose > 1:
+            opt_np = np.asarray(final_opt)
+            success_np = np.asarray(success)
+            err_np = np.asarray(combined_err)
+            opt_rs = opt_np.reshape(n_targets, attempts_per_pose, union_n_opt)
+            success_rs = success_np.reshape(n_targets, attempts_per_pose)
+            err_rs = err_np.reshape(n_targets, attempts_per_pose)
+            best_idx = np.zeros(n_targets, dtype=np.int32)
+            for i in range(n_targets):
+                if np.any(success_rs[i]):
+                    cands = np.where(success_rs[i])[0]
+                    best_idx[i] = cands[np.argmin(err_rs[i, cands])]
+                else:
+                    best_idx[i] = np.argmin(err_rs[i])
+            sols = opt_rs[np.arange(n_targets), best_idx]
+            succ = success_rs[np.arange(n_targets), best_idx]
+            errs = err_rs[np.arange(n_targets), best_idx]
+            return sols, succ, errs
+
+        return (np.asarray(final_opt), np.asarray(success),
+                np.asarray(combined_err))
+
+    solve.union_n_opt = union_n_opt
+    solve.joint_limits_lower = np.asarray(
+        union_info['union_joint_limits_lower'])
+    solve.joint_limits_upper = np.asarray(
+        union_info['union_joint_limits_upper'])
+    solve.fk_params_list = fk_params_list
+    solve.union_info = union_info
+    solve.n_tasks = n_tasks
+    solve.backend_name = 'jax'
+    solve.multi_ee = True
+    return solve
+
+
 def compute_geometric_jacobian_jax(joint_angles, fk_params, return_non_mimic=True):
     """Compute the geometric Jacobian using JAX.
 
@@ -3034,9 +3595,11 @@ def create_batch_ik_solver(robot_model, link_list, move_target,
         union_info = _build_union_joint_mapping(link_list, fk_params_list)
         if backend_name == 'numpy':
             return _create_numpy_multi_ee_solver(fk_params_list, union_info)
+        if backend_name == 'jax':
+            return _create_jax_multi_ee_solver(fk_params_list, union_info)
         raise NotImplementedError(
             "Multi-EE batch IK on backend {!r} is not yet implemented; "
-            "use backend_name='numpy'.".format(backend_name))
+            "use backend_name='numpy' or 'jax'.".format(backend_name))
 
     # Extract FK parameters
     fk_params = extract_fk_parameters(robot_model, link_list, move_target)

--- a/skrobot/model/__init__.py
+++ b/skrobot/model/__init__.py
@@ -15,9 +15,11 @@ from skrobot.model.primitives import PointCloudLink
 from skrobot.model.primitives import Sphere
 
 from skrobot.model.joint import FixedJoint
+from skrobot.model.joint import FloatingJoint
 from skrobot.model.joint import Joint
 from skrobot.model.joint import LinearJoint
 from skrobot.model.joint import OmniWheelJoint
+from skrobot.model.joint import PlanarJoint
 from skrobot.model.joint import RotationalJoint
 
 from skrobot.model.joint import calc_angle_speed_gain_scalar

--- a/skrobot/model/joint.py
+++ b/skrobot/model/joint.py
@@ -700,6 +700,215 @@ class OmniWheelJoint(Joint):
         return jacobian
 
 
+class PlanarJoint(Joint):
+    """3-DoF virtual joint for a floating base constrained to a plane.
+
+    Joint angle vector layout: [x, y, yaw]. Intended as a virtual joint
+    inserted between the world and a robot's root_link so that fullbody
+    inverse kinematics can solve for base pose on flat ground.
+    """
+
+    def __init__(self,
+                 max_joint_velocity=(np.inf, np.inf, np.inf),
+                 max_joint_torque=(np.inf, np.inf, np.inf),
+                 min_angle=None,
+                 max_angle=None,
+                 *args, **kwargs):
+        if min_angle is None:
+            min_angle = np.array([-np.inf] * 3)
+        if max_angle is None:
+            max_angle = np.array([np.inf] * 3)
+        self.axis = ((1, 0, 0),
+                     (0, 1, 0),
+                     (0, 0, 1))
+        self._joint_angle = np.zeros(3, dtype=np.float64)
+        super(PlanarJoint, self).__init__(
+            max_joint_velocity=max_joint_velocity,
+            max_joint_torque=max_joint_torque,
+            min_angle=min_angle,
+            max_angle=max_angle,
+            *args, **kwargs)
+        self.joint_velocity = (0, 0, 0)
+        self.joint_acceleration = (0, 0, 0)
+        self.joint_torque = (0, 0, 0)
+
+    @property
+    def type(self):
+        return 'planar'
+
+    def joint_angle(self, v=None, relative=None, enable_hook=True):
+        if v is not None:
+            v = np.array(v, dtype=np.float64)
+            if relative is not None:
+                self._joint_angle = v + self._joint_angle
+            else:
+                self._joint_angle = v
+            self._joint_angle = np.minimum(
+                np.maximum(self._joint_angle, self.min_angle), self.max_angle)
+            self.child_link.rotation = self.default_coords.rotation.copy()
+            self.child_link.translation = \
+                self.default_coords.translation.copy()
+            self.child_link.translate(
+                (self._joint_angle[0], self._joint_angle[1], 0))
+            self.child_link.rotate(self._joint_angle[2], 'z')
+            if enable_hook:
+                for hook in self._hooks:
+                    hook()
+        return self._joint_angle
+
+    @property
+    def joint_dof(self):
+        return 3
+
+    def calc_angle_speed_gain(self, dav, i, periodic_time):
+        return calc_angle_speed_gain_vector(self, dav, i, periodic_time)
+
+    def calc_jacobian(self,
+                      jacobian, row, column,
+                      joint, paxis, child_link,
+                      world_default_coords,
+                      move_target, transform_coords,
+                      rotation_axis, translation_axis):
+        calc_jacobian_linear(jacobian, row, column + 0,
+                             joint, [1, 0, 0], child_link,
+                             world_default_coords,
+                             move_target, transform_coords,
+                             rotation_axis, translation_axis)
+        calc_jacobian_linear(jacobian, row, column + 1,
+                             joint, [0, 1, 0], child_link,
+                             world_default_coords,
+                             move_target, transform_coords,
+                             rotation_axis, translation_axis)
+        calc_jacobian_rotational(jacobian, row, column + 2,
+                                 joint, [0, 0, 1], child_link,
+                                 world_default_coords,
+                                 move_target, transform_coords,
+                                 rotation_axis, translation_axis)
+        return jacobian
+
+
+class FloatingJoint(Joint):
+    """6-DoF virtual joint for an unconstrained floating base.
+
+    Joint angle vector layout: [x, y, z, rx, ry, rz]. The rotational
+    part is applied as successive rotations about the child link's
+    local x, y, z axes (body-fixed XYZ Euler). Intended as a virtual
+    joint inserted between the world and a robot's root_link so that
+    fullbody inverse kinematics can solve for base pose on uneven
+    terrain (e.g. slopes).
+    """
+
+    def __init__(self,
+                 max_joint_velocity=(np.inf,) * 6,
+                 max_joint_torque=(np.inf,) * 6,
+                 min_angle=None,
+                 max_angle=None,
+                 *args, **kwargs):
+        if min_angle is None:
+            min_angle = np.array([-np.inf] * 6)
+        if max_angle is None:
+            max_angle = np.array([np.inf] * 6)
+        self.axis = ((1, 0, 0),
+                     (0, 1, 0),
+                     (0, 0, 1),
+                     (1, 0, 0),
+                     (0, 1, 0),
+                     (0, 0, 1))
+        self._joint_angle = np.zeros(6, dtype=np.float64)
+        super(FloatingJoint, self).__init__(
+            max_joint_velocity=max_joint_velocity,
+            max_joint_torque=max_joint_torque,
+            min_angle=min_angle,
+            max_angle=max_angle,
+            *args, **kwargs)
+        self.joint_velocity = (0,) * 6
+        self.joint_acceleration = (0,) * 6
+        self.joint_torque = (0,) * 6
+
+    @property
+    def type(self):
+        return 'floating'
+
+    def joint_angle(self, v=None, relative=None, enable_hook=True):
+        if v is not None:
+            v = np.array(v, dtype=np.float64)
+            if relative is not None:
+                self._joint_angle = v + self._joint_angle
+            else:
+                self._joint_angle = v
+            self._joint_angle = np.minimum(
+                np.maximum(self._joint_angle, self.min_angle), self.max_angle)
+            self.child_link.rotation = self.default_coords.rotation.copy()
+            self.child_link.translation = \
+                self.default_coords.translation.copy()
+            self.child_link.translate(
+                (self._joint_angle[0],
+                 self._joint_angle[1],
+                 self._joint_angle[2]))
+            self.child_link.rotate(self._joint_angle[3], 'x')
+            self.child_link.rotate(self._joint_angle[4], 'y')
+            self.child_link.rotate(self._joint_angle[5], 'z')
+            if enable_hook:
+                for hook in self._hooks:
+                    hook()
+        return self._joint_angle
+
+    @property
+    def joint_dof(self):
+        return 6
+
+    def calc_angle_speed_gain(self, dav, i, periodic_time):
+        return calc_angle_speed_gain_vector(self, dav, i, periodic_time)
+
+    def calc_jacobian(self,
+                      jacobian, row, column,
+                      joint, paxis, child_link,
+                      world_default_coords,
+                      move_target, transform_coords,
+                      rotation_axis, translation_axis):
+        calc_jacobian_linear(jacobian, row, column + 0,
+                             joint, [1, 0, 0], child_link,
+                             world_default_coords,
+                             move_target, transform_coords,
+                             rotation_axis, translation_axis)
+        calc_jacobian_linear(jacobian, row, column + 1,
+                             joint, [0, 1, 0], child_link,
+                             world_default_coords,
+                             move_target, transform_coords,
+                             rotation_axis, translation_axis)
+        calc_jacobian_linear(jacobian, row, column + 2,
+                             joint, [0, 0, 1], child_link,
+                             world_default_coords,
+                             move_target, transform_coords,
+                             rotation_axis, translation_axis)
+        # Rotational DoFs are applied in body-fixed XYZ order (rx->ry->rz).
+        # The effective rotation axis for each DoF must reflect the
+        # intermediate rotations, otherwise ry/rz columns diverge from the
+        # numerical derivative once rx/ry are non-zero.
+        rx = self._joint_angle[3]
+        ry = self._joint_angle[4]
+        c_rx, s_rx = np.cos(rx), np.sin(rx)
+        c_ry, s_ry = np.cos(ry), np.sin(ry)
+        ry_axis_local = np.array([0.0, c_rx, s_rx])
+        rz_axis_local = np.array([s_ry, -s_rx * c_ry, c_rx * c_ry])
+        calc_jacobian_rotational(jacobian, row, column + 3,
+                                 joint, [1, 0, 0], child_link,
+                                 world_default_coords,
+                                 move_target, transform_coords,
+                                 rotation_axis, translation_axis)
+        calc_jacobian_rotational(jacobian, row, column + 4,
+                                 joint, ry_axis_local, child_link,
+                                 world_default_coords,
+                                 move_target, transform_coords,
+                                 rotation_axis, translation_axis)
+        calc_jacobian_rotational(jacobian, row, column + 5,
+                                 joint, rz_axis_local, child_link,
+                                 world_default_coords,
+                                 move_target, transform_coords,
+                                 rotation_axis, translation_axis)
+        return jacobian
+
+
 def calc_joint_angle_min_max_for_limit_calculation(j, kk, jamm=None):
     if jamm is None:
         jamm = np.zeros(3, 'f')

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -3067,11 +3067,13 @@ class RobotModel(CascadedLink):
         from skrobot.kinematics.differentiable import create_batch_ik_solver
 
         if backend is None:
-            backend = 'numpy'
-        elif backend != 'numpy':
+            from skrobot.pycompat import HAS_JAX
+            backend = 'jax' if HAS_JAX else 'numpy'
+        elif backend not in ('numpy', 'jax'):
             warnings.warn(
-                "Multi-EE batch IK currently supports only backend='numpy'; "
-                "falling back from {!r}.".format(backend), RuntimeWarning)
+                "Multi-EE batch IK supports backend='numpy' or 'jax'; "
+                "falling back to 'numpy' from {!r}.".format(backend),
+                RuntimeWarning)
             backend = 'numpy'
 
         n_tasks = len(link_list)

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -1133,6 +1133,14 @@ class CascadedLink(CascadedCoords):
             child_link=root_link,
             name='_fullbody_ik_base_joint',
         )
+        # Detach root_link from its original parent's _child_links before
+        # reparenting so the kinematic graph stays consistent (a link must
+        # appear in at most one parent's child list at a time).
+        state['orig_parent_had_child'] = False
+        if state['orig_parent_link'] is not None and root_link in \
+                state['orig_parent_link']._child_links:
+            state['orig_parent_link'].del_child_link(root_link)
+            state['orig_parent_had_child'] = True
         root_link._parent_link = virtual_link
         virtual_link.add_child_link(root_link)
         root_link.joint = virtual_joint
@@ -1168,6 +1176,11 @@ class CascadedLink(CascadedCoords):
         root_link._parent_link = state['orig_parent_link']
         if root_link in virtual_link._child_links:
             virtual_link.del_child_link(root_link)
+        # Restore the original parent -> root_link child edge we removed
+        # during attach, if it existed before.
+        if state.get('orig_parent_had_child') \
+                and state['orig_parent_link'] is not None:
+            state['orig_parent_link'].add_child_link(root_link)
         if self._relevance_predicate_table is not None:
             for key in state['rel_entries']:
                 self._relevance_predicate_table.pop(key, None)
@@ -1264,7 +1277,15 @@ class CascadedLink(CascadedCoords):
             'use_base': use_base,
             'orig_parent_link': root_link._parent_link,
             'orig_joint': root_link.joint,
+            'orig_parent_had_child': False,
         }
+        # Detach root_link from its original parent's child list before
+        # reparenting so the graph stays consistent (a link must appear in
+        # at most one parent's child list at a time).
+        if state['orig_parent_link'] is not None and root_link in \
+                state['orig_parent_link']._child_links:
+            state['orig_parent_link'].del_child_link(root_link)
+            state['orig_parent_had_child'] = True
         root_link._parent_link = chain_joints[-1].parent_link
         root_link.joint = chain_joints[-1]
 
@@ -1304,6 +1325,12 @@ class CascadedLink(CascadedCoords):
             cl = j.child_link
             if cl in pl._child_links:
                 pl.del_child_link(cl)
+        # Restore the original parent -> root_link edge we removed in
+        # attach, if one existed. Placed after chain-teardown so root_link
+        # is only re-added once its virtual-chain parent edge is gone.
+        if state.get('orig_parent_had_child') \
+                and state['orig_parent_link'] is not None:
+            state['orig_parent_link'].add_child_link(root_link)
 
     def inverse_kinematics(
             self,

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -2982,11 +2982,6 @@ class RobotModel(CascadedLink):
         # Fullbody IK state threaded from the public wrapper.
         _base_state = kwargs.pop('_base_state', None)
         _base_weight = kwargs.pop('base_weight', None)
-        if _base_state is not None and _base_weight is not None:
-            warnings.warn(
-                'base_weight is not yet wired into batch inverse_kinematics '
-                '(Phase 3C); falling back to uniform base weighting.',
-                RuntimeWarning)
 
         # Auto-select backend: prefer JAX if available, fallback to NumPy
         if backend is None:
@@ -3157,6 +3152,26 @@ class RobotModel(CascadedLink):
         )
         solver_kwargs['damping'] = 0.01
 
+        # Build per-opt-variable weights when use_base + base_weight is
+        # active. The virtual chain joints are always the leading non-mimic
+        # entries of link_list (see _attach_batch_virtual_base_chain), so
+        # they occupy opt indices 0..n_dof-1 in the single-EE solver.
+        if _base_state is not None and _base_weight is not None:
+            n_dof = _base_state['n_dof']
+            base_weight_vec = np.broadcast_to(
+                np.asarray(_base_weight, dtype=np.float64),
+                (n_dof,)).copy()
+            if np.any(base_weight_vec <= 0):
+                raise ValueError(
+                    "base_weight must be strictly positive")
+            n_opt = solver.fk_params['n_joints'] - int(
+                np.sum(np.asarray(
+                    solver.fk_params.get(
+                        'mimic_parent_indices', np.array([-1])) >= 0)))
+            joint_weights = np.ones(n_opt, dtype=np.float64)
+            joint_weights[:n_dof] = base_weight_vec
+            solver_kwargs['joint_weights'] = joint_weights
+
         solutions_array, success_array, errors_array = solver(
             target_positions,
             target_rotations,
@@ -3298,11 +3313,6 @@ class RobotModel(CascadedLink):
 
         _base_state = kwargs.pop('_base_state', None)
         _base_weight = kwargs.pop('base_weight', None)
-        if _base_state is not None and _base_weight is not None:
-            warnings.warn(
-                'base_weight is not yet wired into batch inverse_kinematics '
-                '(Phase 3C); falling back to uniform base weighting.',
-                RuntimeWarning)
 
         if backend is None:
             from skrobot.pycompat import HAS_JAX
@@ -3404,6 +3414,38 @@ class RobotModel(CascadedLink):
             attempts_per_pose=attempts_per_pose,
             use_current_angles=use_current_angles,
         )
+
+        # Per-union-variable weights when use_base + base_weight is set.
+        # The virtual chain joints always end up at the leading union
+        # indices (first task to register them owns 0..n_dof-1 and later
+        # tasks map to the same slots).
+        if _base_state is not None and _base_weight is not None:
+            n_dof = _base_state['n_dof']
+            base_weight_vec = np.broadcast_to(
+                np.asarray(_base_weight, dtype=np.float64),
+                (n_dof,)).copy()
+            if np.any(base_weight_vec <= 0):
+                raise ValueError("base_weight must be strictly positive")
+            union_n_opt = solver.union_n_opt
+            joint_weights = np.ones(union_n_opt, dtype=np.float64)
+            # Locate each virtual-chain joint in union_refs (they should
+            # be at the beginning, but look them up explicitly rather
+            # than assuming the position).
+            chain_joints = _base_state['chain_joints']
+            located = []
+            for vj in chain_joints:
+                for uidx, ref in enumerate(union_refs):
+                    if ref is vj:
+                        located.append(uidx)
+                        break
+            if len(located) != n_dof:
+                raise RuntimeError(
+                    "could not locate all virtual-chain joints in union "
+                    "for base_weight wiring ({} of {})".format(
+                        len(located), n_dof))
+            joint_weights[np.asarray(located, dtype=np.int64)] = (
+                base_weight_vec)
+            solver_kwargs['joint_weights'] = joint_weights
 
         solutions_array, success_array, errors_array = solver(
             target_positions_list, target_rotations_list, **solver_kwargs)

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -2834,17 +2834,39 @@ class RobotModel(CascadedLink):
             else:
                 link_list = list(map(lambda mt: self.link_lists(mt.parent), move_target))
 
-        # Handle single link list (not list of lists) for now
-        if isinstance(link_list, list) and len(link_list) > 0 and isinstance(link_list[0], list):
-            single_link_list = link_list[0]  # Use first link list for batch processing
-        else:
-            single_link_list = link_list
+        # Detect multi-EE. Require BOTH inputs to be matching lists so that
+        # legacy callers passing a single-element list-of-lists with a scalar
+        # move_target still land on the single-EE path. Mismatched lists are
+        # ambiguous and raise an explicit error instead of guessing.
+        link_list_is_nested = (isinstance(link_list, list)
+                               and len(link_list) > 0
+                               and isinstance(link_list[0], list))
+        move_target_is_list = isinstance(move_target, list)
+        if link_list_is_nested and move_target_is_list \
+                and len(move_target) == len(link_list):
+            return self._batch_inverse_kinematics_multi_ee_impl(
+                target_coords, move_target, link_list,
+                rotation_mask, position_mask, rotation_mirror, stop, thre,
+                rthre, initial_angles, alpha, attempts_per_pose,
+                random_initial_range, translation_tolerance,
+                rotation_tolerance, backend=backend, **kwargs)
+        if link_list_is_nested and len(link_list) > 1:
+            raise ValueError(
+                "Ambiguous batch_inverse_kinematics inputs: link_list has {} "
+                "sub-lists but move_target is not a matching list of that "
+                "length. For multi-EE batch IK, pass move_target as a list "
+                "of the same length as link_list.".format(len(link_list)))
+        if link_list_is_nested:
+            # Legacy shorthand: link_list=[[...]] with a scalar or 1-element
+            # move_target means single-EE.
+            link_list = link_list[0]
+        if isinstance(move_target, list) and len(move_target) == 1:
+            move_target = move_target[0]
 
-        # Handle single move_target (not list)
-        if isinstance(move_target, list):
-            single_move_target = move_target[0]
-        else:
-            single_move_target = move_target
+        single_link_list = link_list
+
+        # Single move_target (multi-EE already handled above).
+        single_move_target = move_target
 
         # Convert target_coords to positions (N, 3) and rotation matrices (N, 3, 3)
         if isinstance(target_coords, list) and all(isinstance(coord, Coordinates) for coord in target_coords):
@@ -2988,6 +3010,176 @@ class RobotModel(CascadedLink):
         # Compute attempt counts (backend always uses all attempts, return attempts_per_pose)
         attempt_counts = [attempts_per_pose] * n_poses
 
+        return full_solutions, success_flags, attempt_counts
+
+    @staticmethod
+    def _multi_ee_targets_to_pos_rot(target_coords_for_task):
+        """Convert one task's batch of targets to (pos, rot) arrays.
+
+        Mirrors the conversion used for single-EE batch IK. Accepts:
+        - list of Coordinates objects,
+        - ``np.ndarray`` of shape ``(N, 6)`` (x, y, z, roll, pitch, yaw), or
+        - ``np.ndarray`` of shape ``(N, 7)`` (x, y, z, qw, qx, qy, qz).
+        """
+        tc = target_coords_for_task
+        if isinstance(tc, list) and all(isinstance(c, Coordinates) for c in tc):
+            positions = np.array([c.worldpos() for c in tc])
+            rotations = np.array([c.worldrot() for c in tc])
+            return positions, rotations
+        if isinstance(tc, np.ndarray):
+            if tc.ndim != 2:
+                raise ValueError(
+                    "per-task target_coords must be 2D, got shape {}".format(
+                        tc.shape))
+            if tc.shape[1] == 6:
+                positions = tc[:, :3]
+                quats = np.array([rpy2quaternion(r) for r in tc[:, 3:]])
+                rotations = np.array([quaternion2matrix(q) for q in quats])
+                return positions, rotations
+            if tc.shape[1] == 7:
+                positions = tc[:, :3]
+                rotations = np.array(
+                    [quaternion2matrix(q) for q in tc[:, 3:]])
+                return positions, rotations
+            raise ValueError(
+                "per-task target_coords must have shape (batch, 6) or "
+                "(batch, 7), got {}".format(tc.shape))
+        raise ValueError(
+            "per-task target_coords must be numpy array or list of "
+            "Coordinates objects")
+
+    def _batch_inverse_kinematics_multi_ee_impl(
+            self, target_coords, move_target, link_list,
+            rotation_mask, position_mask, rotation_mirror, stop, thre, rthre,
+            initial_angles, alpha, attempts_per_pose, random_initial_range,
+            translation_tolerance, rotation_tolerance, backend=None, **kwargs):
+        """Multi-end-effector batch IK.
+
+        ``link_list`` is ``list[list[Link]]`` (one chain per task) and
+        ``move_target`` is ``list[CascadedCoords]`` of the same length.
+        ``target_coords`` must be a list of per-task batches (ndarray or list
+        of Coordinates). All tasks must share the same batch size ``N``.
+
+        Additional kwargs:
+        - ``task_weights``: ``(n_tasks,)`` array-like of per-task weights
+          applied to the stacked DLS residuals. Default: uniform 1.0.
+        """
+        from skrobot.kinematics.differentiable import create_batch_ik_solver
+
+        if backend is None:
+            backend = 'numpy'
+        elif backend != 'numpy':
+            warnings.warn(
+                "Multi-EE batch IK currently supports only backend='numpy'; "
+                "falling back from {!r}.".format(backend), RuntimeWarning)
+            backend = 'numpy'
+
+        n_tasks = len(link_list)
+        if not isinstance(move_target, list) or len(move_target) != n_tasks:
+            raise ValueError(
+                "For multi-EE batch IK, move_target must be a list of length "
+                "{}, got {}".format(
+                    n_tasks,
+                    type(move_target).__name__ + (
+                        "(len={})".format(len(move_target))
+                        if isinstance(move_target, list) else "")))
+        if not isinstance(target_coords, list) or len(target_coords) != n_tasks:
+            raise ValueError(
+                "For multi-EE batch IK, target_coords must be a list of "
+                "length {} (one batch per task)".format(n_tasks))
+
+        target_positions_list = []
+        target_rotations_list = []
+        n_poses = None
+        for t, tc in enumerate(target_coords):
+            pos, rot = self._multi_ee_targets_to_pos_rot(tc)
+            if n_poses is None:
+                n_poses = pos.shape[0]
+            elif pos.shape[0] != n_poses:
+                raise ValueError(
+                    "Inconsistent batch sizes across tasks: task 0 has {} "
+                    "poses, task {} has {}".format(
+                        n_poses, t, pos.shape[0]))
+            target_positions_list.append(pos)
+            target_rotations_list.append(rot)
+
+        task_weights = kwargs.pop('task_weights', None)
+
+        # Cached solver keyed by per-task link/move-target identities.
+        cache_key = (
+            tuple(tuple(id(link) for link in ll) for ll in link_list),
+            tuple(id(mt) for mt in move_target),
+            backend,
+        )
+        if not hasattr(self, '_batch_ik_multi_ee_solver_cache'):
+            self._batch_ik_multi_ee_solver_cache = {}
+        if cache_key not in self._batch_ik_multi_ee_solver_cache:
+            self._batch_ik_multi_ee_solver_cache[cache_key] = \
+                create_batch_ik_solver(
+                    self, link_list, move_target, backend_name=backend)
+        solver = self._batch_ik_multi_ee_solver_cache[cache_key]
+
+        union_refs = solver.union_info['union_joint_refs']
+        union_n_opt = solver.union_n_opt
+
+        # Initial angles (in union opt space, not full robot angle vector).
+        use_current_angles = True
+        if initial_angles is None or (
+                isinstance(initial_angles, str) and initial_angles == "random"):
+            initial_angles_for_solver = None
+            use_current_angles = False
+        elif isinstance(initial_angles, str) and initial_angles == "current":
+            current = np.array(
+                [j.joint_angle() for j in union_refs], dtype=np.float64)
+            initial_angles_for_solver = np.tile(current, (n_poses, 1))
+        elif isinstance(initial_angles, np.ndarray):
+            if initial_angles.shape == (n_poses, union_n_opt):
+                initial_angles_for_solver = initial_angles.copy()
+            else:
+                raise ValueError(
+                    "initial_angles for multi-EE must have shape ({}, {}), "
+                    "got {}".format(n_poses, union_n_opt, initial_angles.shape))
+        else:
+            raise ValueError(
+                "initial_angles must be None, 'random', 'current', or "
+                "np.ndarray, got {}".format(type(initial_angles)))
+
+        solver_kwargs = dict(
+            initial_angles=initial_angles_for_solver,
+            max_iterations=stop,
+            damping=0.01,
+            pos_threshold=thre,
+            rot_threshold=rthre,
+            position_masks=position_mask,
+            rotation_masks=rotation_mask,
+            rotation_mirrors=rotation_mirror,
+            task_weights=task_weights,
+            attempts_per_pose=attempts_per_pose,
+            use_current_angles=use_current_angles,
+        )
+
+        solutions_array, success_array, errors_array = solver(
+            target_positions_list, target_rotations_list, **solver_kwargs)
+        solutions_np = np.asarray(solutions_array)
+        success_np = np.asarray(success_array)
+
+        # Map union opt solutions to robot's full angle vector.
+        robot_joint_list = self.joint_list
+        union_to_robot = []  # list of (union_idx, robot_idx)
+        for uidx, joint in enumerate(union_refs):
+            if joint in robot_joint_list:
+                union_to_robot.append((uidx, robot_joint_list.index(joint)))
+
+        full_solutions = []
+        full_av_org = self.angle_vector()
+        for i in range(n_poses):
+            full_av = full_av_org.copy()
+            for uidx, ridx in union_to_robot:
+                full_av[ridx] = solutions_np[i, uidx]
+            full_solutions.append(full_av)
+
+        success_flags = [bool(s) for s in success_np]
+        attempt_counts = [attempts_per_pose] * n_poses
         return full_solutions, success_flags, attempt_counts
 
     def inverse_kinematics_loop(self,

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -3163,20 +3163,28 @@ class RobotModel(CascadedLink):
         solutions_np = np.asarray(solutions_array)
         success_np = np.asarray(success_array)
 
-        # Map union opt solutions to robot's full angle vector.
-        robot_joint_list = self.joint_list
-        union_to_robot = []  # list of (union_idx, robot_idx)
+        # Map union opt solutions to robot's full angle vector. An id-keyed
+        # dict turns the O(n_union * n_robot_joints) membership test into
+        # O(n_union), and the double loop over poses and joints collapses
+        # into a single fancy-indexed assignment.
+        robot_joint_to_idx = {
+            id(j): k for k, j in enumerate(self.joint_list)}
+        union_idx_list = []
+        robot_idx_list = []
         for uidx, joint in enumerate(union_refs):
-            if joint in robot_joint_list:
-                union_to_robot.append((uidx, robot_joint_list.index(joint)))
+            ridx = robot_joint_to_idx.get(id(joint))
+            if ridx is not None:
+                union_idx_list.append(uidx)
+                robot_idx_list.append(ridx)
+        union_idx_arr = np.asarray(union_idx_list, dtype=np.int64)
+        robot_idx_arr = np.asarray(robot_idx_list, dtype=np.int64)
 
-        full_solutions = []
         full_av_org = self.angle_vector()
-        for i in range(n_poses):
-            full_av = full_av_org.copy()
-            for uidx, ridx in union_to_robot:
-                full_av[ridx] = solutions_np[i, uidx]
-            full_solutions.append(full_av)
+        full_solutions_arr = np.tile(full_av_org, (n_poses, 1))
+        if len(union_idx_arr) > 0:
+            full_solutions_arr[:, robot_idx_arr] = \
+                solutions_np[:, union_idx_arr]
+        full_solutions = list(full_solutions_arr)
 
         success_flags = [bool(s) for s in success_np]
         attempt_counts = [attempts_per_pose] * n_poses

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -167,11 +167,24 @@ class CascadedLink(CascadedCoords):
             return ids
 
         n = len(link_lists)
+        # A link shared across multiple chains (e.g. a virtual base joint
+        # injected by use_base, which prepends root_link to every sub-chain)
+        # cannot discriminate move_targets, so filter those out before
+        # matching.
+        occurrences = {}
+        for ll in link_lists:
+            for link in ll:
+                occurrences[id(link)] = occurrences.get(id(link), 0) + 1
+        unique_link_ids = [
+            {id(link) for link in ll if occurrences[id(link)] == 1}
+            for ll in link_lists
+        ]
+
         matches = []
         for mt in move_targets:
-            anc = ancestor_id_set(mt)
-            candidates = [j for j, ll in enumerate(link_lists)
-                          if any(id(link) in anc for link in ll)]
+            ancestor_ids = ancestor_id_set(mt)
+            candidates = [j for j, ids in enumerate(unique_link_ids)
+                          if ancestor_ids & ids]
             if len(candidates) != 1:
                 return link_lists
             matches.append(candidates[0])

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -3120,20 +3120,28 @@ class RobotModel(CascadedLink):
             raise ValueError(
                 f"initial_angles must be None, 'random', 'current', or np.ndarray, got {type(initial_angles)}")
 
-        # Create or retrieve cached backend solver
-        # Cache key: (link_list ids, move_target id, backend)
-        cache_key = (
-            tuple(id(link) for link in single_link_list),
-            id(single_move_target),
-            backend,
-        )
-        if not hasattr(self, '_batch_ik_solver_cache'):
-            self._batch_ik_solver_cache = {}
-        if cache_key not in self._batch_ik_solver_cache:
-            self._batch_ik_solver_cache[cache_key] = create_batch_ik_solver(
+        # Create or retrieve cached backend solver. When use_base attaches
+        # a virtual chain, the fresh Link/Joint objects give unique id()s
+        # every call, so caching would accumulate stale entries without
+        # ever hitting. Bypass the cache in that case.
+        if _base_state is None:
+            cache_key = (
+                tuple(id(link) for link in single_link_list),
+                id(single_move_target),
+                backend,
+            )
+            if not hasattr(self, '_batch_ik_solver_cache'):
+                self._batch_ik_solver_cache = {}
+            if cache_key not in self._batch_ik_solver_cache:
+                self._batch_ik_solver_cache[cache_key] = \
+                    create_batch_ik_solver(
+                        self, single_link_list, single_move_target,
+                        backend_name=backend)
+            solver = self._batch_ik_solver_cache[cache_key]
+        else:
+            solver = create_batch_ik_solver(
                 self, single_link_list, single_move_target,
                 backend_name=backend)
-        solver = self._batch_ik_solver_cache[cache_key]
 
         # Build solver kwargs based on backend
         solver_kwargs = dict(
@@ -3338,18 +3346,25 @@ class RobotModel(CascadedLink):
         task_weights = kwargs.pop('task_weights', None)
 
         # Cached solver keyed by per-task link/move-target identities.
-        cache_key = (
-            tuple(tuple(id(link) for link in ll) for ll in link_list),
-            tuple(id(mt) for mt in move_target),
-            backend,
-        )
-        if not hasattr(self, '_batch_ik_multi_ee_solver_cache'):
-            self._batch_ik_multi_ee_solver_cache = {}
-        if cache_key not in self._batch_ik_multi_ee_solver_cache:
-            self._batch_ik_multi_ee_solver_cache[cache_key] = \
-                create_batch_ik_solver(
-                    self, link_list, move_target, backend_name=backend)
-        solver = self._batch_ik_multi_ee_solver_cache[cache_key]
+        # Bypass the cache when a virtual base chain is attached: its
+        # fresh Link/Joint objects would poison the cache with one-shot
+        # entries (id()s never match again).
+        if _base_state is None:
+            cache_key = (
+                tuple(tuple(id(link) for link in ll) for ll in link_list),
+                tuple(id(mt) for mt in move_target),
+                backend,
+            )
+            if not hasattr(self, '_batch_ik_multi_ee_solver_cache'):
+                self._batch_ik_multi_ee_solver_cache = {}
+            if cache_key not in self._batch_ik_multi_ee_solver_cache:
+                self._batch_ik_multi_ee_solver_cache[cache_key] = \
+                    create_batch_ik_solver(
+                        self, link_list, move_target, backend_name=backend)
+            solver = self._batch_ik_multi_ee_solver_cache[cache_key]
+        else:
+            solver = create_batch_ik_solver(
+                self, link_list, move_target, backend_name=backend)
 
         union_refs = solver.union_info['union_joint_refs']
         union_n_opt = solver.union_n_opt

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -125,6 +125,73 @@ class CascadedLink(CascadedCoords):
             return self._relevance_predicate_table[key]
         return False
 
+    @staticmethod
+    def _reorder_link_lists_for_move_targets(link_lists, move_targets):
+        """Reorder ``link_lists`` so entry ``i`` is the chain whose kinematic
+        descendants include ``move_targets[i]``.
+
+        Multi-end-effector IK requires ``link_lists[i]`` to correspond to
+        ``move_targets[i]`` because the per-task Jacobian is computed along
+        ``link_lists[i]`` but the position/orientation error is measured on
+        ``move_targets[i]``.  If a caller passes them in different orders
+        the solver silently converges to a wrong joint configuration (the
+        errors get projected through mismatched Jacobians).  Detect this
+        case and fix it automatically, so the caller only has to supply
+        the right *set* of chains and the right *set* of end-effectors.
+
+        A chain matches a move_target when at least one link in the chain
+        appears on the parent path from the move_target back to the root.
+        If the match is ambiguous (more than one candidate chain per
+        move_target, or two move_targets mapping to the same chain) the
+        original ``link_lists`` is returned unchanged so existing
+        validation paths can emit their usual error.
+        """
+        if not isinstance(link_lists, list) or len(link_lists) < 2:
+            return link_lists
+        if (not isinstance(move_targets, list)
+                or len(move_targets) != len(link_lists)):
+            return link_lists
+        if not all(isinstance(ll, list) for ll in link_lists):
+            return link_lists
+
+        def ancestor_id_set(mt):
+            ids = set()
+            cur = mt
+            # Guard against circular parent links (shouldn't happen but we
+            # don't want the helper to hang if the graph is malformed).
+            for _ in range(4096):
+                if cur is None:
+                    break
+                ids.add(id(cur))
+                cur = getattr(cur, 'parent', None)
+            return ids
+
+        n = len(link_lists)
+        matches = []
+        for mt in move_targets:
+            anc = ancestor_id_set(mt)
+            candidates = [j for j, ll in enumerate(link_lists)
+                          if any(id(link) in anc for link in ll)]
+            if len(candidates) != 1:
+                return link_lists
+            matches.append(candidates[0])
+
+        if sorted(matches) != list(range(n)):
+            return link_lists
+        if matches == list(range(n)):
+            return link_lists
+
+        # Debug-level because the reorder is an intentional transparency
+        # feature: callers often pass a fixed link_list while move_target
+        # cycles (e.g. alternating stance/swing), and they should not see a
+        # warning on every step for that legitimate usage.
+        logger.debug(
+            'inverse_kinematics: reordered link_list via kinematic-chain '
+            'membership to match move_target order '
+            '(move_target[i] -> link_list[%s]).',
+            matches)
+        return [link_lists[matches[i]] for i in range(n)]
+
     def _resolve_mask_params(self, position_mask, rotation_mask, rotation_mirror):
         """Resolve mask parameters to normalized format.
 
@@ -891,6 +958,8 @@ class CascadedLink(CascadedCoords):
         if link_list is None or not isinstance(link_list[0], list):
             link_list = [link_list]
         move_target = listify(move_target)
+        link_list = self._reorder_link_lists_for_move_targets(
+            link_list, move_target)
         target_coords = listify(target_coords)
         dif_pos = listify(dif_pos)
         dif_rot = listify(dif_rot)
@@ -1464,6 +1533,14 @@ class CascadedLink(CascadedCoords):
             additional_jacobi = additional_jacobi or []
             additional_vel = additional_vel or []
             target_coords = listify(target_coords)
+            # Re-pair each link_list chain with its corresponding move_target
+            # before deriving anything else (union_link_list, joint_list, etc.)
+            # so the fix takes effect for every downstream path, not just the
+            # per-task Jacobian in inverse_kinematics_loop.
+            if (isinstance(link_list, list) and len(link_list) > 0
+                    and isinstance(link_list[0], list)):
+                link_list = self._reorder_link_lists_for_move_targets(
+                    link_list, listify(move_target))
             if callable(union_link_list):
                 union_link_list = union_link_list(link_list)
             else:

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -31,9 +31,11 @@ from skrobot.coordinates.math import select_by_mask
 from skrobot.model.joint import calc_target_joint_dimension
 from skrobot.model.joint import calc_target_joint_dimension_from_link_list
 from skrobot.model.joint import FixedJoint
+from skrobot.model.joint import FloatingJoint
 from skrobot.model.joint import joint_angle_limit_nspace
 from skrobot.model.joint import joint_angle_limit_weight
 from skrobot.model.joint import LinearJoint
+from skrobot.model.joint import PlanarJoint
 from skrobot.model.joint import RotationalJoint
 from skrobot.model.link import find_link_path
 from skrobot.model.link import Link
@@ -1090,6 +1092,86 @@ class CascadedLink(CascadedCoords):
                     ret=ret,
                     **kwargs)
 
+    def _find_fullbody_root_link(self):
+        root_link = getattr(self, 'root_link', None)
+        if root_link is not None:
+            return root_link
+        for link in self.link_list:
+            if link.parent_link is None:
+                return link
+        raise RuntimeError(
+            'Cannot determine root_link for fullbody IK; '
+            'set self.root_link or ensure one link has no parent_link.')
+
+    def _attach_virtual_base_joint(self, use_base, link_list):
+        """Inject a temporary virtual joint above root_link so IK can
+        solve for the base pose as additional DoFs.
+
+        Returns a state dict used by _detach_virtual_base_joint to
+        undo the injection, and the rewritten link_list that contains
+        root_link at the head of every sub-chain.
+        """
+        if use_base == 'planar':
+            joint_cls = PlanarJoint
+        elif use_base == '6dof':
+            joint_cls = FloatingJoint
+        else:
+            raise ValueError(
+                "use_base must be False, 'planar', or '6dof', got %r"
+                % (use_base,))
+        root_link = self._find_fullbody_root_link()
+        virtual_link = Link(name='_fullbody_ik_virtual_world')
+        state = {
+            'root_link': root_link,
+            'virtual_link': virtual_link,
+            'orig_parent_link': root_link._parent_link,
+            'orig_joint': root_link.joint,
+            'rel_entries': [],
+        }
+        virtual_joint = joint_cls(
+            parent_link=virtual_link,
+            child_link=root_link,
+            name='_fullbody_ik_base_joint',
+        )
+        root_link._parent_link = virtual_link
+        virtual_link.add_child_link(root_link)
+        root_link.joint = virtual_joint
+        state['virtual_joint'] = virtual_joint
+        # Make _is_relevant(virtual_joint, link) return True for every link
+        # in the robot (the virtual joint sits at the root so it influences
+        # every descendant).
+        if self._relevance_predicate_table is not None:
+            for link in self.link_list:
+                key = (virtual_joint, link)
+                self._relevance_predicate_table[key] = True
+                state['rel_entries'].append(key)
+        # Prepend root_link to every sub link_list so the virtual joint
+        # enters union_link_list and contributes Jacobian columns.
+        if link_list is None:
+            new_link_list = None
+        else:
+            if len(link_list) > 0 and not isinstance(link_list[0], list):
+                sub_lists = [list(link_list)]
+            else:
+                sub_lists = [list(ll) for ll in link_list]
+            new_link_list = [
+                [root_link] + [lk for lk in ll if lk is not root_link]
+                for ll in sub_lists
+            ]
+        state['link_list'] = new_link_list
+        return state
+
+    def _detach_virtual_base_joint(self, state):
+        root_link = state['root_link']
+        virtual_link = state['virtual_link']
+        root_link.joint = state['orig_joint']
+        root_link._parent_link = state['orig_parent_link']
+        if root_link in virtual_link._child_links:
+            virtual_link.del_child_link(root_link)
+        if self._relevance_predicate_table is not None:
+            for key in state['rel_entries']:
+                self._relevance_predicate_table.pop(key, None)
+
     def inverse_kinematics(
             self,
             target_coords,
@@ -1115,6 +1197,8 @@ class CascadedLink(CascadedCoords):
             additional_vel=None,
             translation_tolerance=None,
             rotation_tolerance=None,
+            use_base=False,
+            base_weight=None,
             **kwargs):
         """Solve inverse kinematics to reach target coordinates.
 
@@ -1151,6 +1235,25 @@ class CascadedLink(CascadedCoords):
             Per-axis rotation tolerance from target as
             [roll_tol, pitch_tol, yaw_tol] in radians. If error on an axis
             is within tolerance, it's treated as reached.
+        use_base : False, 'planar', or '6dof'
+            If not False, inject a virtual joint above root_link so
+            fullbody inverse kinematics can solve for the base pose as
+            additional DoFs. 'planar' uses 3 DoF (x, y, yaw), intended
+            for flat-ground mobile bases. '6dof' uses 6 DoF
+            (x, y, z, rx, ry, rz), appropriate for humanoids on uneven
+            terrain when combined with held-fixed end-effectors (feet)
+            as contact constraints. The virtual joint is detached
+            before the call returns.
+        base_weight : float, sequence, or None
+            Per-DoF weighting of the virtual base joint in the weighted
+            SR-inverse. Only meaningful when ``use_base`` is set.
+            ``1.0`` (default when ``use_base`` is set) treats base DoFs
+            the same as arm joints. Values ``< 1.0`` make the base
+            "heavier" and prefer arm motion; values ``> 1.0`` make the
+            base "lighter" and prefer base motion. A sequence of length
+            matching the base joint's DoF (3 for ``'planar'``, 6 for
+            ``'6dof'``) allows per-axis weighting, e.g. ``[1.0, 1.0,
+            0.1]`` for planar to discourage yaw changes.
         **kwargs
             Additional keyword arguments passed to inverse_kinematics_loop.
 
@@ -1179,101 +1282,182 @@ class CascadedLink(CascadedCoords):
         position_mask, rotation_mask, rotation_mirror = self._resolve_mask_params(
             position_mask, rotation_mask, rotation_mirror)
 
-        additional_jacobi = additional_jacobi or []
-        additional_vel = additional_vel or []
-        target_coords = listify(target_coords)
-        if callable(union_link_list):
-            union_link_list = union_link_list(link_list)
-        else:
-            union_link_list = self.calc_union_link_list(link_list)
-
-        if thre is None:
-            if isinstance(move_target, list):
-                thre = [0.001] * len(move_target)
+        # Inject virtual joint for fullbody IK if requested.
+        _base_state = None
+        if use_base:
+            _base_state = self._attach_virtual_base_joint(use_base, link_list)
+            link_list = _base_state['link_list']
+            base_joint_dof = _base_state['virtual_joint'].joint_dof
+            if base_weight is None:
+                base_weight_vec = np.ones(base_joint_dof, dtype=np.float64)
             else:
-                thre = [0.001]
-        if rthre is None:
-            if isinstance(move_target, list):
-                rthre = [np.deg2rad(1)] * len(move_target)
+                base_weight_vec = np.broadcast_to(
+                    np.asarray(base_weight, dtype=np.float64),
+                    (base_joint_dof,)).copy()
+            existing_awl = list(kwargs.pop('additional_weight_list', []) or [])
+            existing_awl.append((_base_state['root_link'], base_weight_vec))
+            kwargs['additional_weight_list'] = existing_awl
+        elif base_weight is not None:
+            logger.warning(
+                'base_weight is ignored when use_base is False')
+        try:
+            additional_jacobi = additional_jacobi or []
+            additional_vel = additional_vel or []
+            target_coords = listify(target_coords)
+            if callable(union_link_list):
+                union_link_list = union_link_list(link_list)
             else:
-                rthre = [np.deg2rad(1)]
+                union_link_list = self.calc_union_link_list(link_list)
 
-        # store current angle vector
-        joint_list = list(
-            set([l.joint for l in union_link_list] + self.joint_list))
-        if None in joint_list:
-            logger.error('All links in link_list must have a parent joint')
-            return True
-        av0 = [j.joint_angle() for j in joint_list]
-        c0 = None
-        if self.parent is None:
-            c0 = self.copy_worldcoords()
-        success = True
-        # (old-analysis-level (send-all union-link-list :analysis-level))
-        # (send-all union-link-list :analysis-level :coords)
+            if thre is None:
+                if isinstance(move_target, list):
+                    thre = [0.001] * len(move_target)
+                else:
+                    thre = [0.001]
+            if rthre is None:
+                if isinstance(move_target, list):
+                    rthre = [np.deg2rad(1)] * len(move_target)
+                else:
+                    rthre = [np.deg2rad(1)]
 
-        # argument check
-        if link_list is None or move_target is None:
-            logger.error('both :link-list and :move-target required')
-            return True
-        # Check if no constraint at all
-        if np.sum(position_mask) == 0 and np.sum(rotation_mask) == 0:
-            return True
-        if not isinstance(link_list[0], list):
-            link_list = [link_list]
-        move_target = listify(move_target)
-        position_mask = listify(position_mask)
-        rotation_mask = listify(rotation_mask)
-        thre = listify(thre)
-        rthre = listify(rthre)
+            # store current angle vector
+            joint_list = list(
+                set([l.joint for l in union_link_list] + self.joint_list))
+            if None in joint_list:
+                logger.error('All links in link_list must have a parent joint')
+                return True
+            av0 = [j.joint_angle() for j in joint_list]
+            c0 = None
+            if self.parent is None:
+                c0 = self.copy_worldcoords()
+            success = True
+            # (old-analysis-level (send-all union-link-list :analysis-level))
+            # (send-all union-link-list :analysis-level :coords)
 
-        if not (len(position_mask)
-                == len(rotation_mask)
-                == len(move_target)
-                == len(link_list)
-                == len(target_coords)):
-            logger.error('list length differ : position_mask %s'
-                         ', rotation_mask %s, move_target %s '
-                         'link_list %s, target_coords %s',
-                         len(position_mask), len(rotation_mask),
-                         len(move_target), len(link_list), len(target_coords))
-            return False
+            # argument check
+            if link_list is None or move_target is None:
+                logger.error('both :link-list and :move-target required')
+                return True
+            # Check if no constraint at all
+            if np.sum(position_mask) == 0 and np.sum(rotation_mask) == 0:
+                return True
+            if not isinstance(link_list[0], list):
+                link_list = [link_list]
+            move_target = listify(move_target)
+            position_mask = listify(position_mask)
+            rotation_mask = listify(rotation_mask)
+            thre = listify(thre)
+            rthre = listify(rthre)
 
-        if len(additional_jacobi) != len(additional_vel):
-            logger.error('list length differ : additional_jacobi %s, '
-                         'additional_vel %s',
-                         len(additional_jacobi), len(additional_vel))
-            return False
+            if not (len(position_mask)
+                    == len(rotation_mask)
+                    == len(move_target)
+                    == len(link_list)
+                    == len(target_coords)):
+                logger.error('list length differ : position_mask %s'
+                             ', rotation_mask %s, move_target %s '
+                             'link_list %s, target_coords %s',
+                             len(position_mask), len(rotation_mask),
+                             len(move_target), len(link_list), len(target_coords))
+                return False
 
-        tmp_additional_jacobi = map(
-            lambda aj: aj(link_list) if callable(aj) else aj,
-            additional_jacobi)
-        if cog_null_space is None and target_centroid_pos is not None:
-            additional_jacobi_dimension = self.calc_target_axis_dimension(
-                False, cog_translation_axis)
-        else:
-            additional_jacobi_dimension = 0
-        additional_jacobi_dimension += sum(map(lambda aj: (
-            aj(link_list) if callable(aj) else aj).shape[0],
-            tmp_additional_jacobi))
-        ik_args = self.inverse_kinematics_args(
-            union_link_list=union_link_list,
-            position_mask=position_mask,
-            rotation_mask=rotation_mask,
-            # evaluate additional-jacobi function and
-            # calculate row dimension of additional_jacobi
-            additional_jacobi_dimension=additional_jacobi_dimension,
-            **kwargs)
-        # self.reset_joint_angle_limit_weight_old(union_link_list) ;; reset
-        # weight
+            if len(additional_jacobi) != len(additional_vel):
+                logger.error('list length differ : additional_jacobi %s, '
+                             'additional_vel %s',
+                             len(additional_jacobi), len(additional_vel))
+                return False
 
-        # inverse_kinematics loop
-        loop = 0
-        while loop < stop:
-            loop += 1
-            target_coords = list(map(
-                lambda x: x() if callable(x) else x,
-                target_coords))
+            tmp_additional_jacobi = map(
+                lambda aj: aj(link_list) if callable(aj) else aj,
+                additional_jacobi)
+            if cog_null_space is None and target_centroid_pos is not None:
+                additional_jacobi_dimension = self.calc_target_axis_dimension(
+                    False, cog_translation_axis)
+            else:
+                additional_jacobi_dimension = 0
+            additional_jacobi_dimension += sum(map(lambda aj: (
+                aj(link_list) if callable(aj) else aj).shape[0],
+                tmp_additional_jacobi))
+            ik_args = self.inverse_kinematics_args(
+                union_link_list=union_link_list,
+                position_mask=position_mask,
+                rotation_mask=rotation_mask,
+                # evaluate additional-jacobi function and
+                # calculate row dimension of additional_jacobi
+                additional_jacobi_dimension=additional_jacobi_dimension,
+                **kwargs)
+            # self.reset_joint_angle_limit_weight_old(union_link_list) ;; reset
+            # weight
+
+            # inverse_kinematics loop
+            loop = 0
+            while loop < stop:
+                loop += 1
+                target_coords = list(map(
+                    lambda x: x() if callable(x) else x,
+                    target_coords))
+                dif_pos = list(map(lambda mv, tc, pmask:
+                                   mv.difference_position(tc, position_mask=pmask),
+                                   move_target, target_coords, position_mask))
+                dif_rot = list(map(lambda mv, tc, rmask:
+                                   mv.difference_rotation(
+                                       tc, rotation_mask=rmask,
+                                       rotation_mirror=rotation_mirror),
+                                   move_target, target_coords, rotation_mask))
+
+                # Apply translation tolerance in target_coords' local frame
+                # Note: tol > 0 check ensures 0.0 means "no special tolerance"
+                if translation_tolerance is not None:
+                    for i, (mt, tc) in enumerate(zip(move_target, target_coords)):
+                        # Calculate error in target_coords' local frame
+                        world_error = tc.worldpos() - mt.worldpos()
+                        local_error = tc.worldrot().T @ world_error
+                        for axis_idx, tol in enumerate(translation_tolerance):
+                            if tol is not None and tol > 0:
+                                if abs(local_error[axis_idx]) <= tol:
+                                    # Zero out the corresponding dif_pos component
+                                    # dif_pos is in move_target's frame, so transform
+                                    target_axis_in_mt = mt.worldrot().T @ tc.worldrot()[:, axis_idx]
+                                    dif_pos[i] -= (dif_pos[i] @ target_axis_in_mt) * target_axis_in_mt
+
+                # Apply rotation tolerance: if error is within tolerance,
+                # treat as reached (set dif to 0)
+                if rotation_tolerance is not None:
+                    for i, dr in enumerate(dif_rot):
+                        for axis_idx, tol in enumerate(rotation_tolerance):
+                            if tol is not None and tol > 0 and abs(dr[axis_idx]) <= tol:
+                                dif_rot[i][axis_idx] = 0.0
+
+                if loop == 1 and self.ik_convergence_check(
+                        dif_pos, dif_rot, thre, rthre):
+                    success = 'ik-succeed'
+                    break
+
+                success = self.inverse_kinematics_loop(
+                    dif_pos, dif_rot,
+                    target_coords=target_coords,
+                    periodic_time=periodic_time,
+                    stop=stop,
+                    loop=loop,
+                    position_mask=position_mask,
+                    rotation_mask=rotation_mask,
+                    rotation_mirror=rotation_mirror,
+                    move_target=move_target,
+                    link_list=link_list,
+                    union_link_list=union_link_list,
+                    thre=thre,
+                    rthre=rthre,
+                    additional_jacobi=additional_jacobi,
+                    additional_vel=additional_vel,
+                    **ik_args)
+                if success == 'ik-succeed':
+                    break
+
+            if target_centroid_pos is not None:
+                self.update_mass_properties()
+
+            target_coords = list(map(lambda x: x() if callable(x) else x,
+                                     target_coords))
             dif_pos = list(map(lambda mv, tc, pmask:
                                mv.difference_position(tc, position_mask=pmask),
                                move_target, target_coords, position_mask))
@@ -1283,86 +1467,27 @@ class CascadedLink(CascadedCoords):
                                    rotation_mirror=rotation_mirror),
                                move_target, target_coords, rotation_mask))
 
-            # Apply translation tolerance in target_coords' local frame
-            # Note: tol > 0 check ensures 0.0 means "no special tolerance"
-            if translation_tolerance is not None:
-                for i, (mt, tc) in enumerate(zip(move_target, target_coords)):
-                    # Calculate error in target_coords' local frame
-                    world_error = tc.worldpos() - mt.worldpos()
-                    local_error = tc.worldrot().T @ world_error
-                    for axis_idx, tol in enumerate(translation_tolerance):
-                        if tol is not None and tol > 0:
-                            if abs(local_error[axis_idx]) <= tol:
-                                # Zero out the corresponding dif_pos component
-                                # dif_pos is in move_target's frame, so transform
-                                target_axis_in_mt = mt.worldrot().T @ tc.worldrot()[:, axis_idx]
-                                dif_pos[i] -= (dif_pos[i] @ target_axis_in_mt) * target_axis_in_mt
+            # success
+            success = self.ik_convergence_check(dif_pos, dif_rot, thre, rthre)
 
-            # Apply rotation tolerance: if error is within tolerance,
-            # treat as reached (set dif to 0)
-            if rotation_tolerance is not None:
-                for i, dr in enumerate(dif_rot):
-                    for axis_idx, tol in enumerate(rotation_tolerance):
-                        if tol is not None and tol > 0 and abs(dr[axis_idx]) <= tol:
-                            dif_rot[i][axis_idx] = 0.0
+            # reset joint angle limit weight
+            self.reset_joint_angle_limit_weight(union_link_list)
 
-            if loop == 1 and self.ik_convergence_check(
-                    dif_pos, dif_rot, thre, rthre):
-                success = 'ik-succeed'
-                break
+            # TODO(add collision check)
+            if success or not revert_if_fail:
+                # Apply joint limit table constraints to ensure
+                # bidirectional dependencies are satisfied
+                return self.apply_joint_limit_table_constraints()
 
-            success = self.inverse_kinematics_loop(
-                dif_pos, dif_rot,
-                target_coords=target_coords,
-                periodic_time=periodic_time,
-                stop=stop,
-                loop=loop,
-                position_mask=position_mask,
-                rotation_mask=rotation_mask,
-                rotation_mirror=rotation_mirror,
-                move_target=move_target,
-                link_list=link_list,
-                union_link_list=union_link_list,
-                thre=thre,
-                rthre=rthre,
-                additional_jacobi=additional_jacobi,
-                additional_vel=additional_vel,
-                **ik_args)
-            if success == 'ik-succeed':
-                break
-
-        if target_centroid_pos is not None:
-            self.update_mass_properties()
-
-        target_coords = list(map(lambda x: x() if callable(x) else x,
-                                 target_coords))
-        dif_pos = list(map(lambda mv, tc, pmask:
-                           mv.difference_position(tc, position_mask=pmask),
-                           move_target, target_coords, position_mask))
-        dif_rot = list(map(lambda mv, tc, rmask:
-                           mv.difference_rotation(
-                               tc, rotation_mask=rmask,
-                               rotation_mirror=rotation_mirror),
-                           move_target, target_coords, rotation_mask))
-
-        # success
-        success = self.ik_convergence_check(dif_pos, dif_rot, thre, rthre)
-
-        # reset joint angle limit weight
-        self.reset_joint_angle_limit_weight(union_link_list)
-
-        # TODO(add collision check)
-        if success or not revert_if_fail:
-            # Apply joint limit table constraints to ensure
-            # bidirectional dependencies are satisfied
-            return self.apply_joint_limit_table_constraints()
-
-        # reset angle vector
-        for joint, angle in zip(joint_list, av0):
-            joint.joint_angle(angle)
-        if c0 is not None:
-            self.newcoords(c0)
-        return False
+            # reset angle vector
+            for joint, angle in zip(joint_list, av0):
+                joint.joint_angle(angle)
+            if c0 is not None:
+                self.newcoords(c0)
+            return False
+        finally:
+            if _base_state is not None:
+                self._detach_virtual_base_joint(_base_state)
 
     def ik_convergence_check(self, dif_pos, dif_rot, thre, rthre):
         """Check IK convergence.

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -1172,6 +1172,139 @@ class CascadedLink(CascadedCoords):
             for key in state['rel_entries']:
                 self._relevance_predicate_table.pop(key, None)
 
+    def _attach_batch_virtual_base_chain(self, use_base, link_list):
+        """Inject a chain of single-DoF virtual joints above ``root_link``.
+
+        Unlike :meth:`_attach_virtual_base_joint`, which uses the multi-DoF
+        :class:`PlanarJoint` / :class:`FloatingJoint`, the batch IK solver
+        only supports single-DoF joints. We decompose the virtual base into
+        an equivalent chain of :class:`LinearJoint` and
+        :class:`RotationalJoint` links so ``extract_fk_parameters`` and
+        ``compute_geometric_jacobian_batched_*`` accept it unchanged.
+
+        Chain layouts:
+
+        - ``'planar'``: ``world -> px -> py -> rz -> root`` (3 DoF).
+        - ``'6dof'``:   ``world -> px -> py -> pz -> rx -> ry -> rz ->
+          root`` (6 DoF, body-fixed XYZ-Euler).
+
+        The chain is kinematically equivalent to the corresponding
+        multi-DoF :class:`PlanarJoint` / :class:`FloatingJoint` because
+        subsequent joints in a serial chain operate in the preceding
+        joint's body frame, which reproduces intrinsic-Euler composition.
+        """
+        if use_base == 'planar':
+            specs = [
+                ('lin', 'x'),
+                ('lin', 'y'),
+                ('rot', 'z'),
+            ]
+            n_dof = 3
+        elif use_base == '6dof':
+            specs = [
+                ('lin', 'x'),
+                ('lin', 'y'),
+                ('lin', 'z'),
+                ('rot', 'x'),
+                ('rot', 'y'),
+                ('rot', 'z'),
+            ]
+            n_dof = 6
+        else:
+            raise ValueError(
+                "use_base must be False, 'planar', or '6dof', got %r"
+                % (use_base,))
+
+        root_link = self._find_fullbody_root_link()
+        virtual_world = Link(name='_batch_ik_virtual_world')
+
+        chain_links = []
+        chain_joints = []
+        parent = virtual_world
+        for i, (kind, axis) in enumerate(specs):
+            # The final joint in the chain attaches to the real root_link.
+            if i == len(specs) - 1:
+                child = root_link
+            else:
+                child = Link(name='_batch_ik_virtual_{}_{}'.format(
+                    i, axis))
+                chain_links.append(child)
+            if kind == 'lin':
+                j = LinearJoint(
+                    axis=axis,
+                    parent_link=parent, child_link=child,
+                    name='_batch_ik_virtual_{}{}_joint'.format(kind, axis),
+                    min_angle=-np.inf, max_angle=np.inf,
+                )
+            else:
+                j = RotationalJoint(
+                    axis=axis,
+                    parent_link=parent, child_link=child,
+                    name='_batch_ik_virtual_{}{}_joint'.format(kind, axis),
+                    min_angle=-np.inf, max_angle=np.inf,
+                )
+            chain_joints.append(j)
+            parent.add_child_link(child)
+            # Wire child -> its joint + parent link (Joint.__init__ records
+            # parent_link/child_link but does not mutate the child's
+            # .joint or ._parent_link fields).
+            if child is not root_link:
+                child.joint = j
+                child._parent_link = parent
+            parent = child
+
+        # The final chain link IS root_link. Its original parent/joint are
+        # snapshotted so we can restore them in detach.
+        state = {
+            'root_link': root_link,
+            'virtual_world': virtual_world,
+            'chain_links': chain_links,
+            'chain_joints': chain_joints,
+            'n_dof': n_dof,
+            'use_base': use_base,
+            'orig_parent_link': root_link._parent_link,
+            'orig_joint': root_link.joint,
+        }
+        root_link._parent_link = chain_joints[-1].parent_link
+        root_link.joint = chain_joints[-1]
+
+        # Prepend the full virtual chain (in kinematic order, excluding
+        # virtual_world which has no joint) to every sub link_list, so the
+        # batch solver's union_link_list sees the virtual joints.
+        virtual_chain_links = chain_links + [root_link]
+        if link_list is None:
+            new_link_list = None
+        else:
+            was_nested = (
+                len(link_list) > 0 and isinstance(link_list[0], list))
+            if was_nested:
+                sub_lists = [list(ll) for ll in link_list]
+            else:
+                sub_lists = [list(link_list)]
+            rewritten = [
+                list(virtual_chain_links)
+                + [lk for lk in ll if lk is not root_link]
+                for ll in sub_lists
+            ]
+            new_link_list = rewritten if was_nested else rewritten[0]
+        state['link_list'] = new_link_list
+        state['virtual_chain_links'] = virtual_chain_links
+        state['was_nested'] = was_nested if link_list is not None else False
+        return state
+
+    def _detach_batch_virtual_base_chain(self, state):
+        """Undo a previous ``_attach_batch_virtual_base_chain`` call."""
+        root_link = state['root_link']
+        root_link._parent_link = state['orig_parent_link']
+        root_link.joint = state['orig_joint']
+        # Break parent/child links within the virtual chain so GC can
+        # reclaim them; joints hold strong refs both ways.
+        for j in state['chain_joints']:
+            pl = j.parent_link
+            cl = j.child_link
+            if cl in pl._child_links:
+                pl.del_child_link(cl)
+
     def inverse_kinematics(
             self,
             target_coords,
@@ -2692,6 +2825,8 @@ class RobotModel(CascadedLink):
             translation_tolerance=None,
             rotation_tolerance=None,
             backend=None,
+            use_base=False,
+            base_weight=None,
             **kwargs):
         """Solve batch inverse kinematics for multiple target poses.
 
@@ -2800,11 +2935,41 @@ class RobotModel(CascadedLink):
         position_mask, rotation_mask, rotation_mirror = self._resolve_mask_params(
             position_mask, rotation_mask, rotation_mirror)
 
-        return self._batch_inverse_kinematics_impl(
-            target_coords, move_target, link_list,
-            rotation_mask, position_mask, rotation_mirror, stop, thre, rthre,
-            initial_angles, alpha, attempts_per_pose, random_initial_range,
-            translation_tolerance, rotation_tolerance, backend=backend, **kwargs)
+        # Fullbody IK via a virtual base joint chain. When set, returns a
+        # 4-tuple (angle_vectors, base_poses, success_flags, attempts).
+        _base_state = None
+        if use_base:
+            if link_list is None:
+                # Need move_target to derive the default link_list; fall
+                # through to impl which handles that case.
+                resolved_mt = (self.end_coords if move_target is None
+                               else move_target)
+                if isinstance(resolved_mt, list):
+                    link_list = [self.link_lists(mt.parent)
+                                 for mt in resolved_mt]
+                else:
+                    link_list = self.link_lists(resolved_mt.parent)
+            _base_state = self._attach_batch_virtual_base_chain(
+                use_base, link_list)
+            link_list = _base_state['link_list']
+        elif base_weight is not None:
+            warnings.warn(
+                'base_weight is ignored when use_base is False',
+                RuntimeWarning)
+        try:
+            result = self._batch_inverse_kinematics_impl(
+                target_coords, move_target, link_list,
+                rotation_mask, position_mask, rotation_mirror, stop, thre,
+                rthre, initial_angles, alpha, attempts_per_pose,
+                random_initial_range, translation_tolerance,
+                rotation_tolerance, backend=backend,
+                _base_state=_base_state,
+                base_weight=base_weight,
+                **kwargs)
+        finally:
+            if _base_state is not None:
+                self._detach_batch_virtual_base_chain(_base_state)
+        return result
 
     def _batch_inverse_kinematics_impl(
             self, target_coords, move_target, link_list,
@@ -2813,6 +2978,15 @@ class RobotModel(CascadedLink):
             translation_tolerance, rotation_tolerance, backend=None, **kwargs):
         """Internal implementation of batch inverse kinematics using backend solver."""
         from skrobot.kinematics.differentiable import create_batch_ik_solver
+
+        # Fullbody IK state threaded from the public wrapper.
+        _base_state = kwargs.pop('_base_state', None)
+        _base_weight = kwargs.pop('base_weight', None)
+        if _base_state is not None and _base_weight is not None:
+            warnings.warn(
+                'base_weight is not yet wired into batch inverse_kinematics '
+                '(Phase 3C); falling back to uniform base weighting.',
+                RuntimeWarning)
 
         # Auto-select backend: prefer JAX if available, fallback to NumPy
         if backend is None:
@@ -2849,7 +3023,8 @@ class RobotModel(CascadedLink):
                 rotation_mask, position_mask, rotation_mirror, stop, thre,
                 rthre, initial_angles, alpha, attempts_per_pose,
                 random_initial_range, translation_tolerance,
-                rotation_tolerance, backend=backend, **kwargs)
+                rotation_tolerance, backend=backend,
+                _base_state=_base_state, **kwargs)
         if link_list_is_nested and len(link_list) > 1:
             raise ValueError(
                 "Ambiguous batch_inverse_kinematics inputs: link_list has {} "
@@ -3010,7 +3185,54 @@ class RobotModel(CascadedLink):
         # Compute attempt counts (backend always uses all attempts, return attempts_per_pose)
         attempt_counts = [attempts_per_pose] * n_poses
 
+        if _base_state is not None:
+            # Virtual chain joints occupy the first n_dof positions of
+            # single_link_list; their angles in the fk solution vector are
+            # interpreted per use_base to synthesize the per-pose base pose.
+            n_dof = _base_state['n_dof']
+            base_poses = [
+                self._virtual_chain_angles_to_base_pose(
+                    solutions_np[i, :n_dof], _base_state['use_base'])
+                for i in range(n_poses)
+            ]
+            return full_solutions, base_poses, success_flags, attempt_counts
+
         return full_solutions, success_flags, attempt_counts
+
+    @staticmethod
+    def _virtual_chain_angles_to_base_pose(joint_angles, use_base):
+        """Convert virtual-chain joint angles to a world-frame base pose.
+
+        The decomposition in :meth:`_attach_batch_virtual_base_chain` means
+        the per-DoF angles compose exactly like the corresponding
+        :class:`PlanarJoint` / :class:`FloatingJoint` applied to
+        ``default_coords = identity``.
+        """
+        if use_base == 'planar':
+            x, y, yaw = float(joint_angles[0]), float(joint_angles[1]), float(
+                joint_angles[2])
+            cz, sz = np.cos(yaw), np.sin(yaw)
+            rot = np.array(
+                [[cz, -sz, 0.0], [sz, cz, 0.0], [0.0, 0.0, 1.0]])
+            return Coordinates(pos=np.array([x, y, 0.0]), rot=rot)
+        if use_base == '6dof':
+            x, y, z = (float(joint_angles[0]), float(joint_angles[1]),
+                       float(joint_angles[2]))
+            rx, ry, rz = (float(joint_angles[3]), float(joint_angles[4]),
+                          float(joint_angles[5]))
+            cx, sx = np.cos(rx), np.sin(rx)
+            cy, sy = np.cos(ry), np.sin(ry)
+            cz, sz = np.cos(rz), np.sin(rz)
+            Rx = np.array(
+                [[1, 0, 0], [0, cx, -sx], [0, sx, cx]])
+            Ry = np.array(
+                [[cy, 0, sy], [0, 1, 0], [-sy, 0, cy]])
+            Rz = np.array(
+                [[cz, -sz, 0], [sz, cz, 0], [0, 0, 1]])
+            return Coordinates(
+                pos=np.array([x, y, z]), rot=Rx @ Ry @ Rz)
+        raise ValueError(
+            "Unknown use_base value %r" % (use_base,))
 
     @staticmethod
     def _multi_ee_targets_to_pos_rot(target_coords_for_task):
@@ -3065,6 +3287,14 @@ class RobotModel(CascadedLink):
           applied to the stacked DLS residuals. Default: uniform 1.0.
         """
         from skrobot.kinematics.differentiable import create_batch_ik_solver
+
+        _base_state = kwargs.pop('_base_state', None)
+        _base_weight = kwargs.pop('base_weight', None)
+        if _base_state is not None and _base_weight is not None:
+            warnings.warn(
+                'base_weight is not yet wired into batch inverse_kinematics '
+                '(Phase 3C); falling back to uniform base weighting.',
+                RuntimeWarning)
 
         if backend is None:
             from skrobot.pycompat import HAS_JAX
@@ -3190,6 +3420,33 @@ class RobotModel(CascadedLink):
 
         success_flags = [bool(s) for s in success_np]
         attempt_counts = [attempts_per_pose] * n_poses
+
+        if _base_state is not None:
+            # Extract virtual-chain joint angles from the union solution by
+            # looking up each virtual joint in union_refs.
+            n_dof = _base_state['n_dof']
+            chain_joints = _base_state['chain_joints']
+            virtual_union_indices = []
+            for vj in chain_joints:
+                for uidx, ref in enumerate(union_refs):
+                    if ref is vj:
+                        virtual_union_indices.append(uidx)
+                        break
+            if len(virtual_union_indices) != n_dof:
+                raise RuntimeError(
+                    "Failed to locate all virtual-chain joints in union "
+                    "(found {} of {}).".format(
+                        len(virtual_union_indices), n_dof))
+            virtual_idx_arr = np.asarray(virtual_union_indices,
+                                         dtype=np.int64)
+            virtual_angles = solutions_np[:, virtual_idx_arr]
+            base_poses = [
+                self._virtual_chain_angles_to_base_pose(
+                    virtual_angles[i], _base_state['use_base'])
+                for i in range(n_poses)
+            ]
+            return full_solutions, base_poses, success_flags, attempt_counts
+
         return full_solutions, success_flags, attempt_counts
 
     def inverse_kinematics_loop(self,

--- a/skrobot/models/__init__.py
+++ b/skrobot/models/__init__.py
@@ -2,6 +2,7 @@
 
 from skrobot.models.differential_wrist_sample import DifferentialWristSample
 from skrobot.models.fetch import Fetch
+from skrobot.models.griphis import Griphis
 from skrobot.models.kuka import Kuka
 from skrobot.models.nextage import Nextage
 from skrobot.models.panda import Panda

--- a/skrobot/models/griphis.py
+++ b/skrobot/models/griphis.py
@@ -1,0 +1,125 @@
+from cached_property import cached_property
+import numpy as np
+
+from skrobot.coordinates import CascadedCoords
+from skrobot.data import griphis_urdfpath
+from skrobot.models.urdf import RobotModelFromURDF
+
+
+class _NailCentroidEndCoords(CascadedCoords):
+    """End-effector coords whose world pose is the live centroid of four
+    nail-tip CascadedCoords, oriented with +X along the tip-forward
+    direction of ``parent_link``.
+
+    The standard CascadedCoords caches a local offset from its parent and
+    composes with ``parent.worldcoords()`` on update.  For Griphis the
+    nail tips move with the mimic-driven ``worm_rotate`` joint, which
+    sits *below* the parent link; a cached local offset would go stale
+    every time worm_rotate changes.  This subclass overrides ``update``
+    to recompute the world pose directly from the (live) tip world
+    positions, so callers never have to manually refresh the frame.
+    """
+
+    def __init__(self, name, parent_link, tips, flip):
+        # Assign attrs before super().__init__ because the parent.assoc()
+        # call inside it triggers a worldcoords() update, which lands in
+        # our overridden update() and needs these attrs to be present.
+        self._tips = tips
+        self._flip = np.asarray(flip, dtype=np.float64)
+        self._parent_link = parent_link
+        super(_NailCentroidEndCoords, self).__init__(
+            parent=parent_link, name=name)
+
+    def update(self, force=False):
+        # Always recompute from live tip positions.  We bypass the usual
+        # parent-world × local-offset composition because the tips'
+        # positions can change without flagging ``_changed`` on this
+        # coord (worm_rotate moves the tips but not the parent link).
+        hook_disabled, original_hook = self.disable_hook()
+        try:
+            centroid = np.mean(
+                [t.worldpos() for t in self._tips], axis=0)
+            rot = self._parent_link.worldrot().dot(self._flip)
+            self._worldcoords._translation = np.asarray(
+                centroid, dtype=np.float64)
+            self._worldcoords._rotation = np.asarray(
+                rot, dtype=np.float64)
+        finally:
+            if hook_disabled:
+                self._hook = original_hook
+        self._changed = False
+
+
+class Griphis(RobotModelFromURDF):
+    """Griphis two-gripper wall-climbing robot.
+
+    Each gripper has four "nail" fingers whose tips form a plane; the
+    per-gripper end-effector frame is placed at their centroid with its
+    +X axis aligned with the tip-forward direction.  Gripper 2's nail
+    meshes are mirrored relative to gripper 1's (tips live at local -X
+    instead of +X), so the class normalizes the frame for both grippers
+    and callers can treat them uniformly in IK targets.
+
+    ``gripper_{1,2}_end_coords.worldcoords()`` is computed on every
+    access from the live nail-tip positions, so changes to
+    ``worm_rotate_{1,2}`` (which move the tips via URDF mimic bindings)
+    are reflected automatically — no manual refresh is required.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(Griphis, self).__init__(*args, **kwargs)
+        e1, tips1 = self._attach_gripper_end_coords(1)
+        e2, tips2 = self._attach_gripper_end_coords(2)
+        self.gripper_1_end_coords = e1
+        self.gripper_2_end_coords = e2
+        self.gripper_1_nail_tips = tips1
+        self.gripper_2_nail_tips = tips2
+
+    @cached_property
+    def default_urdf_path(self):
+        return griphis_urdfpath()
+
+    def _attach_gripper_end_coords(self, gripper_id):
+        """Attach per-nail tip coords and a live-centroid end_coords."""
+        tips = []
+        tip_x_signs = []
+        for i in range(1, 5):
+            link = getattr(self, 'nail{}_{}_link'.format(i, gripper_id))
+            tip_pos = self._nail_tip_local(link)
+            tip_x_signs.append(np.sign(tip_pos[0]))
+            tip = CascadedCoords(
+                pos=tip_pos,
+                name='nail{}_{}_tip'.format(i, gripper_id))
+            link.assoc(tip, relative_coords='local')
+            tips.append(tip)
+
+        roll_link = getattr(self, 'roll_{}_link'.format(gripper_id))
+        # Gripper 2's tips sit at -X of their nail links, so the gripper's
+        # forward direction is -X of roll_link too.  Flipping the x/y
+        # columns of the world rotation keeps +X pointing at the tips
+        # for both grippers.
+        flip = np.eye(3)
+        if np.mean(tip_x_signs) < 0:
+            flip = np.array([[-1.0, 0.0, 0.0],
+                             [0.0, -1.0, 0.0],
+                             [0.0, 0.0, 1.0]])
+
+        end_coords = _NailCentroidEndCoords(
+            name='gripper_{}_end'.format(gripper_id),
+            parent_link=roll_link,
+            tips=tips,
+            flip=flip,
+        )
+        return end_coords, tips
+
+    @staticmethod
+    def _nail_tip_local(link):
+        """Vertex with the largest |x| on the link's visual mesh, in the
+        link's local frame.  The URDF loader has already parsed and cached
+        the mesh on each link, so no extra trimesh.load is needed."""
+        meshes = link.visual_mesh
+        if not isinstance(meshes, list):
+            meshes = [meshes]
+        verts = np.concatenate(
+            [np.asarray(m.vertices) for m in meshes], axis=0)
+        return verts[np.argmax(np.abs(verts[:, 0]))]

--- a/tests/skrobot_tests/model_tests/test_batch_use_base.py
+++ b/tests/skrobot_tests/model_tests/test_batch_use_base.py
@@ -192,19 +192,77 @@ def test_batch_use_base_does_not_grow_solver_cache():
             before, after))
 
 
-def test_batch_use_base_base_weight_warns():
-    """base_weight is accepted but ignored with a RuntimeWarning in 3B."""
+def _pr2_base_displacement(base_weight, dx=0.3):
+    """Solve a +x target on PR2 rarm with the given base_weight and
+    report how much the base moved. PR2's rarm is flexible enough from
+    its reset pose that arm vs. base is genuinely weight-sensitive;
+    Fetch's default pose tucks the arm and skews this test."""
+    robot = skrobot.models.PR2()
+    robot.reset_pose()
+    ee = robot.rarm.end_coords.worldpos()
+    targets = [Coordinates(pos=ee + np.array([dx, 0.0, 0.0]))]
+    _, base_poses, success, _ = robot.batch_inverse_kinematics(
+        target_coords=targets,
+        move_target=robot.rarm.end_coords,
+        link_list=robot.link_lists(robot.rarm.end_coords.parent),
+        rotation_mask=False,
+        stop=500, thre=0.005,
+        backend='numpy', initial_angles='current',
+        use_base='planar', base_weight=base_weight,
+    )
+    return base_poses[0].worldpos(), bool(success[0])
+
+
+def test_batch_base_weight_shifts_effort():
+    """Higher base_weight => base moves more; lower base_weight => less."""
+    pos_heavy, ok_heavy = _pr2_base_displacement(base_weight=0.01)
+    pos_light, ok_light = _pr2_base_displacement(base_weight=10.0)
+    assert ok_heavy and ok_light, (
+        "both solves should succeed; heavy={}, light={}".format(
+            ok_heavy, ok_light))
+    # A "heavy" base (weight << 1) makes the base barely move; a "light"
+    # base (weight >> 1) makes the base do most of the work. Expect a
+    # sizeable gap on the same 30 cm target.
+    assert pos_light[0] > pos_heavy[0] + 0.1, (
+        "expected light-base to travel further than heavy-base; "
+        "heavy_x={:.3f}, light_x={:.3f}".format(pos_heavy[0], pos_light[0]))
+
+
+def test_batch_base_weight_per_axis_discourages_yaw():
+    """Per-axis base_weight [1, 1, 0.01] discourages base yaw rotation."""
     robot = _build_fetch()
     ee = robot.rarm_end_coords.worldpos()
-    targets = [Coordinates(pos=ee + np.array([0.5, 0, 0]))]
+    # Off-axis target makes yaw attractive to the solver.
+    targets = [Coordinates(pos=ee + np.array([0.4, 0.3, 0.0]))]
+    solutions, base_poses, success, _ = robot.batch_inverse_kinematics(
+        target_coords=targets,
+        move_target=robot.rarm_end_coords,
+        link_list=robot.rarm.link_list,
+        rotation_mask=False,
+        stop=200, thre=0.01,
+        backend='numpy', initial_angles='current',
+        use_base='planar', base_weight=[1.0, 1.0, 0.01],
+    )
+    assert success[0]
+    # Extract yaw from base pose rotation (planar → rotation is Rz(yaw)).
+    rot = base_poses[0].worldrot()
+    yaw = float(np.arctan2(rot[1, 0], rot[0, 0]))
+    assert abs(yaw) < 0.05, (
+        "expected near-zero yaw under heavy yaw weighting, got {}".format(
+            yaw))
 
-    with pytest.warns(RuntimeWarning, match="base_weight"):
+
+def test_batch_base_weight_rejects_nonpositive():
+    """base_weight <= 0 raises a clear ValueError."""
+    robot = _build_fetch()
+    ee = robot.rarm_end_coords.worldpos()
+    targets = [Coordinates(pos=ee + np.array([0.4, 0, 0]))]
+    with pytest.raises(ValueError, match="base_weight"):
         robot.batch_inverse_kinematics(
             target_coords=targets,
             move_target=robot.rarm_end_coords,
             link_list=robot.rarm.link_list,
             rotation_mask=False,
-            stop=50, thre=0.01,
-            backend='numpy', initial_angles='current',
-            use_base='planar', base_weight=0.1,
+            stop=30, backend='numpy', initial_angles='current',
+            use_base='planar', base_weight=0.0,
         )

--- a/tests/skrobot_tests/model_tests/test_batch_use_base.py
+++ b/tests/skrobot_tests/model_tests/test_batch_use_base.py
@@ -1,0 +1,178 @@
+"""Tests for batch_inverse_kinematics with use_base."""
+import numpy as np
+import pytest
+
+import skrobot
+from skrobot.coordinates import Coordinates
+
+
+def _build_fetch():
+    robot = skrobot.models.Fetch()
+    return robot
+
+
+def test_batch_use_base_false_backcompat():
+    """use_base=False leaves return signature as 3-tuple, same as before."""
+    robot = _build_fetch()
+    ee = robot.rarm_end_coords.worldpos()
+    target = [Coordinates(pos=ee + np.array([0.1, 0.0, 0.0]))]
+
+    result = robot.batch_inverse_kinematics(
+        target_coords=target,
+        move_target=robot.rarm_end_coords,
+        link_list=robot.rarm.link_list,
+        rotation_mask=False,
+        stop=100, thre=0.01,
+        backend='numpy', initial_angles='current',
+    )
+    assert isinstance(result, tuple) and len(result) == 3
+
+
+def test_batch_use_base_planar_reaches_far_target():
+    """Arm-unreachable target succeeds with use_base='planar'; applied base
+    + angle vector reproduces the target EE pose."""
+    robot = _build_fetch()
+    ee = robot.rarm_end_coords.worldpos()
+    N = 3
+    targets = [
+        Coordinates(pos=ee + np.array([0.7 + 0.1 * i, 0.0, 0.0]))
+        for i in range(N)
+    ]
+    solutions, base_poses, success, _ = robot.batch_inverse_kinematics(
+        target_coords=targets,
+        move_target=robot.rarm_end_coords,
+        link_list=robot.rarm.link_list,
+        rotation_mask=False,
+        stop=200, thre=0.01,
+        backend='numpy', initial_angles='current',
+        use_base='planar',
+    )
+    assert all(success), "unexpected failures: {}".format(success)
+    # Apply each solution and verify the EE lands on target.
+    for av, bp, tgt in zip(solutions, base_poses, targets):
+        robot.angle_vector(av)
+        robot.newcoords(bp)
+        err = np.linalg.norm(
+            robot.rarm_end_coords.worldpos() - tgt.worldpos())
+        assert err < 0.01, "EE err {} exceeds threshold".format(err)
+
+
+def test_batch_use_base_planar_arm_alone_fails():
+    """Same far target without use_base fails — validates the base is what
+    made use_base='planar' succeed in the previous test."""
+    robot = _build_fetch()
+    ee = robot.rarm_end_coords.worldpos()
+    targets = [Coordinates(pos=ee + np.array([0.9, 0.0, 0.0]))]
+
+    _, success, _ = robot.batch_inverse_kinematics(
+        target_coords=targets,
+        move_target=robot.rarm_end_coords,
+        link_list=robot.rarm.link_list,
+        rotation_mask=False,
+        stop=200, thre=0.01,
+        backend='numpy', initial_angles='current',
+    )
+    assert not success[0], "arm alone should not reach 0.9m target"
+
+
+def test_batch_use_base_6dof_allows_vertical_motion():
+    """6dof base can move in z; planar base cannot reach a target that
+    needs vertical base displacement."""
+    robot = _build_fetch()
+    ee = robot.rarm_end_coords.worldpos()
+    # Target shifted far forward and up, beyond arm-only reach.
+    targets = [Coordinates(pos=ee + np.array([0.7, 0.0, 0.4]))]
+
+    _, base_poses_6, success_6, _ = robot.batch_inverse_kinematics(
+        target_coords=targets,
+        move_target=robot.rarm_end_coords,
+        link_list=robot.rarm.link_list,
+        rotation_mask=False,
+        stop=200, thre=0.01,
+        backend='numpy', initial_angles='current',
+        use_base='6dof',
+    )
+    assert success_6[0], "6dof should reach vertically displaced target"
+    # The base's z should have moved (non-trivially) to make the reach.
+    assert abs(base_poses_6[0].worldpos()[2]) > 0.05
+
+
+def test_batch_use_base_multi_ee_shared_base():
+    """Multi-EE + use_base: both arms share the same base DoFs."""
+    robot = _build_fetch()
+    rarm_mt = robot.rarm_end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+
+    ee = rarm_mt.worldpos()
+    r_targets = [Coordinates(pos=ee + np.array([0.6, 0.0, 0.0]))]
+    # Single-EE multi-task (arm alone, but wrapped in list form) to exercise
+    # the multi-EE + use_base path.
+    solutions, base_poses, success, _ = robot.batch_inverse_kinematics(
+        target_coords=[r_targets],
+        move_target=[rarm_mt],
+        link_list=[rarm_ll],
+        rotation_mask=False,
+        stop=200, thre=0.01,
+        backend='numpy', initial_angles='current',
+        use_base='planar',
+    )
+    assert success[0]
+    robot.angle_vector(solutions[0])
+    robot.newcoords(base_poses[0])
+    err = np.linalg.norm(rarm_mt.worldpos() - r_targets[0].worldpos())
+    assert err < 0.01
+
+
+def test_batch_use_base_invalid_raises():
+    """Invalid use_base value raises a clear ValueError."""
+    robot = _build_fetch()
+    ee = robot.rarm_end_coords.worldpos()
+    targets = [Coordinates(pos=ee + np.array([0.1, 0, 0]))]
+    with pytest.raises(ValueError, match="use_base"):
+        robot.batch_inverse_kinematics(
+            target_coords=targets,
+            move_target=robot.rarm_end_coords,
+            link_list=robot.rarm.link_list,
+            rotation_mask=False,
+            stop=10, backend='numpy', initial_angles='current',
+            use_base='bogus',
+        )
+
+
+def test_batch_use_base_detaches_on_exception():
+    """An exception inside the solver still detaches the virtual chain."""
+    robot = _build_fetch()
+    root_link = robot._find_fullbody_root_link()
+    orig_parent = root_link._parent_link
+    orig_joint = root_link.joint
+
+    with pytest.raises(Exception):
+        robot.batch_inverse_kinematics(
+            # Intentionally malformed input to trigger an error inside impl.
+            target_coords=np.zeros((1, 5)),  # wrong shape
+            move_target=robot.rarm_end_coords,
+            link_list=robot.rarm.link_list,
+            stop=10, backend='numpy', initial_angles='current',
+            use_base='planar',
+        )
+
+    assert root_link._parent_link is orig_parent
+    assert root_link.joint is orig_joint
+
+
+def test_batch_use_base_base_weight_warns():
+    """base_weight is accepted but ignored with a RuntimeWarning in 3B."""
+    robot = _build_fetch()
+    ee = robot.rarm_end_coords.worldpos()
+    targets = [Coordinates(pos=ee + np.array([0.5, 0, 0]))]
+
+    with pytest.warns(RuntimeWarning, match="base_weight"):
+        robot.batch_inverse_kinematics(
+            target_coords=targets,
+            move_target=robot.rarm_end_coords,
+            link_list=robot.rarm.link_list,
+            rotation_mask=False,
+            stop=50, thre=0.01,
+            backend='numpy', initial_angles='current',
+            use_base='planar', base_weight=0.1,
+        )

--- a/tests/skrobot_tests/model_tests/test_batch_use_base.py
+++ b/tests/skrobot_tests/model_tests/test_batch_use_base.py
@@ -160,6 +160,38 @@ def test_batch_use_base_detaches_on_exception():
     assert root_link.joint is orig_joint
 
 
+def test_batch_use_base_does_not_grow_solver_cache():
+    """Repeated use_base calls must not leave stale entries in the solver
+    caches; every call attaches fresh virtual Link/Joint objects whose
+    id()s are unique and would otherwise accumulate forever."""
+    robot = _build_fetch()
+    ee = robot.rarm_end_coords.worldpos()
+    targets = [Coordinates(pos=ee + np.array([0.3, 0.0, 0.0]))]
+
+    def _cache_sizes():
+        return (
+            len(getattr(robot, '_batch_ik_solver_cache', {}) or {}),
+            len(getattr(
+                robot, '_batch_ik_multi_ee_solver_cache', {}) or {}),
+        )
+
+    before = _cache_sizes()
+    for _ in range(3):
+        robot.batch_inverse_kinematics(
+            target_coords=targets,
+            move_target=robot.rarm_end_coords,
+            link_list=robot.rarm.link_list,
+            rotation_mask=False,
+            stop=30, thre=0.02,
+            backend='numpy', initial_angles='current',
+            use_base='planar',
+        )
+    after = _cache_sizes()
+    assert after == before, (
+        "use_base batch IK leaked solver cache entries: {} -> {}".format(
+            before, after))
+
+
 def test_batch_use_base_base_weight_warns():
     """base_weight is accepted but ignored with a RuntimeWarning in 3B."""
     robot = _build_fetch()

--- a/tests/skrobot_tests/model_tests/test_batch_use_base.py
+++ b/tests/skrobot_tests/model_tests/test_batch_use_base.py
@@ -295,8 +295,12 @@ def test_batch_base_weight_jax_parity_with_numpy():
     """JAX backend produces equivalent base_weight behavior to NumPy."""
     try:
         import jax  # noqa: F401
-    except ImportError:  # pragma: no cover
-        pytest.skip("JAX not installed")
+    except Exception:  # pragma: no cover - depends on environment
+        # A plain ImportError covers "jax not installed", but JAX also
+        # raises AttributeError (e.g. ``module 'numpy' has no attribute
+        # 'dtypes'``) when the installed numpy is older than what the
+        # current jax wheel expects.  Skip in either case.
+        pytest.skip("JAX not installed or incompatible with numpy")
 
     def _run(backend):
         robot = skrobot.models.PR2()

--- a/tests/skrobot_tests/model_tests/test_batch_use_base.py
+++ b/tests/skrobot_tests/model_tests/test_batch_use_base.py
@@ -252,6 +252,36 @@ def test_batch_base_weight_per_axis_discourages_yaw():
             yaw))
 
 
+def test_batch_base_weight_jax_parity_with_numpy():
+    """JAX backend produces equivalent base_weight behavior to NumPy."""
+    try:
+        import jax  # noqa: F401
+    except ImportError:  # pragma: no cover
+        pytest.skip("JAX not installed")
+
+    def _run(backend):
+        robot = skrobot.models.PR2()
+        robot.reset_pose()
+        ee = robot.rarm.end_coords.worldpos()
+        targets = [Coordinates(pos=ee + np.array([0.3, 0.0, 0.0]))]
+        _, base_poses, success, _ = robot.batch_inverse_kinematics(
+            target_coords=targets,
+            move_target=robot.rarm.end_coords,
+            link_list=robot.link_lists(robot.rarm.end_coords.parent),
+            rotation_mask=False,
+            stop=500, thre=0.005,
+            backend=backend, initial_angles='current',
+            use_base='planar', base_weight=0.1,
+        )
+        return base_poses[0].worldpos(), bool(success[0])
+
+    pos_np, ok_np = _run('numpy')
+    pos_jx, ok_jx = _run('jax')
+    assert ok_np and ok_jx
+    # JAX defaults to float32 so expect mm-scale drift at most.
+    np.testing.assert_allclose(pos_jx, pos_np, atol=0.01)
+
+
 def test_batch_base_weight_rejects_nonpositive():
     """base_weight <= 0 raises a clear ValueError."""
     robot = _build_fetch()

--- a/tests/skrobot_tests/model_tests/test_batch_use_base.py
+++ b/tests/skrobot_tests/model_tests/test_batch_use_base.py
@@ -139,6 +139,45 @@ def test_batch_use_base_invalid_raises():
         )
 
 
+def test_batch_virtual_base_chain_graph_consistency():
+    """Attach then detach keeps the kinematic graph consistent even when
+    root_link has a non-None original parent; root_link must not appear
+    in two parents' _child_links simultaneously during the solve."""
+    from skrobot.model.link import Link
+
+    robot = _build_fetch()
+    root_link = robot._find_fullbody_root_link()
+
+    # Give root_link a synthetic original parent with root_link as child
+    # so we can verify the attach helper cleans up that edge and the
+    # detach helper restores it.
+    synthetic_parent = Link(name='_test_synthetic_root_parent')
+    orig_parent = root_link._parent_link
+    root_link._parent_link = synthetic_parent
+    synthetic_parent.add_child_link(root_link)
+
+    try:
+        assert root_link in synthetic_parent._child_links
+        state = robot._attach_batch_virtual_base_chain(
+            'planar', robot.rarm.link_list)
+        # While attached, root_link must not be listed under the original
+        # parent; exactly the new virtual-chain tail should own it.
+        assert root_link not in synthetic_parent._child_links, (
+            "original parent still lists root_link after attach")
+        virtual_tail = state['chain_joints'][-1].parent_link
+        assert root_link in virtual_tail._child_links
+        robot._detach_batch_virtual_base_chain(state)
+        # After detach the original edge is restored and the virtual
+        # chain no longer owns root_link.
+        assert root_link in synthetic_parent._child_links, (
+            "original parent edge not restored after detach")
+        assert root_link._parent_link is synthetic_parent
+    finally:
+        if root_link in synthetic_parent._child_links:
+            synthetic_parent.del_child_link(root_link)
+        root_link._parent_link = orig_parent
+
+
 def test_batch_use_base_detaches_on_exception():
     """An exception inside the solver still detaches the virtual chain."""
     robot = _build_fetch()

--- a/tests/skrobot_tests/model_tests/test_fullbody_ik.py
+++ b/tests/skrobot_tests/model_tests/test_fullbody_ik.py
@@ -1,0 +1,152 @@
+import numpy as np
+from numpy import testing
+
+import skrobot
+from skrobot.coordinates import Coordinates
+
+
+def _far_target_from_current(robot):
+    """Target that is far enough the arm alone cannot reach."""
+    ee_pos = robot.rarm_end_coords.worldpos().copy()
+    return Coordinates(pos=ee_pos + np.array([0.8, 0.3, 0.0]))
+
+
+def test_inverse_kinematics_use_base_false_is_backcompat():
+    robot_a = skrobot.models.Fetch()
+    robot_b = skrobot.models.Fetch()
+    ee_pos = robot_a.rarm_end_coords.worldpos().copy()
+    target = Coordinates(pos=ee_pos + np.array([0.2, 0.1, 0.0]))
+
+    result_a = robot_a.inverse_kinematics(
+        target, move_target=robot_a.rarm_end_coords,
+        link_list=robot_a.rarm.link_list,
+        rotation_mask=False, stop=100)
+    result_b = robot_b.inverse_kinematics(
+        target, move_target=robot_b.rarm_end_coords,
+        link_list=robot_b.rarm.link_list,
+        rotation_mask=False, stop=100, use_base=False)
+
+    assert (result_a is False) == (result_b is False)
+    testing.assert_allclose(
+        robot_a.angle_vector(), robot_b.angle_vector(), atol=1e-8)
+
+
+def test_inverse_kinematics_use_base_planar_reaches_far_target():
+    robot = skrobot.models.Fetch()
+    root0 = robot.root_link.copy_worldcoords()
+    target = _far_target_from_current(robot)
+
+    result = robot.inverse_kinematics(
+        target, move_target=robot.rarm_end_coords,
+        link_list=robot.rarm.link_list,
+        rotation_mask=False, stop=100, use_base='planar')
+
+    assert result is not False
+    err = np.linalg.norm(
+        robot.rarm_end_coords.worldpos() - target.worldpos())
+    assert err < 1e-3, 'rarm end did not reach target: err={}'.format(err)
+    moved = np.linalg.norm(
+        robot.root_link.worldpos() - root0.worldpos())
+    assert moved > 0.1, 'base did not move to reach far target'
+
+
+def test_inverse_kinematics_use_base_detach_restores_root_link():
+    robot = skrobot.models.Fetch()
+    target = _far_target_from_current(robot)
+
+    robot.inverse_kinematics(
+        target, move_target=robot.rarm_end_coords,
+        link_list=robot.rarm.link_list,
+        rotation_mask=False, stop=100, use_base='planar')
+
+    # After the call the virtual joint must be gone.
+    assert robot.root_link.joint is None
+    assert robot.root_link.parent_link is None
+
+
+def test_inverse_kinematics_use_base_6dof_reaches_far_target():
+    robot = skrobot.models.Fetch()
+    target = _far_target_from_current(robot)
+
+    result = robot.inverse_kinematics(
+        target, move_target=robot.rarm_end_coords,
+        link_list=robot.rarm.link_list,
+        rotation_mask=False, stop=100, use_base='6dof')
+
+    assert result is not False
+    err = np.linalg.norm(
+        robot.rarm_end_coords.worldpos() - target.worldpos())
+    assert err < 1e-3
+
+
+def test_base_weight_biases_toward_arm_when_small():
+    """Small base_weight makes arm absorb most of the motion."""
+    def run(bw):
+        robot = skrobot.models.Fetch()
+        ee0 = robot.rarm_end_coords.worldpos().copy()
+        # y-only target: both arm (shoulder_pan) and base can contribute.
+        target = Coordinates(pos=ee0 + np.array([0.0, 0.1, 0.0]))
+        robot.inverse_kinematics(
+            target, move_target=robot.rarm_end_coords,
+            link_list=robot.rarm.link_list,
+            rotation_mask=False, stop=200,
+            use_base='planar', base_weight=bw)
+        base_y = abs(robot.root_link.worldpos()[1])
+        return base_y
+
+    base_y_equal = run(1.0)
+    base_y_arm_pref = run(0.01)
+    base_y_base_pref = run(100.0)
+
+    assert base_y_arm_pref < base_y_equal
+    assert base_y_equal < base_y_base_pref
+    # Arm-preferred should move the base at least 10x less than equal.
+    assert base_y_arm_pref * 10 < base_y_equal
+
+
+def test_base_weight_per_axis_vector():
+    """Providing a per-axis sequence weights base DoFs independently."""
+    robot = skrobot.models.Fetch()
+    ee0 = robot.rarm_end_coords.worldpos().copy()
+    target = Coordinates(pos=ee0 + np.array([0.0, 0.1, 0.0]))
+    # Heavy yaw penalty, light xy.
+    robot.inverse_kinematics(
+        target, move_target=robot.rarm_end_coords,
+        link_list=robot.rarm.link_list,
+        rotation_mask=False, stop=200,
+        use_base='planar', base_weight=[1.0, 1.0, 0.001])
+    # Should still converge — vector weight accepted.
+    err = np.linalg.norm(
+        robot.rarm_end_coords.worldpos() - target.worldpos())
+    assert err < 1e-3
+
+
+def test_base_weight_without_use_base_warns():
+    robot = skrobot.models.Fetch()
+    ee0 = robot.rarm_end_coords.worldpos().copy()
+    target = Coordinates(pos=ee0 + np.array([0.01, 0.0, 0.0]))
+    # Expect a warning but IK still runs normally.
+    robot.inverse_kinematics(
+        target, move_target=robot.rarm_end_coords,
+        link_list=robot.rarm.link_list,
+        rotation_mask=False, stop=50,
+        use_base=False, base_weight=0.5)
+
+
+def test_inverse_kinematics_use_base_invalid_raises():
+    robot = skrobot.models.Fetch()
+    ee_pos = robot.rarm_end_coords.worldpos().copy()
+    target = Coordinates(pos=ee_pos + np.array([0.1, 0.0, 0.0]))
+
+    try:
+        robot.inverse_kinematics(
+            target, move_target=robot.rarm_end_coords,
+            link_list=robot.rarm.link_list,
+            rotation_mask=False, stop=10, use_base='invalid')
+    except ValueError:
+        pass
+    else:
+        raise AssertionError('Expected ValueError for invalid use_base')
+    # Detach must still have run via finally.
+    assert robot.root_link.joint is None
+    assert robot.root_link.parent_link is None

--- a/tests/skrobot_tests/model_tests/test_fullbody_ik.py
+++ b/tests/skrobot_tests/model_tests/test_fullbody_ik.py
@@ -208,3 +208,27 @@ def test_multi_ee_link_list_auto_reorders_to_match_move_target():
     assert l_err_correct < 5e-3
     assert l_err_swapped < 5e-3
     testing.assert_allclose(av_correct, av_swapped, atol=1e-6)
+
+
+def test_multi_ee_reorder_helper_ignores_shared_root_link():
+    """When use_base is active, the virtual-base injection prepends the
+    shared root_link to every sub-chain.  The reorder helper must still
+    produce a unique per-move_target match by ignoring links that appear
+    in more than one chain.
+    """
+    robot = skrobot.models.PR2()
+    base_link = robot.root_link
+    # Simulate what _attach_virtual_base_joint does: prepend root_link
+    # to every arm chain so both sub-lists share the first element.
+    rarm_with_root = [base_link] + robot.rarm.link_list
+    larm_with_root = [base_link] + robot.larm.link_list
+
+    # Pass them in swapped order; helper must still pair rarm->rarm_with_root.
+    reordered = robot._reorder_link_lists_for_move_targets(
+        [larm_with_root, rarm_with_root],
+        [robot.rarm_end_coords, robot.larm_end_coords])
+
+    assert reordered[0] is rarm_with_root, (
+        'rarm_end_coords must pair with the chain containing r_shoulder_pan '
+        'even though both chains share root_link')
+    assert reordered[1] is larm_with_root

--- a/tests/skrobot_tests/model_tests/test_fullbody_ik.py
+++ b/tests/skrobot_tests/model_tests/test_fullbody_ik.py
@@ -150,3 +150,61 @@ def test_inverse_kinematics_use_base_invalid_raises():
     # Detach must still have run via finally.
     assert robot.root_link.joint is None
     assert robot.root_link.parent_link is None
+
+
+def _run_multi_ee_dual_arm(robot, link_list_order):
+    """Solve the same 2-EE IK with a user-specified ``link_list_order``.
+
+    ``link_list_order`` controls which arm chain is passed as
+    ``link_list[0]`` vs ``link_list[1]``.  ``move_target`` and
+    ``target_coords`` are always in (rarm, larm) order, so the two
+    arguments agree when ``link_list_order == ('rarm', 'larm')`` and
+    disagree when ``('larm', 'rarm')`` — the reorder helper has to fix
+    the latter silently.
+    """
+    robot.reset_manip_pose()  # start from a valid, within-limits pose
+    chains = {'rarm': robot.rarm.link_list, 'larm': robot.larm.link_list}
+    r_goal = Coordinates(
+        pos=robot.rarm_end_coords.worldpos() + np.array([0.02, 0.0, 0.01]))
+    l_goal = Coordinates(
+        pos=robot.larm_end_coords.worldpos() + np.array([0.02, 0.0, 0.01]))
+    mask_pair = [np.array([1, 1, 1]), np.array([1, 1, 1])]
+    zero_mask = [np.array([0, 0, 0]), np.array([0, 0, 0])]
+    robot.inverse_kinematics(
+        target_coords=[r_goal, l_goal],
+        move_target=[robot.rarm_end_coords, robot.larm_end_coords],
+        link_list=[chains[link_list_order[0]], chains[link_list_order[1]]],
+        position_mask=mask_pair,
+        rotation_mask=zero_mask,
+        stop=200, thre=[0.001, 0.001])
+    return robot.angle_vector().copy(), r_goal, l_goal
+
+
+def test_multi_ee_link_list_auto_reorders_to_match_move_target():
+    """Swapping the order of link_list vs move_target must still converge
+    to the same joint configuration — the solver auto-pairs each
+    move_target with its kinematic-chain link_list.
+    """
+    robot_correct = skrobot.models.PR2()
+    av_correct, r_goal, l_goal = _run_multi_ee_dual_arm(
+        robot_correct, ('rarm', 'larm'))
+    r_err_correct = np.linalg.norm(
+        robot_correct.rarm_end_coords.worldpos() - r_goal.worldpos())
+    l_err_correct = np.linalg.norm(
+        robot_correct.larm_end_coords.worldpos() - l_goal.worldpos())
+
+    robot_swapped = skrobot.models.PR2()
+    av_swapped, r_goal_s, l_goal_s = _run_multi_ee_dual_arm(
+        robot_swapped, ('larm', 'rarm'))
+    r_err_swapped = np.linalg.norm(
+        robot_swapped.rarm_end_coords.worldpos() - r_goal_s.worldpos())
+    l_err_swapped = np.linalg.norm(
+        robot_swapped.larm_end_coords.worldpos() - l_goal_s.worldpos())
+
+    assert r_err_correct < 5e-3, (
+        'rarm err with correct order: {}'.format(r_err_correct))
+    assert r_err_swapped < 5e-3, (
+        'rarm err with swapped order: {}'.format(r_err_swapped))
+    assert l_err_correct < 5e-3
+    assert l_err_swapped < 5e-3
+    testing.assert_allclose(av_correct, av_swapped, atol=1e-6)

--- a/tests/skrobot_tests/model_tests/test_multi_ee_batch_ik.py
+++ b/tests/skrobot_tests/model_tests/test_multi_ee_batch_ik.py
@@ -330,8 +330,68 @@ def test_multi_ee_per_task_bool_masks_internal():
     assert sol.shape == (N, solver.union_n_opt)
 
 
-def test_multi_ee_jax_raises_until_ported():
-    """Multi-EE on JAX backend currently falls back to NumPy with a warning."""
+_HAS_JAX = False
+try:
+    import jax  # noqa: F401
+    _HAS_JAX = True
+except ImportError:  # pragma: no cover - depends on environment
+    pass
+
+
+@pytest.mark.skipif(not _HAS_JAX, reason="JAX not installed")
+def test_multi_ee_jax_parity_with_numpy():
+    """JAX multi-EE solver converges to the same solution as NumPy."""
+    from skrobot.kinematics.differentiable import create_batch_ik_solver
+
+    robot = _build_pr2()
+    rarm_mt = robot.rarm.end_coords
+    larm_mt = robot.larm.end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+    larm_ll = robot.link_lists(larm_mt.parent)
+
+    r_pos0 = rarm_mt.worldpos()
+    r_rot0 = rarm_mt.worldrot()
+    l_pos0 = larm_mt.worldpos()
+    l_rot0 = larm_mt.worldrot()
+
+    N = 3
+    r_pos_t = np.tile(r_pos0, (N, 1)) + np.array(
+        [[0.01 * (i + 1), 0.0, 0.0] for i in range(N)])
+    r_rot_t = np.tile(r_rot0, (N, 1, 1))
+    l_pos_t = np.tile(l_pos0, (N, 1)) + np.array(
+        [[-0.01 * (i + 1), 0.0, 0.0] for i in range(N)])
+    l_rot_t = np.tile(l_rot0, (N, 1, 1))
+
+    np_solver = create_batch_ik_solver(
+        robot, [rarm_ll, larm_ll], [rarm_mt, larm_mt],
+        backend_name='numpy')
+    union_refs = np_solver.union_info['union_joint_refs']
+    init = np.tile(
+        np.array([j.joint_angle() for j in union_refs]), (N, 1))
+
+    common = dict(
+        initial_angles=init, max_iterations=80,
+        pos_threshold=0.003, rot_threshold=0.05)
+
+    sol_np, _, err_np = np_solver(
+        [r_pos_t, l_pos_t], [r_rot_t, l_rot_t], **common)
+    jx_solver = create_batch_ik_solver(
+        robot, [rarm_ll, larm_ll], [rarm_mt, larm_mt],
+        backend_name='jax')
+    sol_jx, _, err_jx = jx_solver(
+        [r_pos_t, l_pos_t], [r_rot_t, l_rot_t], **common)
+
+    # Default JAX is float32; NumPy is float64. Tolerance allows for both
+    # the floating-type mismatch and the JIT accumulation order.
+    np.testing.assert_allclose(
+        np.asarray(sol_jx), np.asarray(sol_np), atol=1e-4)
+    np.testing.assert_allclose(
+        np.asarray(err_jx), np.asarray(err_np), atol=1e-4)
+
+
+@pytest.mark.skipif(not _HAS_JAX, reason="JAX not installed")
+def test_multi_ee_jax_public_api():
+    """batch_inverse_kinematics with backend='jax' routes through the JAX solver."""
     robot = _build_pr2()
     rarm_mt = robot.rarm.end_coords
     larm_mt = robot.larm.end_coords
@@ -343,11 +403,11 @@ def test_multi_ee_jax_raises_until_ported():
     lt = [Coordinates(pos=larm_mt.worldpos() - np.array([0.005, 0, 0]),
                       rot=larm_mt.worldrot())]
 
-    with pytest.warns(RuntimeWarning, match="Multi-EE batch IK"):
-        solutions, success, _ = robot.batch_inverse_kinematics(
-            target_coords=[rt, lt],
-            move_target=[rarm_mt, larm_mt], link_list=[rarm_ll, larm_ll],
-            stop=100, thre=0.005, rthre=np.deg2rad(3.0),
-            backend='jax', initial_angles='current',
-        )
+    solutions, success, _ = robot.batch_inverse_kinematics(
+        target_coords=[rt, lt],
+        move_target=[rarm_mt, larm_mt], link_list=[rarm_ll, larm_ll],
+        stop=100, thre=0.005, rthre=np.deg2rad(3.0),
+        backend='jax', initial_angles='current',
+    )
     assert len(solutions) == 1
+    assert success[0]

--- a/tests/skrobot_tests/model_tests/test_multi_ee_batch_ik.py
+++ b/tests/skrobot_tests/model_tests/test_multi_ee_batch_ik.py
@@ -1,0 +1,353 @@
+"""Tests for multi-end-effector batch inverse kinematics."""
+import numpy as np
+import pytest
+
+import skrobot
+from skrobot.coordinates import Coordinates
+
+
+def _build_pr2():
+    robot = skrobot.models.PR2()
+    robot.reset_pose()
+    return robot
+
+
+def test_multi_ee_single_task_matches_single_ee():
+    """Multi-EE with a single task is numerically identical to single-EE."""
+    robot_a = _build_pr2()
+    robot_b = _build_pr2()
+
+    rarm_mt_a = robot_a.rarm.end_coords
+    rarm_mt_b = robot_b.rarm.end_coords
+    rarm_ll_a = robot_a.link_lists(rarm_mt_a.parent)
+    rarm_ll_b = robot_b.link_lists(rarm_mt_b.parent)
+
+    pos0 = rarm_mt_a.worldpos()
+    rot0 = rarm_mt_a.worldrot()
+
+    N = 3
+    targets_single = [
+        Coordinates(pos=pos0 + np.array([0.01 * i, 0.0, 0.0]), rot=rot0)
+        for i in range(1, N + 1)
+    ]
+    # Same targets, wrapped for multi-EE (1 task).
+    targets_multi = [list(targets_single)]
+
+    sol_a, suc_a, _ = robot_a.batch_inverse_kinematics(
+        target_coords=targets_single,
+        move_target=rarm_mt_a, link_list=rarm_ll_a,
+        stop=100, thre=0.003, rthre=np.deg2rad(3.0),
+        backend='numpy', initial_angles='current',
+    )
+    sol_b, suc_b, _ = robot_b.batch_inverse_kinematics(
+        target_coords=targets_multi,
+        move_target=[rarm_mt_b], link_list=[rarm_ll_b],
+        stop=100, thre=0.003, rthre=np.deg2rad(3.0),
+        backend='numpy', initial_angles='current',
+    )
+
+    assert suc_a == suc_b
+    for sa, sb in zip(sol_a, sol_b):
+        np.testing.assert_allclose(sa, sb, atol=1e-10)
+
+
+def test_multi_ee_pr2_dual_arm_reachable_targets():
+    """PR2 dual-arm batch with small symmetric targets converges."""
+    robot = _build_pr2()
+    rarm_mt = robot.rarm.end_coords
+    larm_mt = robot.larm.end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+    larm_ll = robot.link_lists(larm_mt.parent)
+
+    r_pos0 = rarm_mt.worldpos()
+    r_rot0 = rarm_mt.worldrot()
+    l_pos0 = larm_mt.worldpos()
+    l_rot0 = larm_mt.worldrot()
+
+    N = 3
+    rarm_targets = [
+        Coordinates(pos=r_pos0 + np.array([0.005 * (i + 1), 0.0, 0.0]),
+                    rot=r_rot0) for i in range(N)
+    ]
+    larm_targets = [
+        Coordinates(pos=l_pos0 - np.array([0.005 * (i + 1), 0.0, 0.0]),
+                    rot=l_rot0) for i in range(N)
+    ]
+
+    solutions, success_flags, _ = robot.batch_inverse_kinematics(
+        target_coords=[rarm_targets, larm_targets],
+        move_target=[rarm_mt, larm_mt], link_list=[rarm_ll, larm_ll],
+        stop=200, thre=0.005, rthre=np.deg2rad(3.0),
+        backend='numpy', initial_angles='current',
+    )
+
+    # All should succeed for these conservative targets.
+    assert all(success_flags), "expected all successes, got {}".format(
+        success_flags)
+
+    # Verify by applying each solution and measuring EE error.
+    for i, sol in enumerate(solutions):
+        robot.angle_vector(sol)
+        r_err = np.linalg.norm(
+            rarm_mt.worldpos() - rarm_targets[i].worldpos())
+        l_err = np.linalg.norm(
+            larm_mt.worldpos() - larm_targets[i].worldpos())
+        assert r_err < 0.005, "rarm pose {} err {}".format(i, r_err)
+        assert l_err < 0.005, "larm pose {} err {}".format(i, l_err)
+
+
+def test_multi_ee_respects_shared_joints():
+    """Shared torso joint is solved jointly across tasks (union space)."""
+    robot = _build_pr2()
+    rarm_mt = robot.rarm.end_coords
+    larm_mt = robot.larm.end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+    larm_ll = robot.link_lists(larm_mt.parent)
+
+    # Construct the solver directly to inspect the union joint set.
+    from skrobot.kinematics.differentiable import create_batch_ik_solver
+    solver = create_batch_ik_solver(
+        robot, [rarm_ll, larm_ll], [rarm_mt, larm_mt],
+        backend_name='numpy',
+    )
+
+    # The two tasks share the torso_lift_joint (and any joint above it).
+    rarm_mapping = set(solver.union_info['task_mappings'][0].tolist())
+    larm_mapping = set(solver.union_info['task_mappings'][1].tolist())
+    shared = rarm_mapping & larm_mapping
+    assert len(shared) > 0, "expected at least one shared joint"
+    # Total union size < sum of per-task sizes when there is overlap.
+    total = (len(solver.union_info['task_mappings'][0])
+             + len(solver.union_info['task_mappings'][1]))
+    assert solver.union_n_opt < total
+
+
+def test_multi_ee_task_weights_bias_effort():
+    """Task weights shift effort distribution between tasks."""
+    robot_a = _build_pr2()
+    robot_b = _build_pr2()
+
+    def _run(robot, weights):
+        rarm_mt = robot.rarm.end_coords
+        larm_mt = robot.larm.end_coords
+        rarm_ll = robot.link_lists(rarm_mt.parent)
+        larm_ll = robot.link_lists(larm_mt.parent)
+        r_pos0 = rarm_mt.worldpos()
+        r_rot0 = rarm_mt.worldrot()
+        l_pos0 = larm_mt.worldpos()
+        l_rot0 = larm_mt.worldrot()
+
+        # One batch element. Easy rarm target, infeasible larm target (too
+        # far). Under very different weights the easy task's accuracy vs.
+        # the hard task's accuracy tradeoff changes.
+        r_targets = [Coordinates(pos=r_pos0 + np.array([0.01, 0.0, 0.0]),
+                                 rot=r_rot0)]
+        l_targets = [Coordinates(pos=l_pos0 + np.array([-0.30, 0.0, 0.0]),
+                                 rot=l_rot0)]
+        solutions, _, _ = robot.batch_inverse_kinematics(
+            target_coords=[r_targets, l_targets],
+            move_target=[rarm_mt, larm_mt], link_list=[rarm_ll, larm_ll],
+            stop=200, thre=0.001, rthre=np.deg2rad(3.0),
+            backend='numpy', initial_angles='current',
+            task_weights=weights,
+        )
+        robot.angle_vector(solutions[0])
+        r_err = np.linalg.norm(rarm_mt.worldpos() - r_targets[0].worldpos())
+        l_err = np.linalg.norm(larm_mt.worldpos() - l_targets[0].worldpos())
+        return r_err, l_err
+
+    # rarm-heavy: rarm error should be smaller than with balanced weights.
+    r_err_heavy, _ = _run(robot_a, [100.0, 1.0])
+    r_err_balanced, _ = _run(robot_b, [1.0, 1.0])
+    assert r_err_heavy <= r_err_balanced + 1e-6, (
+        "expected rarm-heavy weighting to reduce rarm error; "
+        "heavy={}, balanced={}".format(r_err_heavy, r_err_balanced))
+
+
+def test_multi_ee_input_validation():
+    """Shape mismatches raise clear ValueErrors."""
+    robot = _build_pr2()
+    rarm_mt = robot.rarm.end_coords
+    larm_mt = robot.larm.end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+    larm_ll = robot.link_lists(larm_mt.parent)
+
+    rt = [Coordinates(pos=rarm_mt.worldpos() + np.array([0.01, 0, 0]),
+                      rot=rarm_mt.worldrot())]
+    lt = [Coordinates(pos=larm_mt.worldpos() - np.array([0.01, 0, 0]),
+                      rot=larm_mt.worldrot()),
+          Coordinates(pos=larm_mt.worldpos() - np.array([0.02, 0, 0]),
+                      rot=larm_mt.worldrot())]
+
+    # Inconsistent batch sizes across tasks.
+    with pytest.raises(ValueError, match="Inconsistent batch sizes"):
+        robot.batch_inverse_kinematics(
+            target_coords=[rt, lt],
+            move_target=[rarm_mt, larm_mt], link_list=[rarm_ll, larm_ll],
+            stop=10, backend='numpy',
+        )
+
+    # Wrong number of move_targets for n_tasks > 1: detected as ambiguous.
+    with pytest.raises(ValueError, match="Ambiguous batch_inverse_kinematics"):
+        robot.batch_inverse_kinematics(
+            target_coords=[rt, rt],
+            move_target=rarm_mt, link_list=[rarm_ll, larm_ll],
+            stop=10, backend='numpy',
+        )
+
+
+def test_multi_ee_legacy_single_ee_nested_link_list():
+    """Legacy pattern ``link_list=[[...]]`` + scalar move_target stays single-EE."""
+    robot = _build_pr2()
+    rarm_mt = robot.rarm.end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+
+    pos0 = rarm_mt.worldpos()
+    rot0 = rarm_mt.worldrot()
+    targets = [Coordinates(pos=pos0 + np.array([0.01, 0.0, 0.0]), rot=rot0)]
+
+    # Should not raise "Ambiguous" and should solve as single-EE.
+    solutions, success, _ = robot.batch_inverse_kinematics(
+        target_coords=targets,
+        move_target=rarm_mt, link_list=[rarm_ll],
+        stop=100, thre=0.005, rthre=np.deg2rad(3.0),
+        backend='numpy', initial_angles='current',
+    )
+    assert len(solutions) == 1
+
+
+def test_multi_ee_inverted_shared_limits_errors():
+    """Shared joint with inconsistent limits across tasks raises ValueError."""
+    from skrobot.kinematics.differentiable import _build_union_joint_mapping
+    from skrobot.kinematics.differentiable import extract_fk_parameters
+
+    robot = _build_pr2()
+    rarm_mt = robot.rarm.end_coords
+    larm_mt = robot.larm.end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+    larm_ll = robot.link_lists(larm_mt.parent)
+
+    fk_rarm = extract_fk_parameters(robot, rarm_ll, rarm_mt)
+    fk_larm = extract_fk_parameters(robot, larm_ll, larm_mt)
+    # Corrupt shared torso limits so they invert under intersection.
+    torso_idx_in_rarm = 1
+    torso_idx_in_larm = 1
+    fk_rarm['joint_limits_lower'][torso_idx_in_rarm] = 0.5
+    fk_rarm['joint_limits_upper'][torso_idx_in_rarm] = 0.6
+    fk_larm['joint_limits_lower'][torso_idx_in_larm] = 0.0
+    fk_larm['joint_limits_upper'][torso_idx_in_larm] = 0.2
+
+    with pytest.raises(ValueError, match="Inconsistent joint limits"):
+        _build_union_joint_mapping(
+            [rarm_ll, larm_ll], [fk_rarm, fk_larm])
+
+
+def test_multi_ee_zero_weight_task_ignored():
+    """A zero-weighted task does not gate success and does not steer solve."""
+    robot = _build_pr2()
+    rarm_mt = robot.rarm.end_coords
+    larm_mt = robot.larm.end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+    larm_ll = robot.link_lists(larm_mt.parent)
+
+    # Reachable rarm target, infeasible larm target.
+    rt = [Coordinates(pos=rarm_mt.worldpos() + np.array([0.01, 0, 0]),
+                      rot=rarm_mt.worldrot())]
+    lt = [Coordinates(pos=larm_mt.worldpos() + np.array([-0.80, 0, 0]),
+                      rot=larm_mt.worldrot())]
+
+    solutions, success_flags, _ = robot.batch_inverse_kinematics(
+        target_coords=[rt, lt],
+        move_target=[rarm_mt, larm_mt], link_list=[rarm_ll, larm_ll],
+        stop=200, thre=0.003, rthre=np.deg2rad(3.0),
+        backend='numpy', initial_angles='current',
+        task_weights=[1.0, 0.0],
+    )
+    assert success_flags[0], (
+        "rarm task should succeed when larm is zero-weighted, "
+        "got success={}".format(success_flags))
+
+
+def test_multi_ee_all_zero_weights_raises():
+    """All-zero task weights raises a clear ValueError."""
+    robot = _build_pr2()
+    rarm_mt = robot.rarm.end_coords
+    larm_mt = robot.larm.end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+    larm_ll = robot.link_lists(larm_mt.parent)
+    rt = [Coordinates(pos=rarm_mt.worldpos(), rot=rarm_mt.worldrot())]
+    lt = [Coordinates(pos=larm_mt.worldpos(), rot=larm_mt.worldrot())]
+
+    with pytest.raises(
+            ValueError, match="no active, non-zero-weight tasks"):
+        robot.batch_inverse_kinematics(
+            target_coords=[rt, lt],
+            move_target=[rarm_mt, larm_mt], link_list=[rarm_ll, larm_ll],
+            stop=10, backend='numpy', initial_angles='current',
+            task_weights=[0.0, 0.0],
+        )
+
+
+def test_multi_ee_per_task_bool_masks_internal():
+    """Internal solver treats ``[True, False]`` as per-task when n_tasks=2.
+
+    This exercises the _to_per_task rule directly on the solver since the
+    public batch_inverse_kinematics path normalizes masks to a single 3-axis
+    form before multi-EE dispatch; per-task mask propagation through the
+    public API is out of scope here.
+    """
+    from skrobot.kinematics.differentiable import create_batch_ik_solver
+
+    robot = _build_pr2()
+    rarm_mt = robot.rarm.end_coords
+    larm_mt = robot.larm.end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+    larm_ll = robot.link_lists(larm_mt.parent)
+
+    solver = create_batch_ik_solver(
+        robot, [rarm_ll, larm_ll], [rarm_mt, larm_mt],
+        backend_name='numpy',
+    )
+
+    N = 1
+    r_targets = np.tile(rarm_mt.worldpos(), (N, 1)) \
+        + np.array([[0.01, 0.0, 0.0]])
+    l_targets = np.tile(larm_mt.worldpos(), (N, 1)) \
+        + np.array([[-0.01, 0.0, 0.0]])
+    r_rots = np.tile(rarm_mt.worldrot(), (N, 1, 1))
+    l_rots = np.tile(larm_mt.worldrot(), (N, 1, 1))
+
+    union_refs = solver.union_info['union_joint_refs']
+    init = np.tile(
+        np.array([j.joint_angle() for j in union_refs]), (N, 1))
+
+    # Must not raise: per-task rotation_masks (True for rarm, False for larm).
+    sol, _, _ = solver(
+        [r_targets, l_targets], [r_rots, l_rots],
+        initial_angles=init, max_iterations=50,
+        rotation_masks=[True, False],
+    )
+    assert sol.shape == (N, solver.union_n_opt)
+
+
+def test_multi_ee_jax_raises_until_ported():
+    """Multi-EE on JAX backend currently falls back to NumPy with a warning."""
+    robot = _build_pr2()
+    rarm_mt = robot.rarm.end_coords
+    larm_mt = robot.larm.end_coords
+    rarm_ll = robot.link_lists(rarm_mt.parent)
+    larm_ll = robot.link_lists(larm_mt.parent)
+
+    rt = [Coordinates(pos=rarm_mt.worldpos() + np.array([0.005, 0, 0]),
+                      rot=rarm_mt.worldrot())]
+    lt = [Coordinates(pos=larm_mt.worldpos() - np.array([0.005, 0, 0]),
+                      rot=larm_mt.worldrot())]
+
+    with pytest.warns(RuntimeWarning, match="Multi-EE batch IK"):
+        solutions, success, _ = robot.batch_inverse_kinematics(
+            target_coords=[rt, lt],
+            move_target=[rarm_mt, larm_mt], link_list=[rarm_ll, larm_ll],
+            stop=100, thre=0.005, rthre=np.deg2rad(3.0),
+            backend='jax', initial_angles='current',
+        )
+    assert len(solutions) == 1

--- a/tests/skrobot_tests/model_tests/test_multi_ee_batch_ik.py
+++ b/tests/skrobot_tests/model_tests/test_multi_ee_batch_ik.py
@@ -334,11 +334,17 @@ _HAS_JAX = False
 try:
     import jax  # noqa: F401
     _HAS_JAX = True
-except ImportError:  # pragma: no cover - depends on environment
+except Exception:  # pragma: no cover - import may fail against old numpy
+    # A plain ImportError covers "jax not installed", but JAX also raises
+    # AttributeError (e.g. ``module 'numpy' has no attribute 'dtypes'``)
+    # when the installed numpy is older than what the current jax wheel
+    # expects, which is common on CI matrices that pin numpy <1.25.
+    # Treat any import-time failure as "JAX unavailable" for the tests.
     pass
 
 
-@pytest.mark.skipif(not _HAS_JAX, reason="JAX not installed")
+@pytest.mark.skipif(
+    not _HAS_JAX, reason="JAX not installed or incompatible with numpy")
 def test_multi_ee_jax_parity_with_numpy():
     """JAX multi-EE solver converges to the same solution as NumPy."""
     from skrobot.kinematics.differentiable import create_batch_ik_solver
@@ -389,7 +395,8 @@ def test_multi_ee_jax_parity_with_numpy():
         np.asarray(err_jx), np.asarray(err_np), atol=1e-4)
 
 
-@pytest.mark.skipif(not _HAS_JAX, reason="JAX not installed")
+@pytest.mark.skipif(
+    not _HAS_JAX, reason="JAX not installed or incompatible with numpy")
 def test_multi_ee_jax_public_api():
     """batch_inverse_kinematics with backend='jax' routes through the JAX solver."""
     robot = _build_pr2()

--- a/tests/skrobot_tests/model_tests/test_virtual_joints.py
+++ b/tests/skrobot_tests/model_tests/test_virtual_joints.py
@@ -1,0 +1,150 @@
+import copy
+
+import numpy as np
+from numpy import testing
+
+from skrobot.model import FloatingJoint
+from skrobot.model import Link
+from skrobot.model import PlanarJoint
+from skrobot.model import RotationalJoint
+from skrobot.model.robot_model import RobotModel
+
+
+def _build_two_link_robot(base_joint_cls):
+    """Build a tiny RobotModel: world_link -> base_joint -> root_link
+    -> rotational_joint -> end_link."""
+    world_link = Link(name='world')
+    root_link = Link(name='root')
+    end_link = Link(name='end')
+    end_link.translate((0.3, 0, 0))
+
+    world_link.assoc(root_link)
+    root_link.assoc(end_link)
+
+    base_joint = base_joint_cls(
+        name='base_joint', parent_link=world_link, child_link=root_link)
+    world_link.add_child_link(root_link)
+    root_link.add_parent_link(world_link)
+    root_link.add_joint(base_joint)
+
+    arm_joint = RotationalJoint(
+        name='arm_joint', parent_link=root_link, child_link=end_link,
+        axis='z')
+    root_link.add_child_link(end_link)
+    end_link.add_parent_link(root_link)
+    end_link.add_joint(arm_joint)
+
+    robot = RobotModel(
+        link_list=[root_link, end_link],
+        joint_list=[base_joint, arm_joint],
+        root_link=world_link)
+    return robot, base_joint, arm_joint, root_link, end_link
+
+
+def _jacobian_vs_finite_difference(base_joint_cls, base_dof, q0):
+    robot, base_joint, arm_joint, root_link, end_link = \
+        _build_two_link_robot(base_joint_cls)
+    link_list = [root_link, end_link]
+
+    def set_q(q):
+        base_joint.joint_angle(q[:base_dof])
+        arm_joint.joint_angle(q[base_dof])
+
+    n_dof = base_dof + 1
+    set_q(q0)
+    pos0 = end_link.worldpos().copy()
+
+    jac_num = np.zeros((3, n_dof))
+    eps = 1e-7
+    for idx in range(n_dof):
+        q1 = copy.copy(q0)
+        q1[idx] += eps
+        set_q(q1)
+        jac_num[:, idx] = (end_link.worldpos() - pos0) / eps
+
+    set_q(q0)
+    world_link = root_link.parent_link
+    jac_analytic = robot.calc_jacobian_from_link_list(
+        end_link, link_list,
+        rotation_mask=False, transform_coords=world_link)
+    testing.assert_almost_equal(jac_num, jac_analytic, decimal=5)
+
+
+def test_planar_joint_dof_and_type():
+    parent = Link()
+    child = Link()
+    parent.assoc(child)
+    j = PlanarJoint(parent_link=parent, child_link=child)
+    assert j.joint_dof == 3
+    assert j.type == 'planar'
+
+
+def test_planar_joint_forward_kinematics():
+    parent = Link()
+    child = Link()
+    parent.assoc(child)
+    j = PlanarJoint(parent_link=parent, child_link=child)
+
+    j.joint_angle(np.array([1.0, 2.0, np.pi / 2]))
+    testing.assert_almost_equal(child.worldpos(), [1.0, 2.0, 0.0])
+    expected_rot = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
+    testing.assert_almost_equal(child.worldrot(), expected_rot)
+
+
+def test_planar_joint_angle_round_trip():
+    parent = Link()
+    child = Link()
+    parent.assoc(child)
+    j = PlanarJoint(parent_link=parent, child_link=child)
+    q = np.array([0.5, -0.2, 0.3])
+    j.joint_angle(q)
+    testing.assert_almost_equal(j.joint_angle(), q)
+
+
+def test_planar_joint_jacobian_matches_finite_difference():
+    q0 = np.array([0.1, -0.2, 0.3, 0.4])
+    _jacobian_vs_finite_difference(PlanarJoint, 3, q0)
+
+
+def test_floating_joint_dof_and_type():
+    parent = Link()
+    child = Link()
+    parent.assoc(child)
+    j = FloatingJoint(parent_link=parent, child_link=child)
+    assert j.joint_dof == 6
+    assert j.type == 'floating'
+
+
+def test_floating_joint_forward_kinematics_translation_only():
+    parent = Link()
+    child = Link()
+    parent.assoc(child)
+    j = FloatingJoint(parent_link=parent, child_link=child)
+    j.joint_angle(np.array([1.0, 2.0, 3.0, 0.0, 0.0, 0.0]))
+    testing.assert_almost_equal(child.worldpos(), [1.0, 2.0, 3.0])
+    testing.assert_almost_equal(child.worldrot(), np.eye(3))
+
+
+def test_floating_joint_forward_kinematics_rotation_only():
+    parent = Link()
+    child = Link()
+    parent.assoc(child)
+    j = FloatingJoint(parent_link=parent, child_link=child)
+    j.joint_angle(np.array([0.0, 0.0, 0.0, 0.0, 0.0, np.pi / 2]))
+    expected_rot = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
+    testing.assert_almost_equal(child.worldrot(), expected_rot)
+
+
+def test_floating_joint_angle_round_trip():
+    parent = Link()
+    child = Link()
+    parent.assoc(child)
+    j = FloatingJoint(parent_link=parent, child_link=child)
+    q = np.array([0.5, -0.2, 0.3, 0.1, -0.1, 0.2])
+    j.joint_angle(q)
+    testing.assert_almost_equal(j.joint_angle(), q)
+
+
+def test_floating_joint_jacobian_matches_finite_difference():
+    q0 = np.array([0.1, -0.2, 0.3, 0.05, -0.08, 0.1, 0.4])
+    _jacobian_vs_finite_difference(FloatingJoint, 6, q0)


### PR DESCRIPTION
  ## Summary
  - Add `use_base='planar' | '6dof'` + `base_weight` to `inverse_kinematics` / `batch_inverse_kinematics` so the base pose is solved alongside joint angles via a temporary virtual joint (`PlanarJoint` /
  `FloatingJoint`).
  - Multi-end-effector support in `batch_inverse_kinematics` on both NumPy and JAX backends; multi-EE `inverse_kinematics` auto-pairs each `link_list` chain with its `move_target` so alternating stance/swing callers
  do not need to reorder inputs.
  - `sr_inverse` now honours a non-uniform `weight_vector` at `k=0` (previously dropped silently).
  - `skrobot.models.Griphis` + `examples/griphis_wall_climb.py` demo: two grippers alternating on a vertical wall, one multi-EE fullbody IK call per step.
  - Backward compatible: `use_base=False` (default) is byte-identical to the old IK (`test_inverse_kinematics_use_base_false_is_backcompat`, `test_batch_use_base_false_backcompat`).

  ## Test plan
  - [x] `pytest tests/skrobot_tests/model_tests/` — 106 passed, 3 skipped
  - [x] `python examples/griphis_wall_climb.py --no-interactive`


https://github.com/user-attachments/assets/fb4cfe05-dcfa-43f0-9309-9ab755850409

