### PR TITLE
Add whole-body centroid extractor + differentiable CoG function

### DIFF
--- a/skrobot/dynamics/__init__.py
+++ b/skrobot/dynamics/__init__.py
@@ -19,9 +19,11 @@ from skrobot.dynamics.differentiable import build_optimized_gravity_torque_fn
 from skrobot.dynamics.differentiable import build_rnea_gravity_fn
 from skrobot.dynamics.differentiable import build_rnea_serial_gravity_fn
 from skrobot.dynamics.differentiable import build_torque_vector_fn
+from skrobot.dynamics.differentiable import build_world_centroid_fn
 from skrobot.dynamics.differentiable import estimate_external_torque
 from skrobot.dynamics.differentiable import extract_dynamics_parameters
 from skrobot.dynamics.differentiable import extract_inverse_dynamics_parameters
+from skrobot.dynamics.differentiable import extract_robot_centroid_params
 from skrobot.dynamics.differentiable import preprocess_external_forces
 from skrobot.dynamics.differentiable import preprocess_velocities
 from skrobot.dynamics.gravity import build_gravity_torque_function
@@ -40,9 +42,11 @@ __all__ = [
     'build_jacobian_gravity_fn',
     'build_inverse_dynamics_fn',
     'build_torque_vector_fn',
+    'build_world_centroid_fn',
     'estimate_external_torque',
     'extract_dynamics_parameters',
     'extract_inverse_dynamics_parameters',
+    'extract_robot_centroid_params',
     # Optimized gravity torque functions
     'build_optimized_gravity_torque_fn',
     'build_gravity_torque_fn_vectorized',

--- a/skrobot/dynamics/differentiable.py
+++ b/skrobot/dynamics/differentiable.py
@@ -145,6 +145,290 @@ def extract_dynamics_parameters(robot_model, link_list=None):
     }
 
 
+def _resolve_array_module(backend):
+    """Resolve ``backend`` to a numpy-compatible array module.
+
+    Accepts ``None`` (auto-pick jax.numpy when available), the
+    ``numpy`` / ``jax.numpy`` module itself, or a backend object
+    returned by :func:`skrobot.backend.get_backend`.
+    """
+    if backend is None:
+        try:
+            import jax.numpy as jnp
+            return jnp
+        except ImportError:
+            return np
+    if hasattr(backend, 'einsum') and hasattr(backend, 'asarray'):
+        return backend
+    name = getattr(backend, 'name', '').lower()
+    if name == 'jax':
+        import jax.numpy as jnp
+        return jnp
+    if name == 'numpy':
+        return np
+    raise TypeError(
+        'Unrecognised backend: {!r}. Pass numpy, jax.numpy, '
+        'or get_backend("jax"|"numpy").'.format(backend))
+
+
+def extract_robot_centroid_params(robot_model, link_lists=None):
+    """Extract per-link mass + centroid bookkeeping for whole-body CoG.
+
+    Splits every robot link with positive mass into
+
+    * ``chain`` links — links whose world poses are produced by FK on
+      one of the chains in ``link_lists``;
+    * ``fixed`` links — links that are rigidly attached to the base,
+      so their world poses follow the base pose alone (this includes
+      every link when ``link_lists`` is ``None``).
+
+    The output feeds :func:`build_world_centroid_fn`, which returns a
+    callable that evaluates the world centre of gravity for a given
+    pose. The split is what lets balance-aware planners compute CoG
+    in JAX without paying for a full robot FK every iteration: only
+    chain links touch the FK output; the rest fold into a single
+    pre-multiplied moment that just rotates / translates with the
+    base.
+
+    Parameters
+    ----------
+    robot_model : RobotModel
+        Robot in the configuration that should serve as the
+        body-frame reference for fixed-to-base links.
+    link_lists : None | list of Link | list of list of Link
+        ``None`` (default): no chains, the whole robot is treated as
+        rigidly attached to the base.  ``list of Link``: a single
+        chain.  ``list of list of Link``: multi-chain (e.g. both legs
+        of a humanoid).
+
+    Returns
+    -------
+    dict
+        Layout::
+
+            {
+                'n_chains': int,
+                'chain_data': [
+                    {'link_indices', 'centroids', 'masses'},
+                    ...
+                ],
+                'fixed_link_body_pos': (n_fixed, 3),
+                'fixed_link_body_rot': (n_fixed, 3, 3),
+                'fixed_link_centroids': (n_fixed, 3),
+                'fixed_link_masses': (n_fixed,),
+                'total_mass': float,
+            }
+
+        ``chain_data[i]['link_indices']`` indexes into
+        ``link_lists[i]``; the FK results for that chain must be
+        consistent with that index order.
+    """
+    if link_lists is None:
+        chains = []
+    elif (isinstance(link_lists, list) and len(link_lists) > 0
+            and isinstance(link_lists[0], list)):
+        chains = list(link_lists)
+    else:
+        chains = [list(link_lists)]
+    n_chains = len(chains)
+
+    base_link = getattr(robot_model, 'root_link', None)
+    if base_link is None:
+        for link in robot_model.link_list:
+            if link.parent is None:
+                base_link = link
+                break
+    base_T = base_link.worldcoords().T()
+    base_T_inv = np.linalg.inv(base_T)
+
+    chain_lookup = {}
+    for ci, chain in enumerate(chains):
+        for li, link in enumerate(chain):
+            chain_lookup[id(link)] = (ci, li)
+
+    per_chain_indices = [[] for _ in range(n_chains)]
+    per_chain_centroids = [[] for _ in range(n_chains)]
+    per_chain_masses = [[] for _ in range(n_chains)]
+    fixed_pos, fixed_rot, fixed_coms, fixed_masses = [], [], [], []
+    total_mass = 0.0
+
+    for link in robot_model.link_list:
+        m = getattr(link, 'mass', 0.0) or 0.0
+        if m <= 0:
+            continue
+        c = np.asarray(
+            link.centroid if link.centroid is not None else np.zeros(3),
+            dtype=np.float64,
+        )
+        total_mass += float(m)
+        key = id(link)
+        if key in chain_lookup:
+            ci, li = chain_lookup[key]
+            per_chain_indices[ci].append(li)
+            per_chain_centroids[ci].append(c)
+            per_chain_masses[ci].append(float(m))
+        else:
+            link_T = link.worldcoords().T()
+            body_T = base_T_inv @ link_T
+            fixed_pos.append(body_T[:3, 3])
+            fixed_rot.append(body_T[:3, :3])
+            fixed_coms.append(c)
+            fixed_masses.append(float(m))
+
+    chain_data = []
+    for ci in range(n_chains):
+        if per_chain_indices[ci]:
+            chain_data.append({
+                'link_indices': np.asarray(per_chain_indices[ci],
+                                            dtype=np.int64),
+                'centroids':    np.asarray(per_chain_centroids[ci],
+                                            dtype=np.float64),
+                'masses':       np.asarray(per_chain_masses[ci],
+                                            dtype=np.float64),
+            })
+        else:
+            chain_data.append({
+                'link_indices': np.zeros((0,), dtype=np.int64),
+                'centroids':    np.zeros((0, 3), dtype=np.float64),
+                'masses':       np.zeros((0,), dtype=np.float64),
+            })
+
+    def _stack(seq, shape):
+        if not seq:
+            return np.zeros((0,) + shape, dtype=np.float64)
+        return np.asarray(seq, dtype=np.float64)
+
+    return {
+        'n_chains':            n_chains,
+        'chain_data':          chain_data,
+        'fixed_link_body_pos': _stack(fixed_pos, (3,)),
+        'fixed_link_body_rot': _stack(fixed_rot, (3, 3)),
+        'fixed_link_centroids': _stack(fixed_coms, (3,)),
+        'fixed_link_masses':   np.asarray(fixed_masses, dtype=np.float64),
+        'total_mass':          float(total_mass),
+    }
+
+
+def build_world_centroid_fn(centroid_params, get_link_transforms,
+                             backend=None,
+                             base_pos_default=None,
+                             base_rot_default=None):
+    """Build a centre-of-gravity forward function.
+
+    The returned callable evaluates the whole-body CoG in world
+    coordinates given per-chain joint angles and a base pose.  Chain
+    links contribute via ``get_link_transforms`` (sensitive to
+    angles); fixed-to-base links rotate / translate with the base
+    pose only.
+
+    Parameters
+    ----------
+    centroid_params : dict
+        Output of :func:`extract_robot_centroid_params`.
+    get_link_transforms : callable | list of callables | None
+        Per-chain link FK function(s).  Each callable has signature
+        ``get_link_transforms(angles, base_pos, base_rot) ->
+        (positions, rotations)`` and returns world poses for every
+        link in the corresponding chain.  Pass ``None`` when there
+        are no chains.  A bare callable is treated as a single chain.
+    backend : module or backend object, optional
+        Array module (``numpy`` or ``jax.numpy``) or a backend
+        object returned by :func:`skrobot.backend.get_backend`.
+        Defaults to ``jax.numpy`` if available, else ``numpy``.
+    base_pos_default, base_rot_default : optional
+        Defaults used when the returned function is called without an
+        explicit base pose.
+
+    Returns
+    -------
+    callable
+        ``compute_centroid(angles_per_chain=None, base_pos=None,
+        base_rot=None)`` returning a length-3 world CoG.
+    """
+    xp = _resolve_array_module(backend)
+
+    n_chains = centroid_params['n_chains']
+    if get_link_transforms is None:
+        get_lt_per_chain = []
+    elif callable(get_link_transforms):
+        get_lt_per_chain = [get_link_transforms]
+    else:
+        get_lt_per_chain = list(get_link_transforms)
+    if len(get_lt_per_chain) != n_chains:
+        raise ValueError(
+            'get_link_transforms count ({}) does not match '
+            'centroid_params n_chains ({})'.format(
+                len(get_lt_per_chain), n_chains))
+
+    chain_jax = []
+    for ci in range(n_chains):
+        cd = centroid_params['chain_data'][ci]
+        chain_jax.append({
+            'indices': xp.asarray(cd['link_indices']),
+            'coms':    xp.asarray(cd['centroids']),
+            'masses':  xp.asarray(cd['masses']),
+        })
+    fixed_pos = xp.asarray(centroid_params['fixed_link_body_pos'])
+    fixed_rot = xp.asarray(centroid_params['fixed_link_body_rot'])
+    fixed_coms = xp.asarray(centroid_params['fixed_link_centroids'])
+    fixed_masses = xp.asarray(centroid_params['fixed_link_masses'])
+    total_mass = float(centroid_params['total_mass'])
+    if total_mass <= 0:
+        raise ValueError(
+            'Total robot mass is zero; cannot compute centroid.')
+
+    if base_pos_default is None:
+        base_pos_default = xp.zeros(3)
+    else:
+        base_pos_default = xp.asarray(base_pos_default)
+    if base_rot_default is None:
+        base_rot_default = xp.eye(3)
+    else:
+        base_rot_default = xp.asarray(base_rot_default)
+
+    def compute_centroid(angles_per_chain=None, base_pos=None,
+                          base_rot=None):
+        if base_pos is None:
+            base_pos = base_pos_default
+        if base_rot is None:
+            base_rot = base_rot_default
+        if angles_per_chain is None:
+            angles_per_chain = []
+        if n_chains > 0 and not isinstance(angles_per_chain, (list, tuple)):
+            # Allow a single bare angle vector for the single-chain case.
+            angles_per_chain = [angles_per_chain]
+        if len(angles_per_chain) != n_chains:
+            raise ValueError(
+                'angles_per_chain count ({}) does not match '
+                'n_chains ({})'.format(
+                    len(angles_per_chain), n_chains))
+
+        moment = xp.zeros(3)
+        for ci in range(n_chains):
+            cd = chain_jax[ci]
+            if cd['indices'].shape[0] == 0:
+                continue
+            link_pos, link_rot = get_lt_per_chain[ci](
+                angles_per_chain[ci], base_pos, base_rot,
+            )
+            cp = link_pos[cd['indices']]
+            cr = link_rot[cd['indices']]
+            cw_com = cp + xp.einsum('nij,nj->ni', cr, cd['coms'])
+            moment = moment + xp.sum(
+                cd['masses'][:, None] * cw_com, axis=0,
+            )
+        if fixed_pos.shape[0] > 0:
+            fwp = base_pos + xp.einsum('ij,nj->ni', base_rot, fixed_pos)
+            fwr = xp.einsum('ij,njk->nik', base_rot, fixed_rot)
+            fwcom = fwp + xp.einsum('nij,nj->ni', fwr, fixed_coms)
+            moment = moment + xp.sum(
+                fixed_masses[:, None] * fwcom, axis=0,
+            )
+        return moment / total_mass
+
+    return compute_centroid
+
+
 def build_gravity_fn(robot_model, link_list=None, backend=None):
     """Build differentiable gravity torque function with autodiff support.
 

--- a/tests/skrobot_tests/dynamics_tests/test_differentiable.py
+++ b/tests/skrobot_tests/dynamics_tests/test_differentiable.py
@@ -1,0 +1,286 @@
+import unittest
+
+import numpy as np
+
+from skrobot.pycompat import HAS_JAX
+
+
+def requires_jax(test_func):
+    return unittest.skipUnless(HAS_JAX, 'JAX not available')(test_func)
+
+
+def _fk_chain_factory(robot_model, link_list, backend_name):
+    """Return get_link_transforms(angles, base_pos, base_rot) for one chain.
+
+    The returned callable matches the floating-base contract expected
+    by :func:`build_world_centroid_fn`: ``base_pos`` / ``base_rot``
+    represent the world pose of ``root_link``.  The chain's natural
+    parent is captured in ``root_link`` frame and composed with the
+    floating-base pose at call time.
+
+    ``backend_name`` is ``'numpy'`` or ``'jax'``.
+    """
+    from skrobot.backend import get_backend
+    from skrobot.kinematics.differentiable import extract_fk_parameters
+    from skrobot.kinematics.differentiable import forward_kinematics
+
+    move_target = link_list[-1]
+    fk_params = extract_fk_parameters(robot_model, link_list, move_target)
+    backend = get_backend(backend_name)
+
+    base_link = robot_model.root_link
+    root_T = base_link.worldcoords().T()
+    root_T_inv = np.linalg.inv(root_T)
+    natural_pos = fk_params['base_position']
+    natural_rot = fk_params['base_rotation']
+    rel_pos = root_T_inv[:3, :3] @ natural_pos + root_T_inv[:3, 3]
+    rel_rot = root_T_inv[:3, :3] @ natural_rot
+
+    def get_link_transforms(angles, base_pos, base_rot):
+        new_base_pos = base_pos + base_rot @ rel_pos
+        new_base_rot = base_rot @ rel_rot
+        params = dict(fk_params)
+        params['base_position'] = np.asarray(new_base_pos)
+        params['base_rotation'] = np.asarray(new_base_rot)
+        return forward_kinematics(backend, angles, params)
+
+    return get_link_transforms, fk_params
+
+
+class TestExtractRobotCentroidParams(unittest.TestCase):
+    """extract_robot_centroid_params bookkeeping."""
+
+    def test_no_chains_total_mass_matches_robot(self):
+        from skrobot.dynamics import extract_robot_centroid_params
+        from skrobot.models import Fetch
+
+        fetch = Fetch()
+        params = extract_robot_centroid_params(fetch, link_lists=None)
+
+        expected_total = sum(
+            link.mass for link in fetch.link_list
+            if getattr(link, 'mass', 0.0) and link.mass > 0
+        )
+
+        self.assertEqual(params['n_chains'], 0)
+        self.assertEqual(len(params['chain_data']), 0)
+        self.assertAlmostEqual(params['total_mass'], expected_total, places=8)
+        n_fixed = params['fixed_link_masses'].shape[0]
+        self.assertGreater(n_fixed, 0)
+        self.assertEqual(params['fixed_link_body_pos'].shape, (n_fixed, 3))
+        self.assertEqual(params['fixed_link_body_rot'].shape, (n_fixed, 3, 3))
+
+    def test_single_chain_split(self):
+        from skrobot.dynamics import extract_robot_centroid_params
+        from skrobot.models import Fetch
+
+        fetch = Fetch()
+        rarm_links = list(fetch.rarm.link_list)
+        params = extract_robot_centroid_params(fetch, link_lists=rarm_links)
+
+        chain_link_ids = {id(link) for link in rarm_links
+                          if getattr(link, 'mass', 0.0) > 0}
+        chain_indices = params['chain_data'][0]['link_indices']
+
+        self.assertEqual(params['n_chains'], 1)
+        self.assertEqual(chain_indices.shape[0], len(chain_link_ids))
+
+        n_fixed = params['fixed_link_masses'].shape[0]
+        chain_mass = float(params['chain_data'][0]['masses'].sum())
+        fixed_mass = float(params['fixed_link_masses'].sum())
+        self.assertAlmostEqual(chain_mass + fixed_mass,
+                               params['total_mass'], places=8)
+        self.assertEqual(n_fixed + chain_indices.shape[0],
+                         sum(1 for link in fetch.link_list
+                             if getattr(link, 'mass', 0.0) > 0))
+
+    def test_multi_chain_split(self):
+        from skrobot.dynamics import extract_robot_centroid_params
+        from skrobot.models import PR2
+
+        pr2 = PR2()
+        rarm_links = list(pr2.rarm.link_list)
+        larm_links = list(pr2.larm.link_list)
+        params = extract_robot_centroid_params(
+            pr2, link_lists=[rarm_links, larm_links])
+
+        self.assertEqual(params['n_chains'], 2)
+        self.assertEqual(len(params['chain_data']), 2)
+        c0 = params['chain_data'][0]['link_indices'].shape[0]
+        c1 = params['chain_data'][1]['link_indices'].shape[0]
+        self.assertGreater(c0, 0)
+        self.assertGreater(c1, 0)
+        chain_mass = (float(params['chain_data'][0]['masses'].sum())
+                      + float(params['chain_data'][1]['masses'].sum()))
+        fixed_mass = float(params['fixed_link_masses'].sum())
+        self.assertAlmostEqual(chain_mass + fixed_mass,
+                               params['total_mass'], places=8)
+
+
+class TestBuildWorldCentroidFnNumpy(unittest.TestCase):
+    """build_world_centroid_fn matches update_mass_properties (NumPy)."""
+
+    def test_no_chains_matches_reference(self):
+        from skrobot.dynamics import build_world_centroid_fn
+        from skrobot.dynamics import extract_robot_centroid_params
+        from skrobot.models import Fetch
+
+        fetch = Fetch()
+        fetch.reset_pose()
+
+        ref = fetch.update_mass_properties()['total_centroid']
+
+        params = extract_robot_centroid_params(fetch, link_lists=None)
+        cog_fn = build_world_centroid_fn(
+            params, get_link_transforms=None, backend=np)
+
+        cog = np.asarray(cog_fn())
+        np.testing.assert_allclose(cog, ref, atol=1e-8)
+
+    def test_single_chain_matches_reference(self):
+        from skrobot.dynamics import build_world_centroid_fn
+        from skrobot.dynamics import extract_robot_centroid_params
+        from skrobot.models import Fetch
+
+        fetch = Fetch()
+        fetch.reset_pose()
+        for link in fetch.rarm.link_list:
+            joint = link.joint
+            mid = 0.5 * (joint.min_angle + joint.max_angle)
+            if not np.isfinite(mid):
+                mid = 0.0
+            joint.joint_angle(np.clip(0.3, joint.min_angle, joint.max_angle))
+        fetch.angle_vector()  # propagate FK
+        ref = fetch.update_mass_properties()['total_centroid']
+
+        rarm_links = list(fetch.rarm.link_list)
+        params = extract_robot_centroid_params(fetch, link_lists=rarm_links)
+        get_lt, _ = _fk_chain_factory(fetch, rarm_links, 'numpy')
+        cog_fn = build_world_centroid_fn(
+            params, get_link_transforms=get_lt, backend=np)
+
+        angles = np.array([link.joint.joint_angle()
+                           for link in rarm_links])
+        cog = np.asarray(cog_fn([angles]))
+        np.testing.assert_allclose(cog, ref, atol=1e-7)
+
+    def test_multi_chain_matches_reference(self):
+        from skrobot.dynamics import build_world_centroid_fn
+        from skrobot.dynamics import extract_robot_centroid_params
+        from skrobot.models import PR2
+
+        pr2 = PR2()
+        pr2.reset_pose()
+        for link in list(pr2.rarm.link_list) + list(pr2.larm.link_list):
+            joint = link.joint
+            joint.joint_angle(
+                np.clip(0.2, joint.min_angle, joint.max_angle))
+        pr2.angle_vector()
+        ref = pr2.update_mass_properties()['total_centroid']
+
+        rarm_links = list(pr2.rarm.link_list)
+        larm_links = list(pr2.larm.link_list)
+        params = extract_robot_centroid_params(
+            pr2, link_lists=[rarm_links, larm_links])
+        get_lt_r, _ = _fk_chain_factory(pr2, rarm_links, 'numpy')
+        get_lt_l, _ = _fk_chain_factory(pr2, larm_links, 'numpy')
+        cog_fn = build_world_centroid_fn(
+            params, get_link_transforms=[get_lt_r, get_lt_l], backend=np)
+
+        ang_r = np.array([link.joint.joint_angle() for link in rarm_links])
+        ang_l = np.array([link.joint.joint_angle() for link in larm_links])
+        cog = np.asarray(cog_fn([ang_r, ang_l]))
+        np.testing.assert_allclose(cog, ref, atol=1e-7)
+
+    def test_base_translation_shifts_cog(self):
+        from skrobot.dynamics import build_world_centroid_fn
+        from skrobot.dynamics import extract_robot_centroid_params
+        from skrobot.models import Fetch
+
+        fetch = Fetch()
+        fetch.reset_pose()
+
+        params = extract_robot_centroid_params(fetch, link_lists=None)
+        cog_fn = build_world_centroid_fn(
+            params, get_link_transforms=None, backend=np)
+
+        cog0 = np.asarray(cog_fn())
+        shift = np.array([0.1, -0.2, 0.05])
+        cog_shifted = np.asarray(cog_fn(base_pos=shift))
+        np.testing.assert_allclose(cog_shifted - cog0, shift, atol=1e-8)
+
+    def test_base_rotation_rotates_cog_about_origin(self):
+        from skrobot.coordinates.math import rotation_matrix
+        from skrobot.dynamics import build_world_centroid_fn
+        from skrobot.dynamics import extract_robot_centroid_params
+        from skrobot.models import Fetch
+
+        fetch = Fetch()
+        fetch.reset_pose()
+
+        params = extract_robot_centroid_params(fetch, link_lists=None)
+        cog_fn = build_world_centroid_fn(
+            params, get_link_transforms=None, backend=np)
+
+        cog0 = np.asarray(cog_fn())
+        R = rotation_matrix(np.deg2rad(35), 'z')
+        cog_rot = np.asarray(cog_fn(base_rot=R))
+        np.testing.assert_allclose(cog_rot, R @ cog0, atol=1e-8)
+
+
+class TestBuildWorldCentroidFnJax(unittest.TestCase):
+    """JAX backend matches NumPy backend numerically."""
+
+    @requires_jax
+    def test_jax_matches_numpy_no_chains(self):
+        import jax.numpy as jnp
+
+        from skrobot.dynamics import build_world_centroid_fn
+        from skrobot.dynamics import extract_robot_centroid_params
+        from skrobot.models import Fetch
+
+        fetch = Fetch()
+        fetch.reset_pose()
+        params = extract_robot_centroid_params(fetch, link_lists=None)
+
+        cog_np = np.asarray(build_world_centroid_fn(
+            params, get_link_transforms=None, backend=np)())
+        cog_jax = np.asarray(build_world_centroid_fn(
+            params, get_link_transforms=None, backend=jnp)())
+        # JAX default precision is float32, so allow a small mismatch.
+        np.testing.assert_allclose(cog_jax, cog_np, atol=1e-5)
+
+    @requires_jax
+    def test_jax_matches_numpy_single_chain(self):
+        import jax.numpy as jnp
+
+        from skrobot.dynamics import build_world_centroid_fn
+        from skrobot.dynamics import extract_robot_centroid_params
+        from skrobot.models import Fetch
+
+        fetch = Fetch()
+        fetch.reset_pose()
+        for link in fetch.rarm.link_list:
+            joint = link.joint
+            joint.joint_angle(
+                np.clip(0.3, joint.min_angle, joint.max_angle))
+        fetch.angle_vector()
+
+        rarm_links = list(fetch.rarm.link_list)
+        params = extract_robot_centroid_params(fetch, link_lists=rarm_links)
+        get_lt_np, _ = _fk_chain_factory(fetch, rarm_links, 'numpy')
+        get_lt_jax, _ = _fk_chain_factory(fetch, rarm_links, 'jax')
+
+        angles = np.array([link.joint.joint_angle()
+                           for link in rarm_links])
+
+        cog_np = np.asarray(build_world_centroid_fn(
+            params, get_link_transforms=get_lt_np, backend=np)([angles]))
+        cog_jax = np.asarray(build_world_centroid_fn(
+            params, get_link_transforms=get_lt_jax, backend=jnp)(
+                [jnp.asarray(angles)]))
+        np.testing.assert_allclose(cog_jax, cog_np, atol=1e-6)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
For balance-aware planning we need a CoG forward function that is cheap inside JAX: only the chain links should depend on joint angles, the rest of the robot can fold into a single base-frame moment. This adds two functions in skrobot.dynamics.differentiable:

* extract_robot_centroid_params(robot_model, link_lists=None) splits every massive link into "chain" (poses produced by FK on one of the link_lists chains) and "fixed" (rigidly attached to root_link), and stores the fixed-link contribution in root_link frame so it just rotates / translates with the floating base. link_lists accepts None / list of Link / list of list of Link (multi-chain).

* build_world_centroid_fn(centroid_params, get_link_transforms, ...) returns compute_centroid(angles_per_chain, base_pos, base_rot) that computes the world CoG. Chain links are summed via user-provided per-chain FK callables; fixed links are accumulated with a single base-frame multiply. base_pos / base_rot are interpreted as the world pose of root_link, so floating-base IK / trajectory optimization can drive them directly.

Both functions support NumPy and JAX (via a small backend resolver that accepts the module, get_backend(...) result, or None for auto).

Tests in tests/skrobot_tests/dynamics_tests/test_differentiable.py verify mass split, base translation/rotation behaviour, and exact agreement with RobotModel.update_mass_properties() on Fetch (single chain) and PR2 (two-arm multi-chain), plus JAX/NumPy parity.