### PR TITLE
Resolve package:// URIs via ament_index when rospkg is missing

### DIFF
--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -205,22 +205,81 @@ def unparse_origin(matrix):
     return node
 
 
+def _try_ament(ros_package):
+    """Resolve via ament_index_python. Returns path or None if unavailable / not found."""
+    try:
+        from ament_index_python.packages import get_package_share_directory
+        from ament_index_python.packages import PackageNotFoundError
+    except ImportError:
+        return None
+    try:
+        return get_package_share_directory(ros_package)
+    except PackageNotFoundError:
+        return None
+    except Exception as e:
+        logger.warning(
+            "ament_index lookup for ROS package '%s' failed: %s",
+            ros_package, e)
+        return None
+
+
+def _try_rospkg(ros_package):
+    """Resolve via rospkg. Returns path or None if unavailable / not found."""
+    if rospkg is None:
+        return None
+    try:
+        return rospkg.RosPack().get_path(ros_package)
+    except rospkg.common.ResourceNotFound:
+        return None
+
+
 @lru_cache(maxsize=None)
 def get_path_with_cache(ros_package):
-    ros_version = os.environ.get('ROS_VERSION', '1')
+    """Resolve a ROS package name to its share/install directory.
 
-    if ros_version == '2':
-        try:
-            from ament_index_python.packages import get_package_share_directory
-            return get_package_share_directory(ros_package)
-        except ImportError:
-            logger.warning("ament_index_python not available, falling back to rospkg")
-        except Exception as e:
-            logger.warning("Failed to find ROS2 package %s: %s", ros_package, e)
+    Tries both ``ament_index_python`` (ROS 2) and ``rospkg`` (ROS 1) when
+    available. The order respects the ``ROS_VERSION`` environment variable so
+    that users with ROS 1 and ROS 2 coexisting on the same machine get the
+    resolver matching their currently-sourced distro:
 
-    # ROS1 or fallback: Use rospkg
-    rospack = rospkg.RosPack()
-    return rospack.get_path(ros_package)
+    * ``ROS_VERSION=1`` -> rospkg first, then ament (preserves the old
+      behaviour where rospkg-only resolution was used).
+    * ``ROS_VERSION=2`` or unset -> ament first, then rospkg. This is what
+      makes the function work on plain ``ros-<distro>-desktop`` installs that
+      ship ament but not rospkg (previously such environments hit a
+      ``TypeError`` deeper in mesh loading).
+
+    Raises
+    ------
+    ImportError
+        Neither resolver is available.
+    LookupError
+        Both resolvers were tried but the package was not found by either.
+    """
+    if os.environ.get('ROS_VERSION') == '1':
+        resolvers = (_try_rospkg, _try_ament)
+    else:
+        resolvers = (_try_ament, _try_rospkg)
+
+    for resolver in resolvers:
+        path = resolver(ros_package)
+        if path is not None:
+            return path
+
+    # Distinguish "neither resolver installed" from "package missing".
+    ament_available = True
+    try:
+        import ament_index_python  # noqa: F401
+    except ImportError:
+        ament_available = False
+    if not ament_available and rospkg is None:
+        raise ImportError(
+            "Cannot resolve ROS package '{}': neither ament_index_python "
+            "nor rospkg is installed.".format(ros_package))
+    raise LookupError(
+        "ROS package '{}' was not found by ament_index_python or rospkg. "
+        "Did you forget to source your ROS workspace "
+        "(e.g. `source install/setup.bash` for ROS 2)?".format(ros_package))
 
 
 def search_up(start_dir, relative_path):
@@ -239,7 +298,7 @@ def resolve_filepath(base_path, file_path):
     parsed_url = urlparse(file_path)
     base_path = os.path.abspath(base_path)
 
-    if rospkg and parsed_url.scheme == 'package':
+    if parsed_url.scheme == 'package':
         try:
             ros_package = parsed_url.netloc
             package_path = get_path_with_cache(ros_package)
@@ -247,7 +306,12 @@ def resolve_filepath(base_path, file_path):
             resolved_filepath = os.path.join(package_path, pkg_relative_path)
             if os.path.exists(resolved_filepath):
                 return resolved_filepath
-        except rospkg.common.ResourceNotFound:
+        except Exception:
+            # Catches ament's PackageNotFoundError, rospkg's ResourceNotFound,
+            # and the ImportError raised by get_path_with_cache when neither
+            # resolver is installed. We fall through to the search_up()
+            # heuristic below so behaviour stays graceful for pure-filesystem
+            # URDFs that just happen to use package:// for documentation.
             pass
 
     rel_paths = [
@@ -363,6 +427,13 @@ def _load_meshes(filename):
     meshes : list of :class:`~trimesh.base.Trimesh`
         The meshes loaded from the file.
     """
+    if filename is None:
+        raise FileNotFoundError(
+            "Cannot load mesh: file path is None. This usually means a "
+            "package:// URI in the URDF could not be resolved. Make sure the "
+            "referenced ROS package is installed and your environment is "
+            "sourced (`source install/setup.bash` for ROS 2, or set "
+            "`ROS_PACKAGE_PATH` for ROS 1).")
     trimesh = _lazy_trimesh()
     _, ext = os.path.splitext(filename)
     is_glb_or_gltf = ext.lower() in ('.glb', '.gltf')

--- a/tests/skrobot_tests/utils_tests/test_urdf.py
+++ b/tests/skrobot_tests/utils_tests/test_urdf.py
@@ -1,0 +1,159 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+import pytest
+
+from skrobot.utils import urdf as urdf_utils
+
+
+class TestLoadMeshesNoneGuard(unittest.TestCase):
+
+    def test_raises_file_not_found_with_helpful_message(self):
+        with pytest.raises(FileNotFoundError) as excinfo:
+            urdf_utils._load_meshes(None)
+        msg = str(excinfo.value)
+        # The user has to know the cause and the typical fix.
+        assert 'package://' in msg
+        assert 'install/setup.bash' in msg or 'ROS_PACKAGE_PATH' in msg
+
+
+class TestGetPathWithCacheResolverOrder(unittest.TestCase):
+    """get_path_with_cache should respect ROS_VERSION when both resolvers are present."""
+
+    def setUp(self):
+        urdf_utils.get_path_with_cache.cache_clear()
+        # Save and clear ROS_VERSION so each test sets it explicitly.
+        self._saved_ros_version = os.environ.pop('ROS_VERSION', None)
+
+    def tearDown(self):
+        urdf_utils.get_path_with_cache.cache_clear()
+        if self._saved_ros_version is None:
+            os.environ.pop('ROS_VERSION', None)
+        else:
+            os.environ['ROS_VERSION'] = self._saved_ros_version
+
+    def test_ament_is_tried_first_by_default(self):
+        with mock.patch.object(urdf_utils, '_try_ament',
+                               return_value='/ament/foo') as ament, \
+             mock.patch.object(urdf_utils, '_try_rospkg',
+                               return_value='/rospkg/foo') as rospkg_:
+            assert urdf_utils.get_path_with_cache('foo') == '/ament/foo'
+            ament.assert_called_once_with('foo')
+            rospkg_.assert_not_called()
+
+    def test_ros_version_2_prefers_ament(self):
+        os.environ['ROS_VERSION'] = '2'
+        with mock.patch.object(urdf_utils, '_try_ament',
+                               return_value='/ament/foo'), \
+             mock.patch.object(urdf_utils, '_try_rospkg',
+                               return_value='/rospkg/foo') as rospkg_:
+            assert urdf_utils.get_path_with_cache('foo') == '/ament/foo'
+            rospkg_.assert_not_called()
+
+    def test_ros_version_1_prefers_rospkg(self):
+        """Hybrid env where the user explicitly asks for ROS 1 must keep using rospkg."""
+        os.environ['ROS_VERSION'] = '1'
+        with mock.patch.object(urdf_utils, '_try_ament',
+                               return_value='/ament/foo') as ament, \
+             mock.patch.object(urdf_utils, '_try_rospkg',
+                               return_value='/rospkg/foo') as rospkg_:
+            assert urdf_utils.get_path_with_cache('foo') == '/rospkg/foo'
+            rospkg_.assert_called_once_with('foo')
+            ament.assert_not_called()
+
+    def test_falls_back_when_first_resolver_returns_none(self):
+        with mock.patch.object(urdf_utils, '_try_ament',
+                               return_value=None) as ament, \
+             mock.patch.object(urdf_utils, '_try_rospkg',
+                               return_value='/rospkg/foo') as rospkg_:
+            assert urdf_utils.get_path_with_cache('foo') == '/rospkg/foo'
+            ament.assert_called_once()
+            rospkg_.assert_called_once()
+
+    def test_lookup_error_when_both_resolvers_fail(self):
+        with mock.patch.object(urdf_utils, '_try_ament', return_value=None), \
+             mock.patch.object(urdf_utils, '_try_rospkg', return_value=None):
+            # rospkg variable still pointing at the real (or None) module is
+            # fine — we just need the resolvers to claim "not found".
+            with pytest.raises((LookupError, ImportError)):
+                urdf_utils.get_path_with_cache('does_not_exist')
+
+    def test_import_error_when_no_resolver_installed(self):
+        with mock.patch.dict(sys.modules,
+                             {'ament_index_python': None,
+                              'ament_index_python.packages': None}):
+            with mock.patch.object(urdf_utils, 'rospkg', None):
+                with pytest.raises(ImportError) as excinfo:
+                    urdf_utils.get_path_with_cache('whatever')
+                assert 'ament_index_python' in str(excinfo.value)
+                assert 'rospkg' in str(excinfo.value)
+
+
+class TestResolveFilepathWithoutRospkg(unittest.TestCase):
+    """package:// URIs must resolve via ament when rospkg is missing.
+
+    Regression test for the previous ``if rospkg and parsed_url.scheme == 'package':``
+    guard which silently skipped the entire package:// branch on rospkg-less
+    environments such as ``apt install ros-<distro>-desktop`` without ROS 1.
+    """
+
+    def setUp(self):
+        urdf_utils.get_path_with_cache.cache_clear()
+        self._saved_ros_version = os.environ.pop('ROS_VERSION', None)
+
+    def tearDown(self):
+        urdf_utils.get_path_with_cache.cache_clear()
+        if self._saved_ros_version is None:
+            os.environ.pop('ROS_VERSION', None)
+        else:
+            os.environ['ROS_VERSION'] = self._saved_ros_version
+
+    def test_resolves_via_ament_when_rospkg_missing(self):
+        with tempfile.TemporaryDirectory() as pkg_dir:
+            mesh_dir = os.path.join(pkg_dir, 'meshes')
+            os.makedirs(mesh_dir)
+            mesh_path = os.path.join(mesh_dir, 'foo.dae')
+            with open(mesh_path, 'w') as f:
+                f.write('<dummy/>')
+
+            with mock.patch.object(urdf_utils, '_try_ament',
+                                    return_value=pkg_dir):
+                with mock.patch.object(urdf_utils, 'rospkg', None):
+                    result = urdf_utils.resolve_filepath(
+                        '/tmp', 'package://my_pkg/meshes/foo.dae')
+            assert result == mesh_path
+
+    def test_falls_back_to_search_up_when_no_ros_installed(self):
+        """package:// must resolve via search_up on machines without ROS at all.
+
+        Mirrors the typical scikit-robot data layout under ~/.skrobot/, where a
+        downloaded URDF references its sibling meshes via package://<name>/...
+        even though no ROS distro is present.
+        """
+        with tempfile.TemporaryDirectory() as data_root:
+            # Layout: <data_root>/pr2_description/{pr2.urdf, meshes/foo.dae}
+            pkg_dir = os.path.join(data_root, 'pr2_description')
+            mesh_dir = os.path.join(pkg_dir, 'meshes')
+            os.makedirs(mesh_dir)
+            urdf_path = os.path.join(pkg_dir, 'pr2.urdf')
+            mesh_path = os.path.join(mesh_dir, 'foo.dae')
+            for p in (urdf_path, mesh_path):
+                with open(p, 'w') as f:
+                    f.write('<dummy/>')
+
+            with mock.patch.object(urdf_utils, '_try_ament',
+                                    return_value=None), \
+                 mock.patch.object(urdf_utils, '_try_rospkg',
+                                    return_value=None), \
+                 mock.patch.dict(sys.modules,
+                                 {'ament_index_python': None,
+                                  'ament_index_python.packages': None}), \
+                 mock.patch.object(urdf_utils, 'rospkg', None):
+                # base_path is the URDF's directory; resolver should walk up
+                # one level and find sibling 'pr2_description/meshes/foo.dae'.
+                result = urdf_utils.resolve_filepath(
+                    pkg_dir, 'package://pr2_description/meshes/foo.dae')
+            assert result == mesh_path


### PR DESCRIPTION
On ROS 2 environments without rospkg installed (e.g. a plain ros-<distro>-desktop apt install), resolve_filepath silently skipped the package:// branch because of an if rospkg and ... guard, so URDF mesh loading failed deep inside _load_meshes with TypeError on os.path.splitext(None).

- Drop the rospkg guard in resolve_filepath; broaden the except.
- Refactor get_path_with_cache to try ament_index_python and rospkg in an order chosen by ROS_VERSION (rospkg first when ROS_VERSION=1, ament first otherwise) and to raise a helpful error when neither is available or the package is not registered with either.
- Raise FileNotFoundError up front in _load_meshes when the path is None instead of crashing later.
- Add tests covering resolver order, rospkg fallback, the helpful error path, and ament-only resolution.