### PR TITLE
Make ROS 2 RobotInterface joint-state waiting safe and fresh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,3 +260,55 @@ jobs:
           fi
         done
 
+  ros2-tests:
+    name: Run ROS 2 Unit Tests (${{ matrix.ros-distribution }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ros-distribution: jazzy
+            os: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup ROS 2
+      uses: ros-tooling/setup-ros@v0.7
+      with:
+        required-ros-distributions: ${{ matrix.ros-distribution }}
+    - name: Install ROS 2 interface packages
+      # ros-tooling/setup-ros only installs ros-<distro>-ros-base, which lacks
+      # the message / action packages that skrobot.interfaces.ros2.base imports
+      # (control_msgs, trajectory_msgs, action_msgs, sensor_msgs).
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends \
+          ros-${{ matrix.ros-distribution }}-control-msgs \
+          ros-${{ matrix.ros-distribution }}-trajectory-msgs \
+          ros-${{ matrix.ros-distribution }}-action-msgs \
+          ros-${{ matrix.ros-distribution }}-sensor-msgs
+    - name: Install Python dependencies
+      shell: bash
+      run: |
+        source /opt/ros/${{ matrix.ros-distribution }}/setup.bash
+        python -m pip install --upgrade pip setuptools wheel
+        pip install pytest pytest-timeout
+        # Install the project itself; '[all]' would pull pybullet etc., but
+        # the ROS 2 unit tests only need the core skrobot model + URDF code.
+        pip install -e .
+    - name: Run ROS 2 unit tests
+      shell: bash
+      # PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 stops pytest from auto-loading every
+      # plugin advertised on the ROS 2 distro's PYTHONPATH (launch_testing,
+      # launch_testing_ros, ament_lint, ...). They each ship pytest hooks that
+      # are incompatible with newer pluggy or assume their own collector
+      # entrypoint, which crashes plain unit-test collection. We explicitly
+      # opt back in to the plugins this job needs (pytest-timeout) via -p.
+      # --timeout=60 keeps any regression of the wait_until_update_all_joints
+      # hang surfacing as a per-test timeout instead of a stuck CI run.
+      env:
+        PYTEST_DISABLE_PLUGIN_AUTOLOAD: '1'
+      run: |
+        source /opt/ros/${{ matrix.ros-distribution }}/setup.bash
+        pytest -v -p pytest_timeout --timeout=60 \
+          tests/skrobot_tests/interfaces_tests/ros2/test_base.py
+

--- a/skrobot/interfaces/ros2/base.py
+++ b/skrobot/interfaces/ros2/base.py
@@ -54,7 +54,9 @@ class ROS2RobotInterfaceBase(Node):
                  joint_states_queue_size=1,
                  controller_timeout=3,
                  namespace=None,
-                 node_name='robot_interface'):
+                 node_name='robot_interface',
+                 wait_for_joint_states=False,
+                 joint_states_timeout=10.0):
         """Initialization of RobotInterface
 
         Parameters
@@ -73,6 +75,17 @@ class ROS2RobotInterfaceBase(Node):
             namespace of controller
         node_name : string
             name of the ROS2 node
+        wait_for_joint_states : bool
+            If True, block in ``__init__`` until at least one ``JointState``
+            message is received on ``joint_states_topic``. This makes the
+            instance immediately usable for ``angle_vector`` / ``update_robot_state``
+            without manual polling. Default is False to preserve backwards
+            compatibility — set to True when you want the constructor to fail
+            fast on misconfigured topics. Has no effect when an executor is
+            not spinning the node externally; in that case rclpy.spin_once
+            is used to drain pending messages.
+        joint_states_timeout : float
+            Timeout in seconds for the ``wait_for_joint_states`` option.
 
         """
         super().__init__(node_name)
@@ -85,11 +98,20 @@ class ROS2RobotInterfaceBase(Node):
         self.joint_action_enable = True
         self.namespace = namespace
         self._joint_state_msg = None
+        # Joint names actually seen on the joint_states topic. Used to filter
+        # which joints wait_until_update_all_joints actually waits for, so
+        # that joints declared in the URDF but never published (e.g. gripper
+        # finger joints when the gripper node is not running) do not cause
+        # an indefinite wait.
+        self._received_joint_names = set()
+        self._not_updated_joints = []
+        self._timeout_reason = ""
 
         if self.namespace:
             topic_name = f'{self.namespace}/{joint_states_topic}'
         else:
             topic_name = joint_states_topic
+        self._joint_states_topic_name = topic_name
 
         self.joint_state_sub = self.create_subscription(
             JointState,
@@ -97,6 +119,9 @@ class ROS2RobotInterfaceBase(Node):
             self.joint_state_callback,
             joint_states_queue_size
         )
+
+        if wait_for_joint_states:
+            self._wait_for_first_joint_state(joint_states_timeout)
 
         self.controller_table = {}
         self.controller_param_table = {}
@@ -164,51 +189,116 @@ class ROS2RobotInterfaceBase(Node):
                 'time is invalid type. {}'.format(time))
         return time
 
-    def wait_until_update_all_joints(self, tgt_tm):
-        """Wait until all joints have been updated with timestamps newer than target time.
+    def _wait_for_first_joint_state(self, timeout):
+        """Spin the node until a JointState is received or timeout elapses."""
+        deadline = time.time() + timeout
+        while self._joint_state_msg is None and time.time() < deadline:
+            try:
+                rclpy.spin_once(self, timeout_sec=0.1)
+            except Exception:
+                # If an external executor is already spinning this node,
+                # spin_once raises. Just yield and let it deliver the message.
+                time.sleep(0.05)
+        if self._joint_state_msg is None:
+            raise TimeoutError(
+                "No JointState received on '{}' within {:.1f}s. "
+                "Check that joint_state_publisher / joint_state_broadcaster "
+                "are running and that the topic name / namespace matches."
+                .format(self._joint_states_topic_name, timeout))
 
-        This method handles both rclpy.time.Time objects (with nanoseconds attribute)
-        and builtin_interfaces.msg.Time objects (with sec and nanosec attributes).
+    @staticmethod
+    def _stamp_nanoseconds(ts):
+        if ts is None:
+            return None
+        if hasattr(ts, 'nanoseconds'):
+            return ts.nanoseconds
+        if hasattr(ts, 'sec') and hasattr(ts, 'nanosec'):
+            return ts.sec * 1_000_000_000 + ts.nanosec
+        return None
+
+    def wait_until_update_all_joints(self, tgt_tm, timeout=3.0):
+        """Wait until joints seen on joint_states have timestamps > tgt_tm.
+
+        Only joints that have ever been received on the joint_states topic
+        are considered (see ``_received_joint_names``). Joints declared in
+        the URDF but never published — e.g. finger joints when the gripper
+        node is not running — are ignored, so this method does not hang
+        when a subset of the URDF is being driven.
 
         Parameters
         ----------
-        tgt_tm : rclpy.time.Time or bool
-            Target time to wait for. If True, uses current time.
+        tgt_tm : rclpy.time.Time, builtin_interfaces.msg.Time, bool, or None
+            Target time. If True / None, uses the current ROS time (i.e. waits
+            for any joint_state newer than now).
+        timeout : float
+            Maximum seconds to wait. ``0`` or ``None`` waits forever.
+
+        Returns
+        -------
+        bool
+            True if all received joints have a stamp newer than ``tgt_tm``
+            within the timeout, False otherwise. The reason for a False
+            return is recorded in ``self._timeout_reason``.
         """
-        if hasattr(tgt_tm, 'nanoseconds'):
-            initial_time = tgt_tm.nanoseconds
-        else:
+        self._not_updated_joints = []
+        self._timeout_reason = "wait_until_update_all_joints did not complete"
+
+        initial_time = self._stamp_nanoseconds(tgt_tm)
+        if initial_time is None:
             initial_time = self.get_clock().now().nanoseconds
 
+        start = time.time()
         while True:
-            if 'stamp_list' in self.robot_state:
-                all_valid = True
-                for ts in self.robot_state['stamp_list']:
-                    if ts is None:
-                        all_valid = False
-                        break
+            if 'stamp_list' in self.robot_state and self._received_joint_names:
+                names = self.robot_state['name']
+                stamps = self.robot_state['stamp_list']
+                check_results = []
+                for i, name in enumerate(names):
+                    if name in self._received_joint_names:
+                        ts_ns = self._stamp_nanoseconds(stamps[i])
+                        check_results.append(
+                            ts_ns is not None and ts_ns > initial_time)
+                if check_results and all(check_results):
+                    self._timeout_reason = ""
+                    return True
 
-                    # Handle rclpy.time.Time objects
-                    if hasattr(ts, 'nanoseconds'):
-                        if ts.nanoseconds <= initial_time:
-                            all_valid = False
-                            break
-                    # Handle builtin_interfaces.msg.Time objects
-                    elif hasattr(ts, 'sec') and hasattr(ts, 'nanosec'):
-                        ts_nano = ts.sec * 1e9 + ts.nanosec
-                        if ts_nano <= initial_time:
-                            all_valid = False
-                            break
-                    else:
-                        # Unknown timestamp type
-                        all_valid = False
-                        break
+            if timeout and (time.time() - start) > timeout:
+                self._set_timeout_reason(initial_time)
+                logger.warning(
+                    "wait_until_update_all_joints timeout. %s",
+                    self._timeout_reason)
+                return False
+            time.sleep(0.005)
 
-                if all_valid:
-                    return
-
-            # Small sleep to avoid busy waiting and allow other threads to run
-            time.sleep(0.001)
+    def _set_timeout_reason(self, initial_time):
+        """Populate self._timeout_reason for diagnostic logging."""
+        if 'stamp_list' not in self.robot_state \
+                or 'name' not in self.robot_state:
+            self._timeout_reason = (
+                "No joint_states message received. robot_state keys: {}"
+                .format(list(self.robot_state.keys())))
+            return
+        stamps = self.robot_state['stamp_list']
+        names = self.robot_state['name']
+        if not names or not stamps:
+            self._timeout_reason = (
+                "joint_names or stamp_list is empty. "
+                "len(joint_names)={}, len(stamp_list)={}"
+                .format(len(names), len(stamps)))
+            return
+        for name, ts in zip(names, stamps):
+            if name not in self._received_joint_names:
+                continue
+            ts_ns = self._stamp_nanoseconds(ts)
+            if ts_ns is None or ts_ns <= initial_time:
+                self._not_updated_joints.append(name)
+        if self._not_updated_joints:
+            self._timeout_reason = (
+                "Not updated joints: {}".format(self._not_updated_joints))
+        else:
+            self._timeout_reason = (
+                "All received joints have stamps but none newer than "
+                "initial_time. Check use_sim_time / clock alignment.")
 
     def set_robot_state(self, key, msg):
         self.robot_state[key] = msg
@@ -234,20 +324,29 @@ class ROS2RobotInterfaceBase(Node):
             self.moving_status[key] = False
 
     def update_robot_state(self, wait_until_update=False):
-        """Update robot state.
+        """Update the robot model from the latest joint_states.
 
         Parameters
         ----------
-        wait_until_update : bool
-            if True TODO
+        wait_until_update : bool, rclpy.time.Time, or float
+            If truthy, wait via :meth:`wait_until_update_all_joints` for a
+            joint_state newer than this time (or "now" when True) before
+            applying the update. Useful right after :meth:`wait_interpolation`
+            to avoid reading state from before motion completion.
 
         Returns
         -------
-        TODO
+        bool
+            True if the model was updated, False if no joint_states have been
+            received yet or wait_until_update timed out. ``self._timeout_reason``
+            holds a description in the False case.
         """
         if wait_until_update:
-            self.wait_until_update_all_joints(wait_until_update)
+            if not self.wait_until_update_all_joints(wait_until_update):
+                return False
         if not self.robot_state:
+            self._timeout_reason = (
+                "robot_state is empty (no joint_states callback received)")
             return False
         joint_names = self.robot_state['name']
         positions = self.robot_state['position']
@@ -269,13 +368,23 @@ class ROS2RobotInterfaceBase(Node):
             joint.joint_angle(position)
             joint.joint_velocity = velocity
             joint.joint_torque = effort
+        return True
 
     def joint_state_callback(self, msg):
         self._joint_state_msg = msg
+        # Track every joint name we have ever seen on this topic so that
+        # wait_until_update_all_joints only waits for joints that are
+        # actually being published.
+        self._received_joint_names.update(msg.name)
+
         if 'name' in self.robot_state:
             robot_state_names = self.robot_state['name']
         else:
-            robot_state_names = msg.name
+            # Pre-allocate the state slots from the URDF model, not from the
+            # first message — joints arriving from a later publisher (e.g. a
+            # gripper node started after the controllers) need their slot to
+            # already exist for stamp tracking.
+            robot_state_names = [j.name for j in self.robot.joint_list]
             self.robot_state['name'] = robot_state_names
             for key in ['position', 'velocity', 'effort']:
                 self.robot_state[key] = np.zeros(len(robot_state_names))
@@ -289,6 +398,11 @@ class ROS2RobotInterfaceBase(Node):
             if len(joint_names) == len(joint_data):
                 data = self.robot_state[key]
                 for jn in joint_names:
+                    # Skip joints not in the robot model (e.g. when a stray
+                    # publisher sends names that are not part of the URDF).
+                    if jn not in robot_state_names:
+                        index += 1
+                        continue
                     joint_index = robot_state_names.index(jn)
                     data[joint_index] = joint_data[index]
                     index += 1
@@ -664,7 +778,9 @@ class ROS2RobotInterfaceBase(Node):
                 traj_points)
         return avs
 
-    def wait_interpolation(self, controller_type=None, timeout=0):
+    def wait_interpolation(self, controller_type=None, timeout=0,
+                           wait_for_state_update=True,
+                           state_update_timeout=1.0):
         """Wait until last sent motion is finished.
 
         Parameters
@@ -673,6 +789,17 @@ class ROS2RobotInterfaceBase(Node):
             controller to be wait
         timeout : float
             max time of for waiting
+        wait_for_state_update : bool
+            If True (default), after each action result arrives, also wait
+            until a joint_state with stamp newer than the result time is
+            received. This guarantees that an immediate ``update_robot_state``
+            / ``self.robot.angle_vector()`` afterwards sees the post-motion
+            state instead of a frame from before completion. Set to False to
+            preserve the old "return as soon as the action result arrives"
+            behaviour.
+        state_update_timeout : float
+            Seconds to wait for the post-motion joint_state. Bounded so a
+            stalled state publisher cannot make wait_interpolation hang.
 
         Returns
         -------
@@ -747,6 +874,16 @@ class ROS2RobotInterfaceBase(Node):
                 except Exception as e:
                     self.get_logger().error(f"Error getting result: {e}")
                     results.append(False)
+
+        # After every controller has reported its goal result, optionally wait
+        # for a fresh joint_state so that callers immediately seeing the post-
+        # motion model state via update_robot_state() do not get a sample from
+        # before the action result arrived (action result completes ~1 cycle
+        # before joint_state_broadcaster publishes the final state).
+        if wait_for_state_update:
+            now = self.get_clock().now()
+            self.wait_until_update_all_joints(
+                now, timeout=state_update_timeout)
 
         return results
 

--- a/tests/skrobot_tests/interfaces_tests/ros2/test_base.py
+++ b/tests/skrobot_tests/interfaces_tests/ros2/test_base.py
@@ -1,0 +1,224 @@
+"""Unit tests for ROS2RobotInterfaceBase that do not require a live controller.
+
+These cover the wait/update plumbing — `_received_joint_names`, the timeout
+behaviour of `wait_until_update_all_joints`, the bool return of
+`update_robot_state`, and the optional first-message wait in `__init__`.
+"""
+import threading
+import time
+import unittest
+
+import numpy as np
+import pytest
+
+
+try:
+    import rclpy
+    from rclpy.executors import SingleThreadedExecutor
+    from sensor_msgs.msg import JointState
+
+    from skrobot.interfaces.ros2.base import ROS2RobotInterfaceBase
+    from skrobot.models import Panda
+    ROS2_AVAILABLE = True
+
+    class _NoControllerInterface(ROS2RobotInterfaceBase):
+        """Skip controller / action setup entirely so tests can focus on the
+        joint_states bookkeeping path."""
+
+        def default_controller(self):
+            return []
+except ImportError:
+    ROS2_AVAILABLE = False
+
+
+pytestmark = pytest.mark.skipif(
+    not ROS2_AVAILABLE, reason="ROS 2 / rclpy not importable")
+
+
+def _make_interface(node_name, joint_states_topic=None, **kwargs):
+    """Create an interface with an isolated joint_states topic by default.
+
+    Each instance subscribes to its own per-test topic so concurrently running
+    publishers (e.g. a panda controller from another shell) do not bleed into
+    timeout tests via DDS discovery.
+    """
+    if joint_states_topic is None:
+        joint_states_topic = '_test_joint_states_' + node_name
+    return _NoControllerInterface(
+        robot=Panda(),
+        node_name=node_name,
+        joint_states_topic=joint_states_topic,
+        controller_timeout=0.1,  # don't actually wait for any controller
+        **kwargs,
+    )
+
+
+def _make_joint_state(node, names, positions, stamp=None):
+    msg = JointState()
+    msg.name = list(names)
+    msg.position = list(positions)
+    msg.velocity = []
+    msg.effort = []
+    msg.header.stamp = (stamp or node.get_clock().now()).to_msg()
+    return msg
+
+
+class TestRos2BaseJointStateBookkeeping(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if not rclpy.ok():
+            rclpy.init()
+
+    def test_received_joint_names_tracks_callback_inputs(self):
+        ri = _make_interface('test_received_names')
+        try:
+            assert ri._received_joint_names == set()
+            ri.joint_state_callback(_make_joint_state(
+                ri, ['panda_joint1', 'panda_joint2'], [0.1, 0.2]))
+            assert ri._received_joint_names == {'panda_joint1', 'panda_joint2'}
+            ri.joint_state_callback(_make_joint_state(
+                ri, ['panda_finger_joint1'], [0.04]))
+            assert ri._received_joint_names == {
+                'panda_joint1', 'panda_joint2', 'panda_finger_joint1'}
+        finally:
+            ri.destroy_node()
+
+    def test_wait_until_update_all_joints_times_out_with_reason(self):
+        ri = _make_interface('test_timeout_reason')
+        try:
+            t0 = time.time()
+            result = ri.wait_until_update_all_joints(True, timeout=0.2)
+            elapsed = time.time() - t0
+            assert result is False
+            assert 0.15 < elapsed < 1.0  # bounded by the timeout
+            # No joint_states arrived at all → reason should mention that.
+            assert 'No joint_states' in ri._timeout_reason or \
+                   'robot_state is empty' in ri._timeout_reason or \
+                   'robot_state keys' in ri._timeout_reason
+        finally:
+            ri.destroy_node()
+
+    def test_wait_returns_true_after_fresh_message(self):
+        ri = _make_interface('test_wait_fresh')
+        try:
+            tgt = ri.get_clock().now()
+            time.sleep(0.05)  # ensure the next stamp is strictly newer
+            ri.joint_state_callback(_make_joint_state(
+                ri, ['panda_joint1', 'panda_joint2'], [0.1, 0.2]))
+            assert ri.wait_until_update_all_joints(tgt, timeout=1.0) is True
+            assert ri._timeout_reason == ""
+        finally:
+            ri.destroy_node()
+
+    def test_wait_ignores_unpublished_joints(self):
+        """A joint declared in the URDF but never published must not block wait."""
+        ri = _make_interface('test_filter_unpublished')
+        try:
+            tgt = ri.get_clock().now()
+            time.sleep(0.05)
+            # Publish only joint1+joint2; finger joints declared in the URDF
+            # but never seen on the topic must be ignored by the wait logic.
+            ri.joint_state_callback(_make_joint_state(
+                ri, ['panda_joint1', 'panda_joint2'], [0.1, 0.2]))
+            assert ri.wait_until_update_all_joints(tgt, timeout=1.0) is True
+        finally:
+            ri.destroy_node()
+
+
+class TestRos2BaseUpdateRobotStateReturnValue(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if not rclpy.ok():
+            rclpy.init()
+
+    def test_returns_false_when_no_message_received(self):
+        ri = _make_interface('test_update_no_msg')
+        try:
+            assert ri.update_robot_state() is False
+            assert ri._timeout_reason  # populated for diagnosis
+        finally:
+            ri.destroy_node()
+
+    def test_returns_true_after_message(self):
+        ri = _make_interface('test_update_after_msg')
+        try:
+            ri.joint_state_callback(_make_joint_state(
+                ri, ['panda_joint1', 'panda_joint2'], [0.5, -0.5]))
+            assert ri.update_robot_state() is True
+            assert np.isclose(ri.robot.panda_joint1.joint_angle(), 0.5)
+            assert np.isclose(ri.robot.panda_joint2.joint_angle(), -0.5)
+        finally:
+            ri.destroy_node()
+
+    def test_returns_false_when_wait_until_update_times_out(self):
+        ri = _make_interface('test_update_timeout')
+        try:
+            assert ri.update_robot_state(wait_until_update=True) is False
+        finally:
+            ri.destroy_node()
+
+
+class TestRos2BaseConstructorWaitsForJointStates(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if not rclpy.ok():
+            rclpy.init()
+
+    def test_wait_for_joint_states_default_off(self):
+        # Default should not block in __init__ even when no publisher exists.
+        t0 = time.time()
+        ri = _make_interface('test_wait_default_off')
+        elapsed = time.time() - t0
+        try:
+            assert elapsed < 1.0  # constructor returned promptly
+        finally:
+            ri.destroy_node()
+
+    def test_wait_for_joint_states_raises_on_timeout(self):
+        with pytest.raises(TimeoutError) as excinfo:
+            _make_interface(
+                'test_wait_timeout_ctor',
+                wait_for_joint_states=True,
+                joint_states_timeout=0.3)
+        assert 'JointState' in str(excinfo.value)
+
+    def test_wait_for_joint_states_returns_when_message_arrives(self):
+        """A background publisher arriving before the timeout unblocks __init__."""
+        topic = '_test_joint_states_arrives_ctor'
+        publisher_node = rclpy.create_node('aux_publisher_for_wait_ctor')
+        publisher = publisher_node.create_publisher(JointState, topic, 10)
+        executor = SingleThreadedExecutor()
+        executor.add_node(publisher_node)
+        spin_thread = threading.Thread(target=executor.spin, daemon=True)
+        spin_thread.start()
+
+        stop_event = threading.Event()
+
+        def publish_loop():
+            while not stop_event.is_set():
+                msg = JointState()
+                msg.name = ['panda_joint1']
+                msg.position = [0.0]
+                msg.header.stamp = publisher_node.get_clock().now().to_msg()
+                publisher.publish(msg)
+                time.sleep(0.05)
+
+        publish_thread = threading.Thread(target=publish_loop, daemon=True)
+        publish_thread.start()
+
+        try:
+            ri = _make_interface(
+                'test_wait_arrives_ctor',
+                joint_states_topic=topic,
+                wait_for_joint_states=True,
+                joint_states_timeout=3.0)
+            assert ri._joint_state_msg is not None
+            ri.destroy_node()
+        finally:
+            stop_event.set()
+            publish_thread.join(timeout=1.0)
+            executor.shutdown()
+            publisher_node.destroy_node()


### PR DESCRIPTION
wait_until_update_all_joints, update_robot_state, and wait_interpolation in skrobot.interfaces.ros2.base previously had three sharp edges that already had matching fixes on the ROS 1 side:

- wait_until_update_all_joints had no timeout and no diagnostic, so it waited forever for any URDF joint that was never published (e.g. gripper finger joints when only an arm controller is up).
- update_robot_state did not return a usable bool, so callers could not distinguish no joint_states yet from updated successfully.
- wait_interpolation returned as soon as the action result arrived, but the final joint_state_broadcaster sample lands ~one cycle later, so an immediate update_robot_state read a frame from before motion completion.

This patch backports the ROS 1 base improvements:

- _received_joint_names tracks names actually seen on the joint_states topic so the wait logic only waits for joints being published.
- robot_state slots are pre-allocated from robot.joint_list, so late publishers (e.g. a gripper node started after controllers) get their slots ready in advance.
- wait_until_update_all_joints accepts a timeout, returns bool, and populates _timeout_reason / _not_updated_joints for diagnosis.
- update_robot_state returns True/False matching the ROS 1 contract.
- wait_interpolation now waits for a fresh joint_state after the action result by default (wait_for_state_update=True, state_update_timeout=1.0), eliminating the post-motion stale-read race.
- ROS2RobotInterfaceBase.__init__ gains opt-in wait_for_joint_states / joint_states_timeout to fail fast on misconfigured topics.

10 unit tests cover the new bookkeeping, timeout behaviour, bool returns, and the constructor wait option.

A new ros2-tests job is added to .github/workflows/test.yml that installs ROS 2 humble (Ubuntu 22.04) and jazzy (Ubuntu 24.04) via ros-tooling/setup-ros and runs the new test_base.py with pytest --timeout=60 so that any future regression of the wait_until_update_all_joints hang surfaces as a per-test timeout instead of a stuck CI run.