### PR TITLE
Add base-pose cost and per-chain weights to multi-EE waypoint cost

### DIFF
--- a/skrobot/planner/trajectory_optimization/problem.py
+++ b/skrobot/planner/trajectory_optimization/problem.py
@@ -274,6 +274,85 @@ class TrajectoryProblem:
             weight=weight,
         ))
 
+    def update_com_targets(self, target_positions, cost_index=0):
+        """Replace the per-waypoint targets of an existing CoG cost.
+
+        After the first ``solver.solve(problem, ...)`` call has compiled
+        the problem, the target values are kept in a frozen jaxls
+        ``Var`` that is rebuilt every solve from this problem instance.
+        Mutating the values here lets the next solve reuse the cached
+        plan and only re-run Levenberg-Marquardt with the new targets,
+        avoiding a 20-30 s JIT recompile.
+
+        Parameters
+        ----------
+        target_positions : (n_waypoints, 3) ndarray *or* (3,) ndarray
+            New per-waypoint world targets.  A length-3 vector is
+            broadcast to every waypoint.
+        cost_index : int
+            Which ``add_com_cost`` call to update (in registration
+            order).  Default 0 == the first.
+
+        Notes
+        -----
+        Only valid after the cost has been compiled at least once.
+        Raises ``RuntimeError`` if called before any solve.
+        """
+        import jax.numpy as jnp
+        if (not hasattr(self, '_com_param_vars')
+                or len(self._com_param_vars) <= cost_index):
+            raise RuntimeError(
+                'update_com_targets() requires that solver.solve(...) '
+                'has been called at least once so the CoG cost is '
+                'compiled (cost_index={}).'.format(cost_index))
+        entry = self._com_param_vars[cost_index]
+        sel = entry['axis_mask_indices']
+        wp_idx = entry['waypoint_indices']
+        targets = np.asarray(target_positions, dtype=np.float64)
+        if targets.ndim == 1:
+            targets = np.broadcast_to(targets, (len(wp_idx), 3))
+        else:
+            targets = targets[wp_idx] if len(wp_idx) != targets.shape[0] \
+                else targets
+        entry['targets_sel'] = jnp.asarray(
+            targets[:, sel], dtype=jnp.float64)
+
+    def update_multi_ee_targets(self,
+                                target_positions_per_chain,
+                                target_rotations_per_chain=None,
+                                cost_index=0):
+        """Replace the per-waypoint targets of an existing multi-EE cost.
+
+        Counterpart to :meth:`update_com_targets`. Same semantics:
+        must be called after the first solve so the param vars exist;
+        the next solve reuses the JIT-compiled plan and only re-runs
+        Levenberg-Marquardt against the new targets.
+        """
+        import jax.numpy as jnp
+        if (not hasattr(self, '_multi_ee_param_vars')
+                or len(self._multi_ee_param_vars) <= cost_index):
+            raise RuntimeError(
+                'update_multi_ee_targets() requires that '
+                'solver.solve(...) has been called at least once so '
+                'the multi-EE cost is compiled (cost_index={}).'.format(
+                    cost_index))
+        entry = self._multi_ee_param_vars[cost_index]
+        T = entry['n_waypoints']
+        target_positions_per_chain = [
+            np.asarray(t, dtype=np.float64)
+            for t in target_positions_per_chain]
+        T_pos = np.stack(target_positions_per_chain, axis=1)
+        entry['target_pos'] = jnp.asarray(T_pos, dtype=jnp.float64)
+        if target_rotations_per_chain is not None:
+            if entry['rot_var_class'] is None:
+                raise ValueError(
+                    'this cost was registered without rotation tracking; '
+                    'cannot supply target_rotations_per_chain.')
+            T_rot = np.stack(
+                [np.asarray(r, dtype=np.float64).reshape(T, 9)
+                 for r in target_rotations_per_chain], axis=1)
+            entry['target_rot'] = jnp.asarray(T_rot, dtype=jnp.float64)
+
     def add_jerk_cost(self, weight=0.1):
         """Add jerk minimization cost.
 
@@ -796,6 +875,8 @@ class TrajectoryProblem:
         target_rotations_per_chain=None,
         position_weight=100.0,
         rotation_weight=10.0,
+        position_weights_per_chain=None,
+        rotation_weights_per_chain=None,
     ):
         """Per-waypoint multi-EE pose tracking with floating base.
 
@@ -812,10 +893,20 @@ class TrajectoryProblem:
             One per-waypoint position trajectory per chain.
         target_rotations_per_chain : list of (n_waypoints, 3, 3), optional
             One per-waypoint rotation trajectory per chain. ``None``
-            disables rotation tracking.
+            disables rotation tracking globally.
         position_weight, rotation_weight : float
-            Position / rotation tracking weights (uniform across all
-            chains and waypoints).
+            Default position / rotation tracking weights, used for
+            chains not listed in ``*_weights_per_chain``.
+        position_weights_per_chain : list of float, optional
+            Per-chain position weight (overrides ``position_weight`` for
+            that chain).  Set to ``0`` to disable position tracking on
+            a chain that should only contribute rotation (GMR-style
+            ``pos_weight=0, rot_weight=10`` rows for elbow / knee /
+            torso).  Length must equal ``n_chains``.
+        rotation_weights_per_chain : list of float, optional
+            Per-chain rotation weight (overrides ``rotation_weight``).
+            Set ``0`` for chains whose source rotation is unreliable
+            (e.g. synthetic-motion hands).
         """
         target_positions_per_chain = [
             np.asarray(t, dtype=np.float64)
@@ -824,6 +915,23 @@ class TrajectoryProblem:
             target_rotations_per_chain = [
                 np.asarray(r, dtype=np.float64)
                 for r in target_rotations_per_chain]
+        n_chains = len(target_positions_per_chain)
+        if position_weights_per_chain is not None:
+            position_weights_per_chain = np.asarray(
+                position_weights_per_chain, dtype=np.float64)
+            if position_weights_per_chain.shape != (n_chains,):
+                raise ValueError(
+                    'position_weights_per_chain must have length '
+                    'n_chains={}; got shape {}'.format(
+                        n_chains, position_weights_per_chain.shape))
+        if rotation_weights_per_chain is not None:
+            rotation_weights_per_chain = np.asarray(
+                rotation_weights_per_chain, dtype=np.float64)
+            if rotation_weights_per_chain.shape != (n_chains,):
+                raise ValueError(
+                    'rotation_weights_per_chain must have length '
+                    'n_chains={}; got shape {}'.format(
+                        n_chains, rotation_weights_per_chain.shape))
         self.residuals.append(ResidualSpec(
             name='multi_ee_waypoint',
             residual_fn='multi_ee_waypoint',
@@ -832,10 +940,96 @@ class TrajectoryProblem:
                 'target_rotations_per_chain': target_rotations_per_chain,
                 'position_weight': position_weight,
                 'rotation_weight': rotation_weight,
+                'position_weights_per_chain': position_weights_per_chain,
+                'rotation_weights_per_chain': rotation_weights_per_chain,
             },
             kind='soft',
             weight=1.0,
         ))
+
+    def add_base_pose_cost(
+        self,
+        target_positions,
+        target_rotations=None,
+        position_weight=2000.0,
+        rotation_weight=100.0,
+    ):
+        """Per-waypoint floating-base pose tracking cost.
+
+        Drives the floating base's world-frame pose at every waypoint
+        toward a target trajectory.  Useful for retargeting where the
+        source motion has a meaningful pelvis position + yaw that the
+        robot should reproduce; without this, the IK is free to put
+        the base anywhere consistent with the EE constraints (e.g.
+        robot facing backward while hands/feet still satisfy targets).
+
+        Requires the problem to have a non-zero ``n_base_dof``;
+        otherwise the call is a no-op.
+
+        Parameters
+        ----------
+        target_positions : (n_waypoints, 3) ndarray
+            World-frame target base positions.
+        target_rotations : (n_waypoints, 3, 3) ndarray, optional
+            World-frame target base rotations.  ``None`` disables
+            rotation tracking.
+        position_weight, rotation_weight : float
+            Tracking weights.
+        """
+        n_base_dof = getattr(self, 'n_base_dof', 0)
+        if n_base_dof == 0:
+            return
+        target_positions = np.asarray(target_positions, dtype=np.float64)
+        if target_positions.shape != (self.n_waypoints, 3):
+            raise ValueError(
+                'target_positions must have shape ({}, 3); got {}'.format(
+                    self.n_waypoints, target_positions.shape))
+        if target_rotations is not None:
+            target_rotations = np.asarray(target_rotations, dtype=np.float64)
+            if target_rotations.shape != (self.n_waypoints, 3, 3):
+                raise ValueError(
+                    'target_rotations must have shape ({}, 3, 3); got {}'
+                    .format(self.n_waypoints, target_rotations.shape))
+        self.residuals.append(ResidualSpec(
+            name='base_pose',
+            residual_fn='base_pose',
+            params={
+                'target_positions': target_positions,
+                'target_rotations': target_rotations,
+                'position_weight': position_weight,
+                'rotation_weight': rotation_weight,
+            },
+            kind='soft',
+            weight=1.0,
+        ))
+
+    def update_base_pose_targets(self,
+                                 target_positions,
+                                 target_rotations=None,
+                                 cost_index=0):
+        """Replace per-waypoint base-pose targets without retracing.
+
+        Mirror of :meth:`update_multi_ee_targets` for the base-pose
+        cost; lets the cached LM plan be reused across motion clips.
+        """
+        import jax.numpy as jnp
+        if (not hasattr(self, '_base_pose_param_vars')
+                or len(self._base_pose_param_vars) <= cost_index):
+            raise RuntimeError(
+                'update_base_pose_targets() requires that '
+                'solver.solve(...) has been called at least once.')
+        entry = self._base_pose_param_vars[cost_index]
+        target_positions = np.asarray(target_positions, dtype=np.float64)
+        entry['target_pos'] = jnp.asarray(
+            target_positions, dtype=jnp.float64)
+        if target_rotations is not None:
+            if entry['rot_var_class'] is None:
+                raise ValueError(
+                    'this cost was registered without rotation tracking.')
+            target_rotations = np.asarray(target_rotations, dtype=np.float64)
+            entry['target_rot'] = jnp.asarray(
+                target_rotations.reshape(self.n_waypoints, 9),
+                dtype=jnp.float64)
 
     def add_ee_waypoint_cost(
         self,

--- a/skrobot/planner/trajectory_optimization/solvers/jaxls_solver.py
+++ b/skrobot/planner/trajectory_optimization/solvers/jaxls_solver.py
@@ -413,6 +413,10 @@ class JaxlsSolver(BaseSolver):
                     costs.append(self._make_multi_ee_waypoint_cost(
                         problem, TrajectoryVar, fk_data, residual_spec
                     ))
+                elif residual_spec.name == 'base_pose':
+                    costs.append(self._make_base_pose_cost(
+                        problem, TrajectoryVar, residual_spec
+                    ))
 
             # --- EE waypoint costs ---
             if has_ee_waypoints:
@@ -544,6 +548,13 @@ class JaxlsSolver(BaseSolver):
                 if entry['rot_var_class'] is not None:
                     all_variables.append(
                         entry['rot_var_class'](jnp.arange(T)))
+            # Base-pose cost ParamVars.
+            for entry in getattr(problem, '_base_pose_param_vars', []):
+                pos_vc = entry['pos_var_class']
+                all_variables.append(pos_vc(jnp.arange(T)))
+                if entry['rot_var_class'] is not None:
+                    all_variables.append(
+                        entry['rot_var_class'](jnp.arange(T)))
 
             ls_problem = jaxls.LeastSquaresProblem(
                 costs=costs,
@@ -638,6 +649,17 @@ class JaxlsSolver(BaseSolver):
             )
         # Multi-EE waypoint ParamVar values.
         for entry in getattr(problem, '_multi_ee_param_vars', []):
+            pos_vc = entry['pos_var_class']
+            init_pairs.append(
+                pos_vc(jnp.arange(T)).with_value(entry['target_pos'])
+            )
+            if entry['rot_var_class'] is not None:
+                init_pairs.append(
+                    entry['rot_var_class'](jnp.arange(T)).with_value(
+                        entry['target_rot'])
+                )
+        # Base-pose ParamVar values.
+        for entry in getattr(problem, '_base_pose_param_vars', []):
             pos_vc = entry['pos_var_class']
             init_pairs.append(
                 pos_vc(jnp.arange(T)).with_value(entry['target_pos'])
@@ -1330,9 +1352,43 @@ class JaxlsSolver(BaseSolver):
 
         target_pos_per_chain = spec.params['target_positions_per_chain']
         target_rot_per_chain = spec.params['target_rotations_per_chain']
-        pos_w = jnp.sqrt(spec.params['position_weight'])
-        rot_w = jnp.sqrt(spec.params['rotation_weight']) \
-            if target_rot_per_chain is not None else None
+        # Per-chain weights: fall back to scalar position/rotation_weight
+        # for chains not explicitly weighted.  The sqrt is folded into
+        # the residual scale so the LM minimises the squared weighted
+        # error (= original weight * squared-error).
+        pos_w_pc = spec.params.get('position_weights_per_chain')
+        rot_w_pc = spec.params.get('rotation_weights_per_chain')
+        if pos_w_pc is not None:
+            pos_w_chain = jnp.sqrt(jnp.asarray(pos_w_pc, dtype=jnp.float64))
+            np.asarray(pos_w_pc, dtype=np.float64)
+        else:
+            pos_w_chain = jnp.sqrt(jnp.asarray(
+                [spec.params['position_weight']] * n_chains,
+                dtype=jnp.float64))
+            np.full(
+                n_chains, float(spec.params['position_weight']),
+                dtype=np.float64)
+        if target_rot_per_chain is not None:
+            if rot_w_pc is not None:
+                rot_w_chain = jnp.sqrt(
+                    jnp.asarray(rot_w_pc, dtype=jnp.float64))
+                rot_w_pc_arr = np.asarray(rot_w_pc, dtype=np.float64)
+            else:
+                rot_w_chain = jnp.sqrt(jnp.asarray(
+                    [spec.params['rotation_weight']] * n_chains,
+                    dtype=jnp.float64))
+                rot_w_pc_arr = np.full(
+                    n_chains, float(spec.params['rotation_weight']),
+                    dtype=np.float64)
+        else:
+            rot_w_chain = None
+            rot_w_pc_arr = np.zeros(n_chains, dtype=np.float64)
+        # Chains with zero rotation weight bypass the SE(3) log error to
+        # avoid the body-frame translation coupling (J^{-1}(ω) term)
+        # that warps gradients when actual_rot != target_rot.  Decided
+        # at trace time so JAX sees a static graph per chain.
+        chain_track_rot = [
+            bool(rot_w_pc_arr[ci] > 0.0) for ci in range(n_chains)]
 
         # Per-chain EE FK that takes the root_link world pose as its
         # base argument; the chain's natural parent transform relative
@@ -1412,11 +1468,18 @@ class JaxlsSolver(BaseSolver):
                 for ci in range(n_chains):
                     ee_pos, ee_rot = get_ee_pose_per_chain[ci](
                         apc[ci], bpos, brot)
-                    target_rot = tgt_rot[ci].reshape(3, 3)
-                    pose_err = pose_error_log(
-                        ee_pos, ee_rot, tgt_pos[ci], target_rot)
-                    errs.append(pos_w * pose_err[:3])
-                    errs.append(rot_w * pose_err[3:])
+                    if chain_track_rot[ci]:
+                        target_rot = tgt_rot[ci].reshape(3, 3)
+                        pose_err = pose_error_log(
+                            ee_pos, ee_rot, tgt_pos[ci], target_rot)
+                        errs.append(pos_w_chain[ci] * pose_err[:3])
+                        errs.append(rot_w_chain[ci] * pose_err[3:])
+                    else:
+                        # World-frame position error only — avoids the
+                        # SE(3) log's J^{-1}(ω) coupling that distorts
+                        # gradients when rot_w == 0.
+                        errs.append(
+                            pos_w_chain[ci] * (ee_pos - tgt_pos[ci]))
                 return jnp.concatenate(errs).flatten()
 
             cost_node = cost_pose(
@@ -1434,7 +1497,7 @@ class JaxlsSolver(BaseSolver):
                 for ci in range(n_chains):
                     ee_pos, _ = get_ee_pose_per_chain[ci](
                         apc[ci], bpos, brot)
-                    errs.append(pos_w * (ee_pos - tgt_pos[ci]))
+                    errs.append(pos_w_chain[ci] * (ee_pos - tgt_pos[ci]))
                 return jnp.concatenate(errs).flatten()
 
             cost_node = cost_pos_only(
@@ -1451,6 +1514,149 @@ class JaxlsSolver(BaseSolver):
             'target_pos': jnp.asarray(T_pos, dtype=jnp.float64),
             'target_rot': (jnp.asarray(T_rot, dtype=jnp.float64)
                             if T_rot is not None else None),
+            # Metadata so problem.update_multi_ee_targets can swap
+            # the per-frame targets without rebuilding / recompiling.
+            'n_chains': n_chains,
+            'n_waypoints': T,
         })
 
+        return cost_node
+
+    def _make_base_pose_cost(self, problem, TrajectoryVar, spec):
+        """Per-waypoint base-pose tracking cost.
+
+        Drives the floating-base 6 DoF (or 3 DoF for planar) so the
+        base world pose at every waypoint follows the target trajectory.
+        Uses simple (Euclidean translation, axis-angle rotation) errors
+        — no SE(3) coupling — because both targets and the base
+        parameterisation live in the world frame.
+        """
+        import jax.numpy as jnp
+        import jaxls
+
+        T = problem.n_waypoints
+        n_joints_total = problem.n_joints
+        n_base_dof = getattr(problem, 'n_base_dof', 0)
+        if n_base_dof == 0:
+            return None
+
+        target_pos = np.asarray(
+            spec.params['target_positions'], dtype=np.float64)
+        target_rot = spec.params['target_rotations']
+        if target_rot is not None:
+            target_rot = np.asarray(target_rot, dtype=np.float64)
+        pos_w = jnp.sqrt(jnp.asarray(
+            spec.params['position_weight'], dtype=jnp.float64))
+        rot_w = jnp.sqrt(jnp.asarray(
+            spec.params['rotation_weight'], dtype=jnp.float64))
+
+        root_pos_np, root_rot_np = _root_link_world_pose(problem)
+        base_pos_default = jnp.asarray(root_pos_np)
+        base_rot_default = jnp.asarray(root_rot_np)
+
+        def _euler_xyz_to_matrix(rx, ry, rz):
+            cx, sx = jnp.cos(rx), jnp.sin(rx)
+            cy, sy = jnp.cos(ry), jnp.sin(ry)
+            cz, sz = jnp.cos(rz), jnp.sin(rz)
+            Rx = jnp.array([[1, 0, 0], [0, cx, -sx], [0, sx, cx]])
+            Ry = jnp.array([[cy, 0, sy], [0, 1, 0], [-sy, 0, cy]])
+            Rz = jnp.array([[cz, -sz, 0], [sz, cz, 0], [0, 0, 1]])
+            return Rx @ Ry @ Rz
+
+        def _split_aug(angles_aug):
+            base_section = angles_aug[n_joints_total:]
+            if n_base_dof == 6:
+                base_pos = base_pos_default + base_section[:3]
+                base_rot = base_rot_default @ _euler_xyz_to_matrix(
+                    base_section[3], base_section[4], base_section[5])
+            else:
+                base_pos = base_pos_default + jnp.array(
+                    [base_section[0], base_section[1], 0.0])
+                base_rot = base_rot_default @ _euler_xyz_to_matrix(
+                    0.0, 0.0, base_section[2])
+            return base_pos, base_rot
+
+        def _so3_log(R):
+            # Robust axis-angle log: clamp trace to [-1, 3] for safety.
+            tr = jnp.trace(R)
+            cos_theta = jnp.clip(0.5 * (tr - 1.0), -1.0, 1.0)
+            theta = jnp.arccos(cos_theta)
+            # Avoid 0/0 with small_angle and singular sin.
+            sin_theta = jnp.sin(theta)
+            safe = jnp.where(sin_theta < 1e-6, 1.0, sin_theta)
+            scale = theta / (2.0 * safe)
+            v = jnp.array([
+                R[2, 1] - R[1, 2],
+                R[0, 2] - R[2, 0],
+                R[1, 0] - R[0, 1],
+            ])
+            return scale * v
+
+        T_pos_jax = jnp.asarray(target_pos, dtype=jnp.float64)
+        if target_rot is not None:
+            T_rot_jax = jnp.asarray(target_rot.reshape(T, 9),
+                                    dtype=jnp.float64)
+        else:
+            T_rot_jax = None
+
+        default_pos3 = jnp.zeros(3)
+        default_rot9 = jnp.zeros(9)
+
+        class BaseTgtPosVar(
+            jaxls.Var[jnp.ndarray],
+            default_factory=lambda: default_pos3,
+            retract_fn=lambda x, delta: x,
+            tangent_dim=0,
+        ):
+            pass
+
+        if T_rot_jax is not None:
+            class BaseTgtRotVar(
+                jaxls.Var[jnp.ndarray],
+                default_factory=lambda: default_rot9,
+                retract_fn=lambda x, delta: x,
+                tangent_dim=0,
+            ):
+                pass
+        else:
+            BaseTgtRotVar = None
+
+        if T_rot_jax is not None:
+            @jaxls.Cost.factory(name='base_pose')
+            def cost_base(vals, var, pos_param, rot_param):
+                aug = vals[var]
+                bpos, brot = _split_aug(aug)
+                tgt_pos = vals[pos_param]
+                tgt_rot = vals[rot_param].reshape(3, 3)
+                pos_err = pos_w * (bpos - tgt_pos)
+                rot_err = rot_w * _so3_log(brot.T @ tgt_rot)
+                return jnp.concatenate([pos_err, rot_err]).flatten()
+
+            cost_node = cost_base(
+                TrajectoryVar(jnp.arange(T)),
+                BaseTgtPosVar(jnp.arange(T)),
+                BaseTgtRotVar(jnp.arange(T)),
+            )
+        else:
+            @jaxls.Cost.factory(name='base_pose')
+            def cost_base_pos(vals, var, pos_param):
+                aug = vals[var]
+                bpos, _ = _split_aug(aug)
+                tgt_pos = vals[pos_param]
+                return (pos_w * (bpos - tgt_pos)).flatten()
+
+            cost_node = cost_base_pos(
+                TrajectoryVar(jnp.arange(T)),
+                BaseTgtPosVar(jnp.arange(T)),
+            )
+
+        if not hasattr(problem, '_base_pose_param_vars'):
+            problem._base_pose_param_vars = []
+        problem._base_pose_param_vars.append({
+            'pos_var_class': BaseTgtPosVar,
+            'rot_var_class': BaseTgtRotVar,
+            'target_pos': T_pos_jax,
+            'target_rot': T_rot_jax,
+            'n_waypoints': T,
+        })
         return cost_node

--- a/tests/skrobot_tests/planner_tests/test_trajectory_optimization.py
+++ b/tests/skrobot_tests/planner_tests/test_trajectory_optimization.py
@@ -987,6 +987,133 @@ class TestFloatingBaseAndMultiChain(unittest.TestCase):
         self.assertLess(rarm_err, 0.02)
         self.assertLess(larm_err, 0.02)
 
+    def test_add_base_pose_cost_registers(self):
+        """``add_base_pose_cost`` adds a base_pose residual and solves."""
+        from skrobot.planner.trajectory_optimization.solvers.jaxls_solver import JaxlsSolver
+
+        robot, link_list, n_joints = _make_kuka()
+        n_waypoints = 3
+        n_base = 6
+        problem = TrajectoryProblem(
+            robot, link_list, n_waypoints=n_waypoints, n_base_dof=n_base)
+        problem.set_fixed_endpoints(start=False, end=False)
+        problem.add_smoothness_cost(weight=0.01)
+
+        target_pos = np.tile(np.array([0.2, -0.1, 0.05]), (n_waypoints, 1))
+        target_rot = np.tile(np.eye(3), (n_waypoints, 1, 1))
+        problem.add_base_pose_cost(
+            target_positions=target_pos,
+            target_rotations=target_rot,
+            position_weight=300.0,
+            rotation_weight=300.0,
+        )
+
+        residual_names = [r.name for r in problem.residuals]
+        self.assertIn('base_pose', residual_names)
+
+        initial_traj = np.zeros((n_waypoints, n_joints + n_base))
+        solver = JaxlsSolver(max_iterations=40)
+        result = solver.solve(problem, initial_traj)
+        self.assertTrue(result.success)
+        self.assertTrue(np.all(np.isfinite(result.trajectory)))
+
+    def test_update_base_pose_targets_reuses_graph(self):
+        """``update_base_pose_targets`` swaps targets without recompiling."""
+        from skrobot.planner.trajectory_optimization.solvers.jaxls_solver import JaxlsSolver
+
+        robot, link_list, n_joints = _make_kuka()
+        n_waypoints = 3
+        n_base = 6
+        problem = TrajectoryProblem(
+            robot, link_list, n_waypoints=n_waypoints, n_base_dof=n_base)
+        problem.set_fixed_endpoints(start=False, end=False)
+        problem.add_smoothness_cost(weight=0.01)
+
+        problem.add_base_pose_cost(
+            target_positions=np.zeros((n_waypoints, 3)),
+            target_rotations=np.tile(np.eye(3), (n_waypoints, 1, 1)),
+            position_weight=200.0,
+            rotation_weight=200.0,
+        )
+
+        # First solve traces the cost graph and populates the cached
+        # param vars.
+        initial_traj = np.zeros((n_waypoints, n_joints + n_base))
+        solver = JaxlsSolver(max_iterations=20)
+        result = solver.solve(problem, initial_traj)
+        self.assertTrue(result.success)
+
+        # Swap targets — should not raise and the next solve still runs.
+        problem.update_base_pose_targets(
+            target_positions=np.tile([0.1, 0.0, 0.0], (n_waypoints, 1)),
+            target_rotations=np.tile(np.eye(3), (n_waypoints, 1, 1)),
+        )
+        result2 = solver.solve(problem, initial_traj)
+        self.assertTrue(result2.success)
+        self.assertTrue(np.all(np.isfinite(result2.trajectory)))
+
+    def test_multi_ee_per_chain_weights_zero_disables(self):
+        """``rotation_weights_per_chain`` = 0 disables rotation tracking
+        for that chain (position still tracked)."""
+        from skrobot.planner.trajectory_optimization.solvers.jaxls_solver import JaxlsSolver
+
+        robot = skrobot.models.PR2()
+        robot.reset_manip_pose()
+        rarm_links = list(robot.rarm.link_list)
+        larm_links = list(robot.larm.link_list)
+        n_waypoints = 3
+
+        nominal = np.concatenate([
+            np.array([link.joint.joint_angle() for link in rarm_links]),
+            np.array([link.joint.joint_angle() for link in larm_links]),
+        ])
+
+        rarm_initial = robot.rarm_end_coords.copy_worldcoords()
+        larm_initial = robot.larm_end_coords.copy_worldcoords()
+        # Position-only target for rarm; full pose for larm.
+        rarm_target_pos = rarm_initial.worldpos() + np.array(
+            [0.02, 0.0, 0.0])
+        larm_target_pos = larm_initial.worldpos() + np.array(
+            [0.02, 0.0, 0.02])
+
+        problem = TrajectoryProblem(
+            robot,
+            link_list=[rarm_links, larm_links],
+            n_waypoints=n_waypoints,
+            move_target=[robot.rarm_end_coords, robot.larm_end_coords],
+        )
+        problem.set_fixed_endpoints(start=False, end=False)
+        problem.add_smoothness_cost(weight=0.01)
+        problem.add_multi_ee_waypoint_cost(
+            target_positions_per_chain=[
+                np.tile(rarm_target_pos, (n_waypoints, 1)),
+                np.tile(larm_target_pos, (n_waypoints, 1))],
+            target_rotations_per_chain=[
+                np.tile(rarm_initial.worldrot(), (n_waypoints, 1, 1)),
+                np.tile(larm_initial.worldrot(), (n_waypoints, 1, 1))],
+            position_weight=500.0,
+            rotation_weight=50.0,
+            rotation_weights_per_chain=[0.0, 50.0],
+        )
+
+        initial_traj = np.tile(nominal, (n_waypoints, 1))
+        solver = JaxlsSolver(max_iterations=80)
+        result = solver.solve(problem, initial_traj)
+        self.assertTrue(result.success)
+
+        n_rarm = len(rarm_links)
+        for link, q in zip(rarm_links, result.trajectory[-1, :n_rarm]):
+            link.joint.joint_angle(float(q))
+        for link, q in zip(larm_links, result.trajectory[-1, n_rarm:]):
+            link.joint.joint_angle(float(q))
+
+        rarm_err = np.linalg.norm(
+            robot.rarm_end_coords.worldpos() - rarm_target_pos)
+        larm_err = np.linalg.norm(
+            robot.larm_end_coords.worldpos() - larm_target_pos)
+        self.assertLess(rarm_err, 0.02)
+        self.assertLess(larm_err, 0.02)
+
 
 @requires_jax
 class TestAugmentedLagrangianSolver(unittest.TestCase):


### PR DESCRIPTION
Extend ``TrajectoryProblem`` and the ``jaxls`` solver with two features needed by the upcoming retargeting workflow on top of the existing trajectory-optimisation infrastructure:

1. ``add_base_pose_cost`` / ``update_base_pose_targets`` — drives the floating-base 6 DoF (or 3 DoF planar) at every waypoint toward a target pose trajectory. Without this cost the IK is free to put the base anywhere consistent with the EE constraints, so a humanoid being retargeted to a forward-facing walk can end up facing backward while still hitting the hand / foot targets. The ``update_*`` companion lets the cached LM plan be reused across motion clips, avoiding the 20-30 s JIT recompile per clip.

2. ``add_multi_ee_waypoint_cost`` per-chain weights — ``position_weights_per_chain`` / ``rotation_weights_per_chain`` override the scalar weights for individual chains. Set 0 to bypass: chains with rotation_weight=0 skip the SE(3) log error to avoid the body-frame translation coupling that warps gradients when only position is meaningful (e.g. elbow / knee intermediate-link rotation-only constraints), and the same is done position-side for chains tracked only by orientation. The selection is made at trace time so JAX sees a static graph per chain.

Companion ``update_com_targets`` and ``update_multi_ee_targets`` accessors are added so the caller can swap per-frame targets between solves without rebuilding / recompiling the cost graph.