### PR TITLE
Add viewer.pause() to keep the window interactive during animation pauses

### DIFF
--- a/docs/source/reference/viewers.rst
+++ b/docs/source/reference/viewers.rst
@@ -263,14 +263,16 @@ The following video demonstrates the interactive IK feature, where dragging the 
     robot = Panda()
     viewer.add(robot)
 
+    # Position the camera. ViserViewer implements the same set_camera API as
+    # the trimesh / pyrender viewers, so the call is identical across backends.
+    import numpy as np
+    viewer.set_camera([0, 0, np.pi / 2.0])
+
     # Open browser to view
     viewer.show()
 
-    # Keep the viewer running
-    import time
-    while viewer.is_active:
-        viewer.redraw()
-        time.sleep(0.1)
+    # Block until the browser tab / window is closed
+    viewer.wait_until_close()
 
 **Command Line Usage:**
 
@@ -291,6 +293,61 @@ The following video demonstrates the interactive IK feature, where dragging the 
     viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480), update_interval=1.0/30)   # 30 Hz (default)
     viewer = skrobot.viewers.PyrenderViewer(resolution=(640, 480), update_interval=1.0)           # 1 Hz, lower idle CPU
 
+
+Selecting a viewer
+==================
+
+Use :func:`skrobot.viewers.create_viewer` to pick a backend by name instead of
+importing a specific class. This is convenient for example scripts and
+applications that expose a ``--viewer`` option:
+
+.. code-block:: python
+
+    import skrobot
+
+    # name is one of 'trimesh', 'pyrender', 'viser' or 'notebook'
+    viewer = skrobot.viewers.create_viewer('pyrender', resolution=(640, 480))
+    viewer.add(skrobot.models.PR2())
+    viewer.show()
+
+Keyword arguments are forwarded to the selected viewer's constructor. Options a
+backend does not accept are ignored, so the same call works across backends
+(for example ``resolution`` applies to the trimesh / pyrender viewers but is
+dropped for ``viser``, which serves over a browser, while ``enable_ik`` applies
+only to ``viser``). An unknown name raises ``ValueError``.
+
+Interactive helpers
+===================
+
+Every interactive viewer (``TrimeshSceneViewer``, ``PyrenderViewer`` and
+``ViserViewer``) shares two convenience methods.
+
+**wait_until_close()**
+  Block until the viewer window is closed, pumping :func:`redraw` while
+  waiting. It replaces the boilerplate
+  ``while viewer.is_active: time.sleep(...); viewer.redraw()`` loop:
+
+  .. code-block:: python
+
+      viewer.show()
+      viewer.wait_until_close()   # returns once the window / tab is closed
+
+**pause(duration, fps=30.0)**
+  Pause for ``duration`` seconds **while keeping the window interactive**. Use
+  it in place of ``time.sleep(duration)`` inside animation loops. On macOS the
+  trimesh and pyrender viewers run their GL event loop on the main thread, so a
+  bare ``time.sleep`` freezes the window (the camera cannot be dragged) for the
+  whole pause because no events are dispatched. ``pause`` instead pumps
+  :func:`redraw` at ``fps`` (default 30 Hz) for the entire duration, so the view
+  stays responsive. On backends that already render in a separate thread
+  (trimesh / pyrender on Linux) or process (viser) the extra redraws are
+  harmless.
+
+  .. code-block:: python
+
+      for av in trajectory:
+          robot.angle_vector(av)
+          viewer.pause(1.0)   # show this pose for 1 s; camera stays draggable
 
 Color Management
 ----------------

--- a/docs/source/tutorials/visualization.rst
+++ b/docs/source/tutorials/visualization.rst
@@ -26,6 +26,40 @@ Basic usage:
    viewer.add(robot)
    viewer.show()
 
+Selecting a backend by name
+---------------------------
+
+Instead of importing a specific class, you can pick a backend by name with
+:func:`skrobot.viewers.create_viewer` -- handy for scripts that expose a
+``--viewer`` flag. Constructor options the chosen backend does not accept are
+ignored, so the same call works for every backend:
+
+.. code-block:: python
+
+   import skrobot
+
+   viewer = skrobot.viewers.create_viewer('pyrender')  # 'trimesh' | 'pyrender' | 'viser'
+   viewer.add(robot)
+   viewer.show()
+
+Keeping the viewer responsive
+-----------------------------
+
+Every interactive viewer provides two helpers:
+
+- ``viewer.wait_until_close()`` blocks until the window is closed, replacing the
+  manual ``while viewer.is_active: ...`` loop.
+- ``viewer.pause(seconds)`` waits like ``time.sleep`` but keeps the window
+  interactive -- use it in animation loops so the camera stays draggable during
+  the pause. This matters on macOS, where the trimesh / pyrender GL loop runs on
+  the main thread and a bare ``time.sleep`` would freeze the window.
+
+.. code-block:: python
+
+   for av in trajectory:
+       robot.angle_vector(av)
+       viewer.pause(0.5)   # redraws and holds for 0.5 s; camera stays draggable
+
 ViserViewer
 -----------
 
@@ -42,11 +76,8 @@ It automatically generates GUI sliders for each joint, allowing real-time manipu
    viewer.add(robot)
    viewer.show()  # Opens browser automatically
 
-   # Keep the server running
-   import time
-   while viewer.is_active:
-       viewer.redraw()
-       time.sleep(0.1)
+   # Keep the server running until the browser tab is closed
+   viewer.wait_until_close()
 
 .. image:: ../../image/viser-viewer.jpg
    :width: 600px

--- a/examples/batch_ik_demo.py
+++ b/examples/batch_ik_demo.py
@@ -383,8 +383,7 @@ def main():
                                 solution_idx = (solution_idx + 1) % len(successful_solutions)
                                 last_change_time = current_time
 
-                        viewer.redraw()
-                        time.sleep(0.05)
+                        viewer.pause(0.05)
 
                     print("\nVisualization completed")
 

--- a/examples/batch_ik_demo.py
+++ b/examples/batch_ik_demo.py
@@ -56,8 +56,8 @@ def main():
     parser.add_argument('--no-interactive', action='store_true',
                         help='Disable interactive visualization')
     parser.add_argument('--viewer', type=str,
-                        choices=['pyrender', 'trimesh'], default='trimesh',
-                        help='Choose the viewer type: trimesh or pyrender. Default: trimesh')
+                        choices=['pyrender', 'trimesh', 'viser'], default='pyrender',
+                        help='Choose the viewer type: trimesh, pyrender or viser. Default: pyrender')
     parser.add_argument('--with-torso', action='store_true',
                         help='Include torso in IK (PR2 and Fetch only)')
 
@@ -292,12 +292,8 @@ def main():
 
         if not args.no_interactive:
             try:
-                if args.viewer == 'pyrender':
-                    from skrobot.viewers import PyrenderViewer
-                    viewer = PyrenderViewer(update_interval=1 / 30.0)
-                else:  # trimesh
-                    from skrobot.viewers import TrimeshSceneViewer
-                    viewer = TrimeshSceneViewer(update_interval=1 / 30.0)
+                from skrobot.viewers import create_viewer
+                viewer = create_viewer(args.viewer)
 
                 print(f"Adding {len(target_poses)} target poses as coordinate frames...")
                 axis_objects = []

--- a/examples/collision_free_trajectory.py
+++ b/examples/collision_free_trajectory.py
@@ -30,8 +30,8 @@ parser.add_argument(
 )
 parser.add_argument(
     '--viewer', type=str,
-    choices=['trimesh', 'pyrender'], default='trimesh',
-    help='Choose the viewer type: trimesh or pyrender')
+    choices=['trimesh', 'pyrender', 'viser'], default='pyrender',
+    help='Choose the viewer type: trimesh, pyrender or viser')
 parser.add_argument(
     '--no-interactive',
     action='store_true',
@@ -133,10 +133,7 @@ robot_coll_checker.add_world_obstacle(box)
 
 # visualization
 print("show trajectory")
-if args.viewer == 'trimesh':
-    viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
-elif args.viewer == 'pyrender':
-    viewer = skrobot.viewers.PyrenderViewer(resolution=(640, 480))
+viewer = skrobot.viewers.create_viewer(args.viewer, resolution=(640, 480))
 
 viewer.add(robot_model)
 viewer.add(box)
@@ -345,9 +342,7 @@ for av in av_seq:
     time.sleep(1.0)
 
 if not args.no_interactive:
-    print('==> Press [q] to close window')
-    while viewer.is_active:
-        time.sleep(0.1)
-        viewer.redraw()
-viewer.close()
+    viewer.wait_until_close()
+else:
+    viewer.close()
 time.sleep(1.0)

--- a/examples/collision_free_trajectory.py
+++ b/examples/collision_free_trajectory.py
@@ -338,8 +338,9 @@ for av in av_seq:
         robot_coll_checker.update_color()
     else:
         sscc.update_color()
-    viewer.redraw()
-    time.sleep(1.0)
+    # viewer.pause keeps the camera draggable during the pause; a bare
+    # time.sleep would freeze the window on macOS (main-thread GL loop).
+    viewer.pause(1.0)
 
 if not args.no_interactive:
     viewer.wait_until_close()

--- a/examples/grasp_and_pull_box.py
+++ b/examples/grasp_and_pull_box.py
@@ -94,8 +94,8 @@ parser.add_argument(
 )
 parser.add_argument(
     '--viewer', type=str,
-    choices=['trimesh', 'pyrender'], default='trimesh',
-    help='Choose the viewer type: trimesh or pyrender')
+    choices=['trimesh', 'pyrender', 'viser'], default='pyrender',
+    help='Choose the viewer type: trimesh, pyrender or viser')
 args = parser.parse_args()
 
 
@@ -115,12 +115,7 @@ right_arm_end_coords = skrobot.coordinates.CascadedCoords(
 move_target = right_arm_end_coords
 
 # Create viewer
-if args.viewer == 'trimesh':
-    viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480),
-                                                update_interval=0.1)
-elif args.viewer == 'pyrender':
-    viewer = skrobot.viewers.PyrenderViewer(resolution=(640, 480),
-                                            update_interval=0.1)
+viewer = skrobot.viewers.create_viewer(args.viewer, resolution=(640, 480))
 viewer.add(robot_model)
 viewer.show()
 viewer.set_camera([np.deg2rad(45), -np.deg2rad(0),
@@ -135,9 +130,7 @@ grasp_box(box)
 pull_box(box)
 
 if not args.no_interactive:
-    print('==> Press [q] to close window')
-    while viewer.is_active:
-        time.sleep(0.1)
-        viewer.redraw()
-viewer.close()
+    viewer.wait_until_close()
+else:
+    viewer.close()
 time.sleep(1.0)

--- a/examples/grasp_and_pull_box.py
+++ b/examples/grasp_and_pull_box.py
@@ -61,8 +61,7 @@ def move_to_box(box):
             midcoords(i / 20.0, start_coords, target_coords),
             link_list=link_list,
             move_target=move_target)
-        viewer.redraw()
-        time.sleep(0.1)
+        viewer.pause(0.1)
 
 
 def grasp_box(box):
@@ -81,8 +80,7 @@ def pull_box(box):
             link_list=link_list,
             move_target=move_target)
         robot_model.look_at(box)
-        viewer.redraw()
-        time.sleep(0.1)
+        viewer.pause(0.1)
 
 
 parser = argparse.ArgumentParser(

--- a/examples/griphis_wall_climb.py
+++ b/examples/griphis_wall_climb.py
@@ -252,7 +252,7 @@ def next_wall_target_above(end_swing):
 # ---------------------------------------------------------------------------
 
 def main(num_steps=40, interactive=True, step_pause=0.05,
-         substep_pause=0.0):
+         substep_pause=0.0, viewer_name='pyrender'):
     robot = Griphis()
     end1 = robot.gripper_1_end_coords
     end2 = robot.gripper_2_end_coords
@@ -275,8 +275,8 @@ def main(num_steps=40, interactive=True, step_pause=0.05,
     axis_swing = None
     if interactive:
         try:
-            from skrobot.viewers import PyrenderViewer
-            viewer = PyrenderViewer()
+            from skrobot.viewers import create_viewer
+            viewer = create_viewer(viewer_name)
             viewer.add(robot)
             # Ground at z = 0, spanning the robot side of the wall so it
             # visually anchors where the climb starts from.
@@ -338,10 +338,7 @@ def main(num_steps=40, interactive=True, step_pause=0.05,
         stance_id, swing_id = swing_id, stance_id
 
     if viewer is not None:
-        print('==> Press [q] to close window')
-        while viewer.is_active:
-            time.sleep(0.1)
-            viewer.redraw()
+        viewer.wait_until_close()
 
 
 if __name__ == '__main__':
@@ -352,16 +349,21 @@ if __name__ == '__main__':
              '3 with --no-interactive)')
     parser.add_argument(
         '--no-interactive', action='store_true',
-        help='skip the PyrenderViewer and exit as soon as the gait finishes; '
+        help='skip the viewer and exit as soon as the gait finishes; '
              'also reduces --steps default to 3 so smoke tests finish fast')
     parser.add_argument('--pause', type=float, default=0.05,
                         help='seconds to pause between steps in viewer')
     parser.add_argument('--substep-pause', type=float, default=0.0,
                         help='seconds to pause between arc waypoints')
+    parser.add_argument(
+        '--viewer', type=str,
+        choices=['trimesh', 'pyrender', 'viser'], default='pyrender',
+        help='Choose the viewer type: trimesh, pyrender or viser')
     args = parser.parse_args()
     steps = args.steps if args.steps is not None else (
         3 if args.no_interactive else 40)
     main(num_steps=steps,
          interactive=not args.no_interactive,
          step_pause=args.pause,
-         substep_pause=args.substep_pause)
+         substep_pause=args.substep_pause,
+         viewer_name=args.viewer)

--- a/examples/griphis_wall_climb.py
+++ b/examples/griphis_wall_climb.py
@@ -332,8 +332,7 @@ def main(num_steps=40, interactive=True, step_pause=0.05,
               f'end{swing_id} @ {end_swing.worldpos().round(4)}')
 
         if viewer is not None:
-            viewer.redraw()
-            time.sleep(step_pause)
+            viewer.pause(step_pause)
 
         stance_id, swing_id = swing_id, stance_id
 

--- a/examples/pr2_inverse_kinematics.py
+++ b/examples/pr2_inverse_kinematics.py
@@ -255,8 +255,8 @@ def main():
     )
     parser.add_argument(
         '--viewer', type=str,
-        choices=['trimesh', 'pyrender'], default='trimesh',
-        help='Choose the viewer type: trimesh or pyrender')
+        choices=['trimesh', 'pyrender', 'viser'], default='pyrender',
+        help='Choose the viewer type: trimesh, pyrender or viser')
     parser.add_argument(
         '--no-ik-visualization',
         action='store_true',
@@ -308,10 +308,8 @@ def main():
     ]
 
     # Create viewer
-    if args.viewer == 'trimesh':
-        viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
-    elif args.viewer == 'pyrender':
-        viewer = skrobot.viewers.PyrenderViewer(resolution=(640, 480))
+    viewer = skrobot.viewers.create_viewer(
+        args.viewer, resolution=(640, 480))
 
     viewer.add(robot_model)
     viewer.show()
@@ -379,11 +377,9 @@ def main():
                                 args.no_ik_visualization)
 
     if not args.no_interactive:
-        print('==> Press [q] to close window')
-        while viewer.is_active:
-            time.sleep(0.1)
-            viewer.redraw()
-    viewer.close()
+        viewer.wait_until_close()
+    else:
+        viewer.close()
     time.sleep(1.0)
 
 

--- a/examples/robot_collision_checker_demo.py
+++ b/examples/robot_collision_checker_demo.py
@@ -194,8 +194,7 @@ def main():
                 status = "COLLISION" if min_dist < 0 else "Safe"
                 print(f"\rmin_dist = {min_dist:+.4f} ({status})    ", end="", flush=True)
 
-            viewer.redraw()
-            time.sleep(0.05)
+            viewer.pause(0.05)
             t += 0.05
 
         print()

--- a/examples/robot_collision_checker_demo.py
+++ b/examples/robot_collision_checker_demo.py
@@ -32,6 +32,11 @@ def main():
         '--no-interactive', action='store_true',
         help='Run without waiting for user input'
     )
+    parser.add_argument(
+        '--viewer', type=str,
+        choices=['trimesh', 'pyrender', 'viser'], default='pyrender',
+        help='Choose the viewer type: trimesh, pyrender or viser'
+    )
     args = parser.parse_args()
 
     # Create robot
@@ -86,7 +91,8 @@ def main():
 
     # Setup viewer
     print("\nStarting viewer...")
-    viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(800, 600))
+    viewer = skrobot.viewers.create_viewer(
+        args.viewer, resolution=(800, 600))
     viewer.add(robot)
     viewer.add(sphere_obs)
     viewer.add(box_obs)

--- a/examples/robot_models.py
+++ b/examples/robot_models.py
@@ -23,8 +23,8 @@ def main():
         description='Set viewer for skrobot.')
     parser.add_argument(
         '--viewer', type=str,
-        choices=['trimesh', 'pyrender'], default='pyrender',
-        help='Choose the viewer type: trimesh or pyrender')
+        choices=['trimesh', 'pyrender', 'viser'], default='pyrender',
+        help='Choose the viewer type: trimesh, pyrender or viser')
     parser.add_argument(
         '--no-interactive',
         action='store_true',
@@ -32,10 +32,8 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.viewer == 'trimesh':
-        viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
-    elif args.viewer == 'pyrender':
-        viewer = skrobot.viewers.PyrenderViewer(resolution=(640, 480))
+    viewer = skrobot.viewers.create_viewer(
+        args.viewer, resolution=(640, 480))
 
     robots = [
         skrobot.models.Kuka(),
@@ -63,11 +61,9 @@ def main():
     viewer.show()
 
     if not args.no_interactive:
-        print('==> Press [q] to close window')
-        while viewer.is_active:
-            time.sleep(0.1)
-            viewer.redraw()
-    viewer.close()
+        viewer.wait_until_close()
+    else:
+        viewer.close()
     time.sleep(1.0)
 
 

--- a/examples/signed_distance_functions.py
+++ b/examples/signed_distance_functions.py
@@ -22,8 +22,8 @@ parser = argparse.ArgumentParser(
     description='Visualization signed distance function.')
 parser.add_argument(
     '--viewer', type=str,
-    choices=['trimesh', 'pyrender'], default='trimesh',
-    help='Choose the viewer type: trimesh or pyrender')
+    choices=['trimesh', 'pyrender', 'viser'], default='pyrender',
+    help='Choose the viewer type: trimesh, pyrender or viser')
 parser.add_argument(
     '--no-interactive',
     action='store_true',
@@ -31,10 +31,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-if args.viewer == 'trimesh':
-    viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
-elif args.viewer == 'pyrender':
-    viewer = skrobot.viewers.PyrenderViewer(resolution=(640, 480))
+viewer = skrobot.viewers.create_viewer(args.viewer, resolution=(640, 480))
 
 viewer.add(b)
 viewer.add(m)
@@ -46,15 +43,11 @@ for _ in range(100):
     ax = Axis(axis_radius=0.001, axis_length=0.01, pos=pts[idx], rot=rot)
     viewer.add(ax)
 
-# Starting the viewer spins up an OpenGL render thread. Under the headless
-# software GL stack used in CI (xvfb + Mesa) this occasionally triggers a
-# native heap corruption (SIGABRT), so skip it in non-interactive runs as the
-# other examples do.
 if not args.no_interactive:
+    # Only start the GL renderer for interactive use. Showing the viewer
+    # during tests (--no-interactive) launches an OpenGL draw thread that
+    # has been an occasional source of native heap corruption under the
+    # CI's software GL, so keep it out of the test path.
     viewer.show()
-    print('==> Press [q] to close window')
-    while viewer.is_active:
-        time.sleep(0.1)
-        viewer.redraw()
-    viewer.close()
+    viewer.wait_until_close()
     time.sleep(1.0)

--- a/examples/skeleton_visualization.py
+++ b/examples/skeleton_visualization.py
@@ -152,6 +152,12 @@ def main():
                         help='Show only skeleton without robot mesh')
     parser.add_argument('--no-interactive', action='store_true',
                         help='Run in non-interactive mode (exit immediately)')
+    parser.add_argument('--viewer', type=str,
+                        choices=['trimesh', 'pyrender', 'viser'],
+                        default='pyrender',
+                        help='Choose the viewer type: trimesh, pyrender or '
+                             'viser (always_on_top is honored by pyrender '
+                             'only)')
     args = parser.parse_args()
 
     # Load robot
@@ -189,21 +195,15 @@ def main():
                 print(f"Saved to {f.name}")
     else:
         # Show in viewer
-        import time
+        from skrobot.viewers import create_viewer
 
-        from skrobot.viewers import PyrenderViewer
-
-        viewer = PyrenderViewer()
+        viewer = create_viewer(args.viewer)
         if not args.no_skeleton:
             viewer.add(robot)
         viewer.add(skeleton, always_on_top=True)
         viewer.show()
 
-        print("Press 'q' to quit")
-        while viewer.is_active:
-            time.sleep(0.1)
-            viewer.redraw()
-        viewer.close()
+        viewer.wait_until_close(message="Press 'q' to quit")
 
 
 if __name__ == "__main__":

--- a/examples/swept_sphere.py
+++ b/examples/swept_sphere.py
@@ -19,8 +19,8 @@ except:  # noqa
         description='Swept spheres visualization.')
     parser.add_argument(
         '--viewer', type=str,
-        choices=['trimesh', 'pyrender'], default='trimesh',
-        help='Choose the viewer type: trimesh or pyrender')
+        choices=['trimesh', 'pyrender', 'viser'], default='pyrender',
+        help='Choose the viewer type: trimesh, pyrender or viser')
     parser.add_argument(
         '--no-interactive',
         action='store_true',
@@ -28,10 +28,8 @@ except:  # noqa
     )
     args = parser.parse_args()
 
-    if args.viewer == 'trimesh':
-        viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
-    elif args.viewer == 'pyrender':
-        viewer = skrobot.viewers.PyrenderViewer(resolution=(640, 480))
+    viewer = skrobot.viewers.create_viewer(
+        args.viewer, resolution=(640, 480))
 
     link_idx_table = {}
     for link_idx in range(len(robot_model.link_list)):
@@ -74,10 +72,8 @@ viewer.add(robot_model)
 viewer.add(table)
 viewer.show()
 
-print('==> Press [q] to close window')
 if not args.no_interactive:
-    while viewer.is_active:
-        time.sleep(0.1)
-        viewer.redraw()
-viewer.close()
+    viewer.wait_until_close()
+else:
+    viewer.close()
 time.sleep(1.0)

--- a/examples/trajectory_interpolation_demo.py
+++ b/examples/trajectory_interpolation_demo.py
@@ -42,9 +42,15 @@ def main():
         action='store_true',
         help='Use simple rotation for comparison (less difference)'
     )
+    parser.add_argument(
+        '--viewer', type=str,
+        choices=['trimesh', 'pyrender', 'viser'], default='pyrender',
+        help='Choose the viewer type: trimesh, pyrender or viser'
+    )
     args = parser.parse_args()
 
-    viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(800, 600))
+    viewer = skrobot.viewers.create_viewer(
+        args.viewer, resolution=(800, 600))
     plane = skrobot.model.Box(
         extents=(2, 2, 0.01), face_colors=(0.75, 0.75, 0.75)
     )

--- a/examples/trimesh_scene_viewer.py
+++ b/examples/trimesh_scene_viewer.py
@@ -22,11 +22,16 @@ def main():
         action='store_true',
         help="Run in non-interactive mode (do not wait for user input)"
     )
+    parser.add_argument(
+        '--viewer', type=str,
+        choices=['trimesh', 'pyrender', 'viser'], default='pyrender',
+        help='Choose the viewer type: trimesh, pyrender or viser'
+    )
     args = parser.parse_args()
 
     robot = skrobot.models.Kuka()
 
-    viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
+    viewer = skrobot.viewers.create_viewer(args.viewer, resolution=(640, 480))
 
     # base plane
     plane = skrobot.model.Box(
@@ -89,11 +94,9 @@ def main():
         viewer.redraw()
 
         if not args.no_interactive:
-            print('==> Press [q] to close window')
-            while viewer.is_active:
-                time.sleep(0.1)
-                viewer.redraw()
-        viewer.close()
+            viewer.wait_until_close()
+        else:
+            viewer.close()
         time.sleep(1.0)
 
 

--- a/examples/walk_with_trajectory_optimization.py
+++ b/examples/walk_with_trajectory_optimization.py
@@ -352,8 +352,7 @@ def animate_segments(viewer, robot, segments_data, viewer_name,
                 base_world = seg['base_world_initial']
                 for idx in range(traj.shape[0]):
                     apply_aug_to_robot(robot, problem, traj[idx], base_world)
-                    viewer.redraw()
-                    time.sleep(dt)
+                    viewer.pause(dt)
                     if viewer_name != 'viser' and not viewer.is_active:
                         return
             if not loop:

--- a/examples/walk_with_trajectory_optimization.py
+++ b/examples/walk_with_trajectory_optimization.py
@@ -282,16 +282,6 @@ def apply_aug_to_robot(robot, problem, aug, base_world_initial):
     robot.root_link.newcoords(pose, relative_coords='world')
 
 
-def build_viewer(viewer_name):
-    if viewer_name == 'pyrender':
-        return skrobot.viewers.PyrenderViewer(resolution=(960, 720))
-    if viewer_name == 'trimesh':
-        return skrobot.viewers.TrimeshSceneViewer(resolution=(960, 720))
-    if viewer_name == 'viser':
-        return skrobot.viewers.ViserViewer()
-    raise ValueError('unknown viewer: {}'.format(viewer_name))
-
-
 def add_ground_with_stripes(viewer, segments_data, viewer_name,
                             stripe_spacing=0.25, margin=1.0):
     """Add a ground plane plus stripes for progress cue, and the planned
@@ -641,7 +631,7 @@ def main():
     apply_aug_to_robot(
         robot, segments_data[0]['problem'], segments_data[0]['traj'][0],
         segments_data[0]['base_world_initial'])
-    viewer = build_viewer(args.viewer)
+    viewer = skrobot.viewers.create_viewer(args.viewer, resolution=(960, 720))
     viewer.add(robot)
     add_ground_with_stripes(viewer, segments_data, args.viewer)
     viewer.show()

--- a/skrobot/viewers/__init__.py
+++ b/skrobot/viewers/__init__.py
@@ -36,6 +36,8 @@ class DummyViewer(object):
         self._is_active = False
     def wait_until_close(self, *args, **kwargs):
         pass
+    def pause(self, *args, **kwargs):
+        pass
 
 try:
     from ._trimesh import TrimeshSceneViewer

--- a/skrobot/viewers/__init__.py
+++ b/skrobot/viewers/__init__.py
@@ -16,6 +16,10 @@ def warn_gl(error_log):
 class DummyViewer(object):
     def __init__(self, *args, **kwargs):
         self.has_exit = True
+        self._is_active = False
+    @property
+    def is_active(self):
+        return self._is_active
     def redraw(self):
         pass
     def show(self):
@@ -27,6 +31,10 @@ class DummyViewer(object):
     def set_camera(self, *args, **kwargs):
         pass
     def save_image(self, file_obj):
+        pass
+    def close(self):
+        self._is_active = False
+    def wait_until_close(self, *args, **kwargs):
         pass
 
 try:
@@ -89,3 +97,76 @@ except ImportError as e:
 
 # Backwards compatibility alias
 ViserVisualizer = ViserViewer
+
+
+# Mapping from viewer name to its class. Used by :func:`create_viewer`.
+_VIEWER_CLASSES = {
+    'trimesh': TrimeshSceneViewer,
+    'pyrender': PyrenderViewer,
+    'viser': ViserViewer,
+    'notebook': JupyterNotebookViewer,
+}
+
+
+def _supported_kwargs(cls, kwargs):
+    """Return the subset of ``kwargs`` accepted by ``cls.__init__``.
+
+    Each viewer backend takes a different set of constructor options
+    (e.g. ``resolution`` applies to the trimesh / pyrender viewers but not
+    to the viser viewer, which serves over a browser). When the factory is
+    called with backend-agnostic convenience arguments, options that the
+    selected backend does not understand are dropped here so the same
+    ``create_viewer(name, resolution=...)`` call works for every backend.
+    """
+    try:
+        signature = inspect.signature(cls.__init__)
+    except (TypeError, ValueError):
+        return dict(kwargs)
+    parameters = signature.parameters.values()
+    # If the constructor accepts **kwargs, forward everything as-is.
+    if any(p.kind == p.VAR_KEYWORD for p in parameters):
+        return dict(kwargs)
+    accepted = {p.name for p in parameters if p.name != 'self'}
+    return {k: v for k, v in kwargs.items() if k in accepted}
+
+
+def create_viewer(name='trimesh', **kwargs):
+    """Create a viewer instance by backend name.
+
+    This is the recommended entry point for examples and applications that
+    want to let the user choose a viewer backend at runtime, replacing the
+    ``if name == 'trimesh': ... elif name == 'pyrender': ...`` blocks that
+    were previously duplicated across scripts.
+
+    Parameters
+    ----------
+    name : str, optional
+        Backend to instantiate. One of ``'trimesh'``, ``'pyrender'``,
+        ``'viser'`` or ``'notebook'``. Default is ``'trimesh'``.
+    **kwargs
+        Keyword arguments forwarded to the selected viewer's constructor
+        (e.g. ``resolution``, ``update_interval``, ``title`` for the
+        trimesh / pyrender viewers, or ``enable_ik`` for the viser viewer).
+        Arguments that the selected backend does not accept are ignored so
+        the same call site can target any backend.
+
+    Returns
+    -------
+    viewer : object
+        An instance of the requested viewer class.
+
+    Raises
+    ------
+    ValueError
+        If ``name`` is not a known viewer backend.
+    """
+    if not isinstance(name, str):
+        raise ValueError(
+            "Viewer name must be a string, got {}.".format(type(name).__name__))
+    key = name.lower()
+    if key not in _VIEWER_CLASSES:
+        raise ValueError(
+            "Unknown viewer '{}'. Available viewers: {}.".format(
+                name, ', '.join(sorted(_VIEWER_CLASSES))))
+    cls = _VIEWER_CLASSES[key]
+    return cls(**_supported_kwargs(cls, kwargs))

--- a/skrobot/viewers/_base.py
+++ b/skrobot/viewers/_base.py
@@ -1,3 +1,4 @@
+import math
 import time
 
 
@@ -39,3 +40,41 @@ class _InteractiveViewerMixin(object):
         except KeyboardInterrupt:
             pass
         self.close()
+
+    def pause(self, duration, fps=30.0):
+        """Pause for ``duration`` seconds while keeping the viewer interactive.
+
+        Use this in place of ``time.sleep(duration)`` inside animation
+        loops. On macOS the trimesh and pyrender viewers run their GL event
+        loop on the main thread, so a bare ``time.sleep`` freezes the window
+        (the camera cannot be dragged) for the whole pause because no events
+        are dispatched. This pumps :meth:`redraw` at ``fps`` for the entire
+        duration so the view stays responsive. On backends that already
+        render in a separate thread (trimesh/pyrender on Linux) or process
+        (viser) the extra redraws are harmless.
+
+        Parameters
+        ----------
+        duration : float, optional
+            Seconds to pause. Non-positive (or non-finite) values just
+            trigger a single redraw and return immediately.
+        fps : float, optional
+            Redraw frequency in Hz while pausing. Must be a positive finite
+            number. Default is 30.
+        """
+        if not (math.isfinite(fps) and fps > 0):
+            raise ValueError(
+                'fps must be a positive finite number, got {}.'.format(fps))
+        self.redraw()
+        if not (math.isfinite(duration) and duration > 0):
+            return
+        interval = 1.0 / fps
+        # monotonic() is used so a wall-clock adjustment cannot shorten or
+        # extend the pause.
+        end = time.monotonic() + duration
+        while True:
+            remaining = end - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(interval, remaining))
+            self.redraw()

--- a/skrobot/viewers/_base.py
+++ b/skrobot/viewers/_base.py
@@ -1,0 +1,41 @@
+import time
+
+
+class _InteractiveViewerMixin(object):
+    """Mixin providing helpers shared by interactive viewers.
+
+    The mixin only relies on the ``is_active`` property and the
+    ``redraw`` / ``close`` methods, all of which are implemented by every
+    interactive viewer backend (TrimeshSceneViewer, PyrenderViewer,
+    ViserViewer). It is intentionally placed last in the base class list so
+    that it never shadows the backend's own ``__init__`` / ``__new__``.
+    """
+
+    def wait_until_close(self, redraw=True, interval=0.1,
+                         message='==> Press [q] to close window'):
+        """Block until the viewer window is closed by the user.
+
+        This replaces the ``while viewer.is_active: time.sleep(...);
+        viewer.redraw()`` loop that is duplicated across the examples.
+
+        Parameters
+        ----------
+        redraw : bool, optional
+            If True, call :meth:`redraw` every ``interval`` seconds while
+            waiting. Default is True.
+        interval : float, optional
+            Seconds to sleep between redraws. Default is 0.1.
+        message : str or None, optional
+            Message printed once before waiting starts. Pass None to
+            suppress it. Default is '==> Press [q] to close window'.
+        """
+        if message:
+            print(message)
+        try:
+            while self.is_active:
+                time.sleep(interval)
+                if redraw:
+                    self.redraw()
+        except KeyboardInterrupt:
+            pass
+        self.close()

--- a/skrobot/viewers/_pyrender.py
+++ b/skrobot/viewers/_pyrender.py
@@ -42,6 +42,7 @@ from trimesh.scene import cameras
 from skrobot import model as model_module
 from skrobot.coordinates import Coordinates
 from skrobot.model.skeleton import SkeletonModel
+from skrobot.viewers._base import _InteractiveViewerMixin
 
 
 # Check if pyrender supports always_on_top parameter
@@ -85,7 +86,7 @@ def _redraw_all_windows():
         pass
 
 
-class PyrenderViewer(pyrender.Viewer):
+class PyrenderViewer(pyrender.Viewer, _InteractiveViewerMixin):
 
     """PyrenderViewer class implemented as a Singleton.
 

--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -14,6 +14,7 @@ import trimesh.viewer
 from trimesh.viewer.trackball import Trackball
 
 from skrobot import model as model_module
+from skrobot.viewers._base import _InteractiveViewerMixin
 
 
 logger = logging.getLogger('trimesh')
@@ -42,7 +43,7 @@ def _redraw_all_windows():
         window._legacy_invalid = False
 
 
-class TrimeshSceneViewer(trimesh.viewer.SceneViewer):
+class TrimeshSceneViewer(trimesh.viewer.SceneViewer, _InteractiveViewerMixin):
     """TrimeshSceneViewer class implemented as a Singleton.
 
     This ensures that only one instance of the viewer

--- a/skrobot/viewers/_viser.py
+++ b/skrobot/viewers/_viser.py
@@ -26,10 +26,11 @@ from skrobot.model.primitives import PointCloudLink
 from skrobot.model.primitives import Sphere
 from skrobot.model.robot_model import CascadedLink
 from skrobot.model.robot_model import RobotModel
+from skrobot.viewers._base import _InteractiveViewerMixin
 from skrobot.viewers._manipulability_ellipse import ManipulabilityEllipse
 
 
-class ViserViewer:
+class ViserViewer(_InteractiveViewerMixin):
     """Viser-based 3D viewer for scikit-robot.
 
     Parameters
@@ -79,6 +80,12 @@ class ViserViewer:
         self._joint_sliders = dict()
         self._joint_folders = dict()
         self._original_joint_limits = dict()  # joint_name -> (min, max)
+
+        # Camera state shared across clients. ``_camera_view`` holds the
+        # most recent (position, look_at, up) tuple set via set_camera so
+        # that clients connecting later get the same view.
+        self._camera_view = None
+        self._camera_connect_registered = False
 
         # Motion planning implies IK
         self._enable_motion_planning = enable_motion_planning
@@ -156,6 +163,147 @@ class ViserViewer:
     def close(self):
         self._is_active = False
         self._server.stop()
+
+    def set_camera(self, angles=None, distance=None, center=None,
+                   resolution=None, fov=None, coords_or_transform=None):
+        """Set the camera pose for every connected viser client.
+
+        The signature mirrors
+        :meth:`skrobot.viewers.PyrenderViewer.set_camera` so the same call
+        site works for any viewer backend. The euler-angle convention
+        (``trimesh.transformations.euler_matrix``) matches the trimesh and
+        pyrender viewers. The resolved view is applied to all currently
+        connected clients and stored so that clients which connect later
+        receive the same view.
+
+        Parameters
+        ----------
+        angles : array-like, optional
+            Camera orientation as XYZ euler angles in radians.
+        distance : float, optional
+            Distance from the camera to the look-at center. When omitted it
+            is estimated from the scene's bounding box so the geometry fits
+            in view.
+        center : array-like, optional
+            World point the camera looks at. Defaults to the center of the
+            bounding box of the geometry currently in the scene.
+        resolution : array-like, optional
+            Accepted for signature compatibility with the other viewers;
+            the viser client controls its own framebuffer resolution, so
+            this value is unused.
+        fov : array-like, optional
+            Horizontal/vertical field of view in degrees, used only to
+            estimate ``distance`` when it is not given. Default (60, 45).
+        coords_or_transform : Coordinates or (4, 4) array-like, optional
+            Explicit camera world pose. Overrides ``angles`` / ``distance``
+            / ``center`` when provided.
+        """
+        view = self._resolve_camera_view(
+            angles, distance, center, fov, coords_or_transform)
+        if view is None:
+            return
+        self._camera_view = view
+        for client in self._server.get_clients().values():
+            self._apply_camera_view(client, view)
+        self._register_camera_on_connect()
+
+    def _resolve_camera_view(self, angles, distance, center, fov,
+                             coords_or_transform):
+        """Resolve set_camera arguments to a (position, look_at, up) tuple.
+
+        Returns None when there is not enough information to position the
+        camera (e.g. neither ``angles`` nor ``coords_or_transform`` given).
+        """
+        from trimesh import transformations
+
+        if coords_or_transform is not None:
+            if isinstance(coords_or_transform, Coordinates):
+                transform = coords_or_transform.worldcoords().T()
+            else:
+                transform = np.asarray(coords_or_transform, dtype=np.float64)
+            position = transform[:3, 3]
+            forward = -transform[:3, 2]
+            up = transform[:3, 1]
+            return position, position + forward, up
+
+        if angles is None:
+            return None
+
+        rotation = transformations.euler_matrix(*angles)[:3, :3]
+        points = self._collect_world_points()
+        if center is not None:
+            center_w = np.asarray(center, dtype=np.float64)
+        elif points is not None:
+            center_w = points.min(axis=0) + 0.5 * np.ptp(points, axis=0)
+        else:
+            center_w = np.zeros(3, dtype=np.float64)
+
+        if distance is None:
+            if points is not None and len(points) > 1:
+                radius = 0.5 * float(np.linalg.norm(np.ptp(points, axis=0)))
+                fov_arr = np.array([60.0, 45.0]) if fov is None else \
+                    np.asarray(fov, dtype=np.float64)
+                half_fov = np.radians(float(np.min(fov_arr))) / 2.0
+                distance = max(radius / max(np.tan(half_fov), 1e-6), 1e-3)
+            else:
+                distance = 1.0
+
+        z_axis = rotation[:, 2]
+        position = center_w + distance * z_axis
+        up = rotation[:, 1]
+        return position, center_w, up
+
+    def _collect_world_points(self):
+        """Return world-frame points spanning the scene geometry.
+
+        Used to derive the camera look-at center and a fit distance. Each
+        link contributes the eight corners of its visual mesh's bounding
+        box (transformed to world), or just its origin when no mesh bounds
+        are available. Returns None when the scene is empty.
+        """
+        points = []
+        for link_id, link in self._linkid_to_link.items():
+            try:
+                translation = np.asarray(link.worldpos(), dtype=np.float64)
+                rotation = np.asarray(link.worldrot(), dtype=np.float64)
+            except Exception:
+                continue
+            mesh = None
+            try:
+                mesh = link.concatenated_visual_mesh
+            except Exception:
+                mesh = None
+            bounds = getattr(mesh, 'bounds', None)
+            if bounds is not None:
+                lower, upper = bounds
+                for cx in (lower[0], upper[0]):
+                    for cy in (lower[1], upper[1]):
+                        for cz in (lower[2], upper[2]):
+                            local = np.array([cx, cy, cz], dtype=np.float64)
+                            points.append(rotation.dot(local) + translation)
+            else:
+                points.append(translation)
+        if not points:
+            return None
+        return np.asarray(points, dtype=np.float64)
+
+    @staticmethod
+    def _apply_camera_view(client, view):
+        position, look_at, up = view
+        client.camera.position = tuple(float(v) for v in position)
+        client.camera.look_at = tuple(float(v) for v in look_at)
+        client.camera.up_direction = tuple(float(v) for v in up)
+
+    def _register_camera_on_connect(self):
+        """Apply the stored camera view to clients that connect later."""
+        if self._camera_connect_registered:
+            return
+        self._camera_connect_registered = True
+
+        @self._server.on_client_connect
+        def _apply_stored_camera(client):
+            if self._camera_view is not None:
+                self._apply_camera_view(client, self._camera_view)
 
     def _get_limb_attribute(self, robot_model, group_name, attr_name):
         """Get an attribute from a robot model's limb for a given group.

--- a/tests/skrobot_tests/viewers_tests/test_create_viewer.py
+++ b/tests/skrobot_tests/viewers_tests/test_create_viewer.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest import mock
+
+import numpy as np
+
+import skrobot
+from skrobot.viewers import _supported_kwargs
+from skrobot.viewers import create_viewer
+from skrobot.viewers import PyrenderViewer
+from skrobot.viewers import TrimeshSceneViewer
+from skrobot.viewers import ViserViewer
+
+
+class _CameraResolver(object):
+    """Minimal stand-in exposing ViserViewer's camera math without a server."""
+
+    _linkid_to_link = {}
+    _collect_world_points = ViserViewer._collect_world_points
+    _resolve_camera_view = ViserViewer._resolve_camera_view
+
+
+class TestCreateViewer(unittest.TestCase):
+
+    def test_unknown_viewer_raises(self):
+        with self.assertRaises(ValueError):
+            create_viewer('not-a-viewer')
+
+    def test_non_string_name_raises_value_error(self):
+        for bad_name in (None, 123, ['trimesh']):
+            with self.assertRaises(ValueError):
+                create_viewer(bad_name)
+
+    def test_viewer_classes_registered(self):
+        self.assertIs(
+            skrobot.viewers._VIEWER_CLASSES['trimesh'], TrimeshSceneViewer)
+        self.assertIs(
+            skrobot.viewers._VIEWER_CLASSES['pyrender'], PyrenderViewer)
+        self.assertIs(
+            skrobot.viewers._VIEWER_CLASSES['viser'], ViserViewer)
+
+    def test_name_is_case_insensitive(self):
+        # Exercise create_viewer with mixed-case names. A lightweight fake
+        # is registered so no real viewer (window / server) is created.
+        class _FakeViewer(object):
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        with mock.patch.dict(skrobot.viewers._VIEWER_CLASSES,
+                             {'trimesh': _FakeViewer}):
+            for name in ('trimesh', 'TRIMESH', 'TrImEsH'):
+                self.assertIsInstance(create_viewer(name), _FakeViewer)
+
+    def test_supported_kwargs_filters_unsupported(self):
+        # resolution is accepted by the trimesh / pyrender viewers ...
+        self.assertEqual(
+            _supported_kwargs(
+                TrimeshSceneViewer, {'resolution': (1, 1), 'bogus': 1}),
+            {'resolution': (1, 1)})
+        # ... but not by the viser viewer, so it is dropped.
+        self.assertEqual(
+            _supported_kwargs(
+                ViserViewer, {'resolution': (1, 1), 'enable_ik': True}),
+            {'enable_ik': True})
+
+    def test_wait_until_close_available_on_all_viewers(self):
+        for cls in (TrimeshSceneViewer, PyrenderViewer, ViserViewer):
+            self.assertTrue(
+                hasattr(cls, 'wait_until_close'),
+                '{} is missing wait_until_close'.format(cls.__name__))
+
+
+class TestViserSetCameraMath(unittest.TestCase):
+
+    def setUp(self):
+        self.resolver = _CameraResolver()
+
+    def test_explicit_distance_and_center(self):
+        # Camera should sit ``distance`` away from ``center`` along the
+        # rotation's +Z axis (identity rotation -> +Z), looking at center.
+        position, look_at, _up = self.resolver._resolve_camera_view(
+            [0, 0, 0], 3.0, [1, 1, 1], None, None)
+        np.testing.assert_allclose(look_at, [1, 1, 1])
+        np.testing.assert_allclose(position, [1, 1, 4])
+        self.assertAlmostEqual(np.linalg.norm(position - look_at), 3.0)
+
+    def test_transform_overrides_angles(self):
+        transform = np.eye(4)
+        transform[:3, 3] = [1, 2, 3]
+        position, _look_at, _up = self.resolver._resolve_camera_view(
+            None, None, None, None, transform)
+        np.testing.assert_allclose(position, [1, 2, 3])
+
+    def test_returns_none_without_pose_info(self):
+        self.assertIsNone(
+            self.resolver._resolve_camera_view(None, None, None, None, None))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/skrobot_tests/viewers_tests/test_create_viewer.py
+++ b/tests/skrobot_tests/viewers_tests/test_create_viewer.py
@@ -9,6 +9,7 @@ from skrobot.viewers import create_viewer
 from skrobot.viewers import PyrenderViewer
 from skrobot.viewers import TrimeshSceneViewer
 from skrobot.viewers import ViserViewer
+from skrobot.viewers._base import _InteractiveViewerMixin
 
 
 class _CameraResolver(object):
@@ -17,6 +18,16 @@ class _CameraResolver(object):
     _linkid_to_link = {}
     _collect_world_points = ViserViewer._collect_world_points
     _resolve_camera_view = ViserViewer._resolve_camera_view
+
+
+class _CountingViewer(_InteractiveViewerMixin):
+    """Mixin-only viewer that counts redraw() calls (no GL backend)."""
+
+    def __init__(self):
+        self.redraw_count = 0
+
+    def redraw(self):
+        self.redraw_count += 1
 
 
 class TestCreateViewer(unittest.TestCase):
@@ -67,6 +78,32 @@ class TestCreateViewer(unittest.TestCase):
             self.assertTrue(
                 hasattr(cls, 'wait_until_close'),
                 '{} is missing wait_until_close'.format(cls.__name__))
+
+    def test_pause_available_on_all_viewers(self):
+        for cls in (TrimeshSceneViewer, PyrenderViewer, ViserViewer):
+            self.assertTrue(
+                hasattr(cls, 'pause'),
+                '{} is missing pause'.format(cls.__name__))
+
+    def test_pause_pumps_redraw(self):
+        viewer = _CountingViewer()
+        # Non-positive / non-finite duration triggers exactly one redraw
+        # and returns immediately.
+        for duration in (0, -1.0, float('nan'), float('inf')):
+            viewer.redraw_count = 0
+            viewer.pause(duration)
+            self.assertEqual(viewer.redraw_count, 1)
+
+        # A finite pause keeps pumping redraw more than once.
+        viewer.redraw_count = 0
+        viewer.pause(0.1, fps=30.0)
+        self.assertGreater(viewer.redraw_count, 1)
+
+    def test_pause_rejects_non_positive_fps(self):
+        viewer = _CountingViewer()
+        for bad_fps in (0, -5.0, float('nan'), float('inf')):
+            with self.assertRaises(ValueError):
+                viewer.pause(0.1, fps=bad_fps)
 
 
 class TestViserSetCameraMath(unittest.TestCase):


### PR DESCRIPTION
Add viewer.pause() to keep the window interactive during animation pauses
The trimesh and pyrender viewers run their GL event loop on the main thread
on macOS, so a bare time.sleep() inside an animation loop freezes the window
(the camera cannot be dragged) for the whole pause because no events are
dispatched.

Add pause(duration, fps=30.0) to the shared interactive-viewer mixin: it
pumps redraw() at fps for the requested duration so the view stays
responsive. fps must be a positive finite number, non-positive / non-finite
durations fall back to a single redraw, and timing uses time.monotonic().

Replace the redraw()+time.sleep() animation pauses in the examples with
viewer.pause(), and document create_viewer, wait_until_close and pause in the
viewer reference and visualization tutorial.