### PR TITLE
Fix GLB export dropping material-only colors

### DIFF
--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -1353,7 +1353,44 @@ class Mesh(URDFType):
                             )
                             if not has_image:
                                 try:
-                                    mesh.visual = mesh.visual.to_color()
+                                    color_visual = mesh.visual.to_color()
+                                    vertex_colors = np.asarray(
+                                        color_visual.vertex_colors)
+                                    if len(vertex_colors) != len(mesh.vertices):
+                                        # ``to_color`` can return a color array
+                                        # whose length does not match the
+                                        # vertex count (e.g. one entry per
+                                        # material) when the TextureVisuals has
+                                        # no UV coordinates.  GLB export then
+                                        # silently drops the mismatched colors
+                                        # and the mesh becomes the default gray.
+                                        # Broadcast the single material color to
+                                        # every vertex so the color survives.
+                                        material_color = getattr(
+                                            mat, 'main_color', None)
+                                        if material_color is None:
+                                            material_color = (
+                                                vertex_colors[0]
+                                                if len(vertex_colors)
+                                                else [200, 200, 200, 255])
+                                        material_color = np.asarray(
+                                            material_color)
+                                        if material_color.dtype.kind == 'f':
+                                            material_color = (
+                                                material_color * 255.0).round()
+                                        material_color = material_color.astype(
+                                            np.uint8)
+                                        if material_color.shape[0] == 3:
+                                            material_color = np.append(
+                                                material_color, np.uint8(255))
+                                        vertex_colors = np.tile(
+                                            material_color,
+                                            (len(mesh.vertices), 1))
+                                        color_visual = \
+                                            trimesh.visual.ColorVisuals(
+                                                mesh=mesh,
+                                                vertex_colors=vertex_colors)
+                                    mesh.visual = color_visual
                                 except Exception:
                                     pass
 

--- a/tests/skrobot_tests/utils_tests/test_urdf.py
+++ b/tests/skrobot_tests/utils_tests/test_urdf.py
@@ -4,6 +4,8 @@ import tempfile
 import unittest
 from unittest import mock
 
+from lxml import etree
+import numpy as np
 import pytest
 
 from skrobot.utils import urdf as urdf_utils
@@ -157,3 +159,43 @@ class TestResolveFilepathWithoutRospkg(unittest.TestCase):
                 result = urdf_utils.resolve_filepath(
                     pkg_dir, 'package://pr2_description/meshes/foo.dae')
             assert result == mesh_path
+
+
+class TestGlbExportPreservesMaterialColor(unittest.TestCase):
+    """GLB export must bake a material-only color into per-vertex colors.
+
+    ``TextureVisuals.to_color`` can return a color array whose length does
+    not match the vertex count when the mesh has a material color but no UV
+    coordinates. The GLB exporter then drops the mismatched colors and the
+    mesh becomes the default gray. The exporter must broadcast the material
+    color to every vertex so the original color survives.
+    """
+
+    def test_material_color_baked_into_vertex_colors(self):
+        import trimesh
+        from trimesh.visual.material import PBRMaterial
+
+        color = [72, 169, 84, 255]
+
+        def make_box():
+            box = trimesh.creation.box(extents=(0.1, 0.1, 0.1))
+            box.visual = trimesh.visual.TextureVisuals(
+                material=PBRMaterial(baseColorFactor=color))
+            return box
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            make_box().export(os.path.join(tmpdir, 'box.dae'))
+            mesh = urdf_utils.Mesh(filename='box.dae', meshes=[make_box()])
+            with urdf_utils.export_mesh_format('.glb', overwrite_mesh=True):
+                mesh._to_xml(etree.Element('visual'), tmpdir)
+
+            scene = trimesh.load(
+                os.path.join(tmpdir, 'box.glb'), process=False)
+            geometries = list(scene.geometry.values())
+            self.assertEqual(len(geometries), 1)
+            geometry = geometries[0]
+            vertex_colors = np.asarray(geometry.visual.vertex_colors)
+            self.assertEqual(len(vertex_colors), len(geometry.vertices))
+            np.testing.assert_array_equal(
+                np.unique(vertex_colors.reshape(-1, 4), axis=0),
+                np.array([color], dtype=np.uint8))


### PR DESCRIPTION
When a DAE stores per-material diffuse colors via a TextureVisuals with no UV coordinates, trimesh's to_color() can return a vertex color array whose length does not match the vertex count. The GLB exporter then silently drops the mismatched colors and the mesh falls back to the default gray.

Broadcast the single material color to every vertex when the lengths differ so the original color survives the GLB export, and add a regression test.