### PR TITLE
Add Jedy dual-arm mobile robot model

### DIFF
--- a/examples/reachability_map_demo.py
+++ b/examples/reachability_map_demo.py
@@ -208,7 +208,7 @@ def main():
     parser.add_argument(
         '--robot', type=str, default='pr2',
         choices=['pr2', 'panda', 'fetch', 'r8', 'nextage', 'tycoon',
-                 'differential_wrist', 'aero'],
+                 'differential_wrist', 'aero', 'jedy'],
         help='Robot model to use (ignored if --urdf is specified)'
     )
     parser.add_argument(
@@ -313,6 +313,9 @@ def main():
             robot.reset_manip_pose()
         elif args.robot == 'aero':
             robot = skrobot.models.Aero()
+            robot.reset_pose()
+        elif args.robot == 'jedy':
+            robot = skrobot.models.Jedy()
             robot.reset_pose()
 
         # Some robots use 'arm' instead of 'rarm'

--- a/skrobot/data/__init__.py
+++ b/skrobot/data/__init__.py
@@ -193,6 +193,20 @@ def jaxon_urdfpath():
     return path
 
 
+def jedy_urdfpath():
+    path = osp.join(get_cache_dir(),
+                    'jedy_description', 'urdf', 'jedy.urdf')
+    if osp.exists(path):
+        return path
+    _retrieve(
+        url='https://github.com/iory/scikit-robot-models/raw/main/jedy_description.tar.gz',  # NOQA
+        fname='jedy_description.tar.gz',
+        md5='620dd412c96ed492e4c2f224c36ab798',
+        extract=True,
+    )
+    return path
+
+
 def kuka_urdfpath():
     return osp.join(data_dir, 'kuka_description', 'kuka.urdf')
 

--- a/skrobot/models/__init__.py
+++ b/skrobot/models/__init__.py
@@ -6,6 +6,7 @@ from skrobot.models.fetch import Fetch
 from skrobot.models.griphis import Griphis
 from skrobot.models.hydrus import Hydrus
 from skrobot.models.jaxon_jvrc import JaxonJVRC
+from skrobot.models.jedy import Jedy
 from skrobot.models.kuka import Kuka
 from skrobot.models.nextage import Nextage
 from skrobot.models.panda import Panda

--- a/skrobot/models/jedy.py
+++ b/skrobot/models/jedy.py
@@ -1,0 +1,91 @@
+from cached_property import cached_property
+import numpy as np
+
+from skrobot.coordinates import CascadedCoords
+from skrobot.data import jedy_urdfpath
+from skrobot.model import RobotModel
+from skrobot.models.urdf import RobotModelFromURDF
+
+
+class Jedy(RobotModelFromURDF):
+    """Jedy dual-arm mobile robot model.
+
+    The robot has two 7-DOF arms (``{r,l}arm_joint0`` .. ``joint6``) each
+    terminated by a parallel gripper, a 2-DOF head (``head_joint0`` pan /
+    ``head_joint1`` tilt) and a 4-wheel mobile base.
+
+    An Intel RealSense D405 is mounted on ``head_link1``. ``head_end_coords``
+    is attached to ``camera_depth_optical_frame``, whose origin RealSense
+    colocates with the D405's **left** (infra1) imager, so the head end
+    coordinates coincide with the left camera. It follows the optical-frame
+    convention, so its z-axis points along the camera's viewing direction.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(Jedy, self).__init__(*args, **kwargs)
+
+        self.rarm_end_coords = CascadedCoords(
+            parent=self.rarm_link6,
+            pos=[0.0, 0.0, -0.102466],
+            name='rarm_end_coords')
+        self.rarm_end_coords.rotate(np.pi / 2.0, 'y')
+        self.larm_end_coords = CascadedCoords(
+            parent=self.larm_link6,
+            pos=[0.0, 0.0, -0.102466],
+            name='larm_end_coords')
+        self.larm_end_coords.rotate(np.pi / 2.0, 'y')
+
+        self.head_end_coords = CascadedCoords(
+            parent=self.camera_depth_optical_frame,
+            name='head_end_coords')
+
+        self.reset_pose()
+
+    @cached_property
+    def default_urdf_path(self):
+        return jedy_urdfpath()
+
+    def reset_pose(self):
+        self.rarm_joint0.joint_angle(np.deg2rad(30))
+        self.rarm_joint1.joint_angle(np.deg2rad(0))
+        self.rarm_joint2.joint_angle(np.deg2rad(0))
+        self.rarm_joint3.joint_angle(np.deg2rad(-120))
+        self.rarm_joint4.joint_angle(np.deg2rad(0))
+        self.rarm_joint5.joint_angle(np.deg2rad(0))
+        self.rarm_joint6.joint_angle(np.deg2rad(0))
+
+        self.larm_joint0.joint_angle(np.deg2rad(-30))
+        self.larm_joint1.joint_angle(np.deg2rad(0))
+        self.larm_joint2.joint_angle(np.deg2rad(0))
+        self.larm_joint3.joint_angle(np.deg2rad(-120))
+        self.larm_joint4.joint_angle(np.deg2rad(0))
+        self.larm_joint5.joint_angle(np.deg2rad(0))
+        self.larm_joint6.joint_angle(np.deg2rad(0))
+
+        self.head_joint0.joint_angle(np.deg2rad(0))
+        self.head_joint1.joint_angle(np.deg2rad(0))
+        return self.angle_vector()
+
+    @cached_property
+    def rarm(self):
+        links = [getattr(self, 'rarm_link{}'.format(i)) for i in range(7)]
+        joints = [link.joint for link in links]
+        r = RobotModel(link_list=links, joint_list=joints)
+        r.end_coords = self.rarm_end_coords
+        return r
+
+    @cached_property
+    def larm(self):
+        links = [getattr(self, 'larm_link{}'.format(i)) for i in range(7)]
+        joints = [link.joint for link in links]
+        r = RobotModel(link_list=links, joint_list=joints)
+        r.end_coords = self.larm_end_coords
+        return r
+
+    @cached_property
+    def head(self):
+        links = [self.head_link0, self.head_link1]
+        joints = [link.joint for link in links]
+        r = RobotModel(link_list=links, joint_list=joints)
+        r.end_coords = self.head_end_coords
+        return r


### PR DESCRIPTION
Add Jedy robot (two 7-DOF arms with grippers, 2-DOF head, mobile base) loaded from jedy_description.tar.gz. The head end_coords is attached to the D405 left camera (camera_depth_frame). Also expose jedy_urdfpath() and add 'jedy' to the reachability_map_demo example.


https://github.com/user-attachments/assets/ddda9dab-7b05-41a7-be17-d9ab27bd9260

