### PR TITLE
Raise clear error for Draco GLB/GLTF when DracoPy is missing

### DIFF
--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -422,6 +422,54 @@ def load_meshes(filename):
         return meshes
 
 
+def _gltf_uses_draco(filename):
+    """Return whether a glTF/GLB file uses Draco mesh compression.
+
+    A glTF/GLB file that lists ``KHR_draco_mesh_compression`` in its
+    ``extensionsUsed`` or ``extensionsRequired`` cannot be decoded without
+    DracoPy.  trimesh silently returns degenerate (all-zero) geometry in
+    that case rather than raising, so we detect it explicitly.
+
+    Parameters
+    ----------
+    filename : str
+        Path to a ``.glb`` or ``.gltf`` file.
+
+    Returns
+    -------
+    uses_draco : bool
+        ``True`` if the file references the Draco extension, ``False``
+        otherwise (including when the file cannot be parsed).
+    """
+    import json
+    import struct
+
+    ext_name = 'KHR_draco_mesh_compression'
+    try:
+        _, ext = os.path.splitext(filename)
+        if ext.lower() == '.glb':
+            with open(filename, 'rb') as f:
+                header = f.read(12)
+                if len(header) < 12 or header[:4] != b'glTF':
+                    return False
+                chunk_header = f.read(8)
+                if len(chunk_header) < 8:
+                    return False
+                chunk_length, chunk_type = struct.unpack('<II', chunk_header)
+                if chunk_type != 0x4E4F534A:  # 'JSON'
+                    return False
+                gltf = json.loads(f.read(chunk_length))
+        else:
+            with open(filename, 'r') as f:
+                gltf = json.load(f)
+    except Exception:
+        return False
+
+    extensions = set(gltf.get('extensionsUsed', []) or [])
+    extensions.update(gltf.get('extensionsRequired', []) or [])
+    return ext_name in extensions
+
+
 def _load_meshes(filename):
     """Loads triangular meshes from a file.
 
@@ -454,6 +502,25 @@ def _load_meshes(filename):
         dracopy_available = is_dracopy_available()
         if dracopy_available:
             register_dracopy_handlers()
+
+    # A Draco-compressed glTF/GLB cannot be decoded without DracoPy.  In
+    # that case trimesh does not raise; it silently returns degenerate
+    # (all-zero) geometry.  Detect the situation up front and fail loudly
+    # so the broken geometry is not mistaken for a successful load.
+    #
+    # NOTE: PR #715 already added a "pip install DracoPy" hint, but it only
+    # fired when trimesh.load() raised or returned an empty mesh list.  For
+    # the urdfeus Draco models trimesh does neither -- it returns a single
+    # all-zero mesh -- so the hint never triggered and nothing was reported.
+    # Parsing the extension list here covers that silent-degenerate case
+    # regardless of how trimesh behaves.
+    if is_glb_or_gltf and not dracopy_available and _gltf_uses_draco(filename):
+        raise ImportError(
+            "Cannot load Draco-compressed mesh '{}': it uses the "
+            "KHR_draco_mesh_compression extension but DracoPy is not "
+            "installed. Without DracoPy trimesh returns empty (all-zero) "
+            "geometry. Install DracoPy with: pip install DracoPy".format(
+                filename))
 
     load_error_reported = False
     try:

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -40,6 +40,12 @@ except ImportError:
 
 mesh_filenames_cache = {}
 logger = getLogger(__name__)
+
+# Whether the one-time "install DracoPy" hint has already been emitted.
+# A scene may reference many Draco-compressed meshes; we warn per file but
+# only show the verbose installation instruction once per process.
+_DRACO_MISSING_HINT_SHOWN = False
+
 _CONFIGURABLE_VALUES = {"mesh_simplify_factor": np.inf,
                         'no_mesh_load_mode': False,
                         'export_mesh_format': None,
@@ -505,8 +511,12 @@ def _load_meshes(filename):
 
     # A Draco-compressed glTF/GLB cannot be decoded without DracoPy.  In
     # that case trimesh does not raise; it silently returns degenerate
-    # (all-zero) geometry.  Detect the situation up front and fail loudly
-    # so the broken geometry is not mistaken for a successful load.
+    # (all-zero) geometry.  Detect the situation up front and skip the mesh
+    # with a clear warning, instead of letting the broken geometry pass as a
+    # successful load.  We deliberately do NOT raise here: a single Draco
+    # mesh would otherwise abort the whole URDF load (and trigger a confusing
+    # "load as URDF string" fallback).  Skipping lets the rest of the model
+    # load while keeping the missing geometry visible in the logs.
     #
     # NOTE: PR #715 already added a "pip install DracoPy" hint, but it only
     # fired when trimesh.load() raised or returned an empty mesh list.  For
@@ -515,12 +525,18 @@ def _load_meshes(filename):
     # Parsing the extension list here covers that silent-degenerate case
     # regardless of how trimesh behaves.
     if is_glb_or_gltf and not dracopy_available and _gltf_uses_draco(filename):
-        raise ImportError(
-            "Cannot load Draco-compressed mesh '{}': it uses the "
-            "KHR_draco_mesh_compression extension but DracoPy is not "
-            "installed. Without DracoPy trimesh returns empty (all-zero) "
-            "geometry. Install DracoPy with: pip install DracoPy".format(
-                filename))
+        global _DRACO_MISSING_HINT_SHOWN
+        if not _DRACO_MISSING_HINT_SHOWN:
+            logger.error(
+                "DracoPy is not installed, so Draco-compressed glTF/GLB "
+                "meshes (KHR_draco_mesh_compression) cannot be decoded and "
+                "will be skipped; trimesh would otherwise return empty "
+                "all-zero geometry. Install DracoPy with: pip install DracoPy")
+            _DRACO_MISSING_HINT_SHOWN = True
+        logger.warning(
+            "Skipping Draco-compressed mesh (DracoPy not installed): %s",
+            filename)
+        return []
 
     load_error_reported = False
     try:

--- a/tests/skrobot_tests/utils_tests/test_urdf.py
+++ b/tests/skrobot_tests/utils_tests/test_urdf.py
@@ -23,11 +23,13 @@ class TestLoadMeshesNoneGuard(unittest.TestCase):
 
 
 class TestDracoCompressedMeshDetection(unittest.TestCase):
-    """A Draco-compressed glTF/GLB must fail loudly when DracoPy is absent.
+    """A Draco-compressed glTF/GLB must be reported when DracoPy is absent.
 
     Without DracoPy, trimesh does not raise; it silently returns degenerate
     (all-zero) geometry. The loader must detect the Draco extension up front
-    and raise an actionable error instead of returning broken meshes.
+    and skip the mesh with a clear warning (returning no meshes) instead of
+    returning broken geometry. It must NOT raise: a single Draco mesh would
+    otherwise abort the entire URDF load.
     """
 
     def _make_draco_glb(self, path):
@@ -55,19 +57,25 @@ class TestDracoCompressedMeshDetection(unittest.TestCase):
         finally:
             os.remove(path)
 
-    def test_load_raises_when_draco_and_no_dracopy(self):
+    def test_load_skips_and_warns_when_draco_and_no_dracopy(self):
         with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as tmp:
             path = tmp.name
         try:
             self._make_draco_glb(path)
+            # Reset the one-time hint flag so the verbose hint is emitted.
+            urdf_utils._DRACO_MISSING_HINT_SHOWN = False
             with mock.patch(
                     'skrobot.utils.draco.is_dracopy_available',
                     return_value=False):
-                with pytest.raises(ImportError) as excinfo:
-                    urdf_utils._load_meshes(path)
-            msg = str(excinfo.value)
-            assert 'DracoPy' in msg
-            assert 'KHR_draco_mesh_compression' in msg
+                with self.assertLogs(
+                        'skrobot.utils.urdf', level='WARNING') as logs:
+                    meshes = urdf_utils._load_meshes(path)
+            # The mesh is skipped (no broken geometry returned) but not raised,
+            # so the rest of a URDF can still load.
+            self.assertEqual(meshes, [])
+            joined = '\n'.join(logs.output)
+            assert 'DracoPy' in joined
+            assert path in joined
         finally:
             os.remove(path)
 

--- a/tests/skrobot_tests/utils_tests/test_urdf.py
+++ b/tests/skrobot_tests/utils_tests/test_urdf.py
@@ -22,6 +22,67 @@ class TestLoadMeshesNoneGuard(unittest.TestCase):
         assert 'install/setup.bash' in msg or 'ROS_PACKAGE_PATH' in msg
 
 
+class TestDracoCompressedMeshDetection(unittest.TestCase):
+    """A Draco-compressed glTF/GLB must fail loudly when DracoPy is absent.
+
+    Without DracoPy, trimesh does not raise; it silently returns degenerate
+    (all-zero) geometry. The loader must detect the Draco extension up front
+    and raise an actionable error instead of returning broken meshes.
+    """
+
+    def _make_draco_glb(self, path):
+        import json
+        import struct
+        gltf = {
+            'asset': {'version': '2.0'},
+            'extensionsUsed': ['KHR_draco_mesh_compression'],
+            'extensionsRequired': ['KHR_draco_mesh_compression'],
+        }
+        json_bytes = json.dumps(gltf).encode('utf-8')
+        json_bytes += b' ' * ((4 - len(json_bytes) % 4) % 4)
+        with open(path, 'wb') as f:
+            f.write(struct.pack('<4sII', b'glTF', 2,
+                                12 + 8 + len(json_bytes)))
+            f.write(struct.pack('<II', len(json_bytes), 0x4E4F534A))
+            f.write(json_bytes)
+
+    def test_gltf_uses_draco_detects_extension(self):
+        with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as tmp:
+            path = tmp.name
+        try:
+            self._make_draco_glb(path)
+            self.assertTrue(urdf_utils._gltf_uses_draco(path))
+        finally:
+            os.remove(path)
+
+    def test_load_raises_when_draco_and_no_dracopy(self):
+        with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as tmp:
+            path = tmp.name
+        try:
+            self._make_draco_glb(path)
+            with mock.patch(
+                    'skrobot.utils.draco.is_dracopy_available',
+                    return_value=False):
+                with pytest.raises(ImportError) as excinfo:
+                    urdf_utils._load_meshes(path)
+            msg = str(excinfo.value)
+            assert 'DracoPy' in msg
+            assert 'KHR_draco_mesh_compression' in msg
+        finally:
+            os.remove(path)
+
+    def test_plain_glb_not_flagged_as_draco(self):
+        import trimesh
+        box = trimesh.creation.box(extents=[1, 1, 1])
+        with tempfile.NamedTemporaryFile(suffix='.glb', delete=False) as tmp:
+            path = tmp.name
+        try:
+            box.export(path)
+            self.assertFalse(urdf_utils._gltf_uses_draco(path))
+        finally:
+            os.remove(path)
+
+
 class TestGetPathWithCacheResolverOrder(unittest.TestCase):
     """get_path_with_cache should respect ROS_VERSION when both resolvers are present."""
 


### PR DESCRIPTION
Without DracoPy, trimesh silently returns degenerate all-zero geometry instead of raising, so the PR https://github.com/iory/scikit-robot/pull/715 hint never fired. Detect the KHR_draco_mesh_compression extension up front and raise an actionable ImportError.