### PR TITLE
Flip winding when a visual mesh has a negative-determinant scale

### DIFF
--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -2917,7 +2917,19 @@ class RobotModel(CascadedLink):
             # rescale
             if visual.geometry.mesh is not None:
                 if visual.geometry.mesh.scale is not None:
-                    mesh.vertices = mesh.vertices * visual.geometry.mesh.scale
+                    # Apply the scale as a transform rather than multiplying
+                    # the vertices directly. A scale with a negative
+                    # determinant (e.g. ``1 -1 1`` used to mirror a mesh)
+                    # reverses the triangle winding order; ``apply_transform``
+                    # flips the faces back so the normals keep pointing
+                    # outward. Without this the renderer's backface culling
+                    # hides the surfaces and the mesh looks see-through.
+                    # This mirrors the handling already used for collision
+                    # meshes (see ``Link.collision_mesh`` in utils/urdf.py).
+                    scale_transform = np.eye(4)
+                    scale_transform[:3, :3] = np.diag(
+                        visual.geometry.mesh.scale)
+                    mesh.apply_transform(scale_transform)
 
             # TextureVisuals is usually slow to render
             if not isinstance(mesh.visual, trimesh.visual.ColorVisuals):

--- a/tests/skrobot_tests/test_urdf.py
+++ b/tests/skrobot_tests/test_urdf.py
@@ -1,6 +1,10 @@
 import os
+import shutil
 import sys
+import tempfile
 import unittest
+
+import trimesh
 
 from skrobot.data import fetch_urdfpath
 from skrobot.models.urdf import RobotModelFromURDF
@@ -32,3 +36,44 @@ class TestURDF(unittest.TestCase):
         # load using existing cache
         with mesh_simplify_factor(0.1):
             RobotModelFromURDF(urdf_file=fetch_urdfpath())
+
+    def test_mirror_scale_keeps_outward_normals(self):
+        # A negative scale (e.g. ``1 -1 1`` used to mirror a mesh) reverses
+        # the triangle winding order. The visual mesh must still have its
+        # normals pointing outward, otherwise backface culling makes the
+        # model look see-through. A watertight box has a positive signed
+        # volume only when its faces are wound outward, so we use the sign
+        # of the volume as a robust check.
+        tmpdir = tempfile.mkdtemp()
+        try:
+            mesh_path = os.path.join(tmpdir, 'box.stl')
+            box = trimesh.creation.box(extents=(0.2, 0.1, 0.05))
+            self.assertGreater(box.volume, 0)
+            box.export(mesh_path)
+
+            urdf_path = os.path.join(tmpdir, 'mirror.urdf')
+            with open(urdf_path, 'w') as f:
+                f.write(
+                    '<?xml version="1.0"?>\n'
+                    '<robot name="mirror_test">\n'
+                    '  <link name="base_link">\n'
+                    '    <visual>\n'
+                    '      <geometry>\n'
+                    '        <mesh filename="box.stl" scale="1 -1 1"/>\n'
+                    '      </geometry>\n'
+                    '    </visual>\n'
+                    '  </link>\n'
+                    '</robot>\n')
+
+            robot = RobotModelFromURDF(urdf_file=urdf_path)
+            visual_mesh = robot.base_link.visual_mesh
+            mesh = visual_mesh[0] if isinstance(visual_mesh, list) \
+                else visual_mesh
+
+            # mirrored across Y ...
+            self.assertLess(mesh.vertices[:, 1].min(), 0)
+            self.assertGreater(mesh.vertices[:, 1].max(), 0)
+            # ... but still wound outward (positive signed volume).
+            self.assertGreater(mesh.volume, 0)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
A URDF that mirrors a mesh with a negative scale (e.g. ``scale="1 -1 1"``) reverses the triangle winding order. The visual-mesh loader applied the scale by multiplying the vertices directly, so the faces ended up wound inward: the renderer's backface culling then hid the surfaces and the model looked see-through / inside-out.

Apply the scale via ``apply_transform`` instead. trimesh flips the face winding for any negative-determinant transform, keeping the normals pointing outward. This matches the handling already used for collision meshes in ``Link.collision_mesh`` and needs no special-casing of the scale value (a single negative component, or three, flips the winding; two do not -- exactly what the determinant check captures).

cc: @nakane11 


https://github.com/user-attachments/assets/a4d51285-6ca0-4c99-a8fc-7f06bcf56133

