### PR TITLE
fix: fallback to viser when pyrender is unavailable

### DIFF
--- a/skrobot/apps/visualize_urdf.py
+++ b/skrobot/apps/visualize_urdf.py
@@ -46,7 +46,23 @@ def main():
     if args.viewer == 'trimesh':
         viewer = skrobot.viewers.TrimeshSceneViewer(update_interval=0.1)
     elif args.viewer == 'pyrender':
-        viewer = skrobot.viewers.PyrenderViewer(update_interval=0.1)
+        from skrobot.viewers import DummyViewer
+        from skrobot.viewers import PyrenderViewer
+        from skrobot.viewers import ViserViewer
+        if issubclass(PyrenderViewer, DummyViewer) and not issubclass(ViserViewer, DummyViewer):
+            cause = getattr(PyrenderViewer, '_import_error', 'Unknown error')
+            print(
+                "\033[93m"  # yellow
+                + "Warning: 'pyrender' is not available. Falling back to 'viser' viewer.\n"
+                + f"Reason: {cause}\n"
+                + "If this is unexpected, please report this issue to:\n"
+                + "  https://github.com/iory/scikit-robot/issues\n"
+                + "\033[0m"
+            )
+            args.viewer = 'viser'
+            viewer = ViserViewer(enable_ik=True)
+        else:
+            viewer = PyrenderViewer(update_interval=0.1)
     elif args.viewer == 'viser':
         viewer = skrobot.viewers.ViserViewer(enable_ik=True)
 

--- a/skrobot/viewers/__init__.py
+++ b/skrobot/viewers/__init__.py
@@ -48,10 +48,10 @@ except TypeError:
             raise RuntimeError('TrimeshSceneViewer cannot be initialized. '
                                'This issue happens when the X window system '
                                'is not running.')
-except ImportError as error_log:
+except (ImportError, RuntimeError) as error_log:
     warn_gl(error_log)
     class TrimeshSceneViewer(DummyViewer):
-        pass
+        _import_error = error_log
 
 try:
     from ._pyrender import PyrenderViewer
@@ -66,10 +66,10 @@ try:
                     'please execute the following command:\n'
                     'pip uninstall -y pyrender && pip install scikit-robot-pyrender --no-cache-dir'
                 )
-except ImportError as error_log:
+except (ImportError, RuntimeError) as error_log:
     warn_gl(error_log)
     class PyrenderViewer(DummyViewer):
-        pass
+        _import_error = error_log
 
 try:
     from ._notebook import JupyterNotebookViewer


### PR DESCRIPTION
When running PowerShell on a Surface Pro 11 (ARM64), some libraries don't include precompiled binaries. For example, in PyrenderViewer, freetype-py doesn't provide the required .dll file. Here is a patch to handle this fallback.