### PR TITLE
Resolve package:// meshes from the ROS environment without ROS Python

### DIFF
--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -247,14 +247,87 @@ def _try_rospkg(ros_package):
         return None
 
 
+def _manifest_package_name(directory):
+    """Return the ``<name>`` declared in ``<directory>/package.xml``, or None."""
+    manifest = os.path.join(directory, 'package.xml')
+    if not os.path.isfile(manifest):
+        return None
+    try:
+        name = ET.parse(manifest).getroot().findtext('name')
+    except (OSError, ET.XMLSyntaxError):
+        return None
+    return name.strip() if name else None
+
+
+def _env_paths(variable):
+    """Absolute, expanded, non-empty entries of an ``os.pathsep`` env variable."""
+    return [os.path.abspath(os.path.expanduser(p))
+            for p in os.environ.get(variable, '').split(os.pathsep) if p]
+
+
+def _find_package_dir(root, ros_package):
+    """Locate ``ros_package`` under one ``ROS_PACKAGE_PATH`` entry.
+
+    An entry may itself be the package, a directory that contains it, or a
+    workspace ``src`` to crawl (the several catkin layouts). The recursive walk
+    is the last resort and prunes build/VCS trees.
+    """
+    if _manifest_package_name(root) == ros_package:
+        return root
+    direct = os.path.join(root, ros_package)
+    if _manifest_package_name(direct) == ros_package:
+        return direct
+    if not os.path.isdir(root):
+        return None
+    for current, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs
+                   if not d.startswith('.')
+                   and d not in ('build', 'devel', 'install', 'log')]
+        if 'package.xml' in files:
+            if _manifest_package_name(current) == ros_package:
+                return current
+            # A catkin package cannot contain another; stop descending here
+            # (also avoids crawling large mesh/resource trees).
+            dirs[:] = []
+    return None
+
+
+def _try_env_prefixes(ros_package):
+    """Resolve a ROS package from the sourced shell environment alone.
+
+    Uses only the standard search-path variables, so it works when neither
+    ``ament_index_python`` nor ``rospkg`` is importable -- e.g. inside a
+    PyInstaller-frozen binary launched from a sourced ROS workspace. Returns
+    the package's share/root directory, or ``None``.
+
+    * ``AMENT_PREFIX_PATH`` / ``COLCON_PREFIX_PATH`` / ``CMAKE_PREFIX_PATH``:
+      ``<prefix>/share/<pkg>`` (the ament / ROS 2 install layout).
+    * ``ROS_PACKAGE_PATH``: each entry is the package, a directory of packages,
+      or a workspace ``src`` to crawl (the catkin / ROS 1 layouts).
+    """
+    for variable in ('AMENT_PREFIX_PATH', 'COLCON_PREFIX_PATH',
+                     'CMAKE_PREFIX_PATH'):
+        for prefix in _env_paths(variable):
+            share = os.path.join(prefix, 'share', ros_package)
+            if _manifest_package_name(share) == ros_package:
+                return share
+    for root in _env_paths('ROS_PACKAGE_PATH'):
+        found = _find_package_dir(root, ros_package)
+        if found:
+            return found
+    return None
+
+
 @lru_cache(maxsize=None)
 def get_path_with_cache(ros_package):
     """Resolve a ROS package name to its share/install directory.
 
-    Tries both ``ament_index_python`` (ROS 2) and ``rospkg`` (ROS 1) when
-    available. The order respects the ``ROS_VERSION`` environment variable so
-    that users with ROS 1 and ROS 2 coexisting on the same machine get the
-    resolver matching their currently-sourced distro:
+    Tries ``ament_index_python`` (ROS 2) and ``rospkg`` (ROS 1) when available,
+    then falls back to :func:`_try_env_prefixes`, which resolves straight from
+    the sourced shell environment and needs no ROS Python at all. The order of
+    the first two respects the ``ROS_VERSION`` environment variable so that
+    users with ROS 1 and ROS 2 coexisting on the same machine get the resolver
+    matching their currently-sourced distro:
 
     * ``ROS_VERSION=1`` -> rospkg first, then ament (preserves the old
       behaviour where rospkg-only resolution was used).
@@ -263,17 +336,30 @@ def get_path_with_cache(ros_package):
       ship ament but not rospkg (previously such environments hit a
       ``TypeError`` deeper in mesh loading).
 
+    The environment fallback runs last in both orders, so it only changes the
+    outcome when the ROS Python resolvers are absent or come up empty -- e.g. a
+    PyInstaller-frozen binary launched from a sourced workspace.
+
+    Results are cached for the process lifetime (``lru_cache``); a change to the
+    ROS search-path environment variables after the first lookup is not picked
+    up, matching the existing behaviour for the ament/rospkg resolvers.
+
     Raises
     ------
     ImportError
-        Neither resolver is available.
+        No ROS Python resolver is installed and the package was not found under
+        the ROS search-path environment variables either.
     LookupError
-        Both resolvers were tried but the package was not found by either.
+        The resolvers were tried but none of them found the package.
     """
+    # ament_index / rospkg are the authoritative package indices when present;
+    # _try_env_prefixes is a dependency-free fallback that resolves straight
+    # from the sourced shell environment, so a frozen binary (no ROS Python)
+    # still finds meshes after `source install/setup.bash`.
     if os.environ.get('ROS_VERSION') == '1':
-        resolvers = (_try_rospkg, _try_ament)
+        resolvers = (_try_rospkg, _try_ament, _try_env_prefixes)
     else:
-        resolvers = (_try_ament, _try_rospkg)
+        resolvers = (_try_ament, _try_rospkg, _try_env_prefixes)
 
     for resolver in resolvers:
         path = resolver(ros_package)
@@ -289,7 +375,10 @@ def get_path_with_cache(ros_package):
     if not ament_available and rospkg is None:
         raise ImportError(
             "Cannot resolve ROS package '{}': neither ament_index_python "
-            "nor rospkg is installed.".format(ros_package))
+            "nor rospkg is installed, and it was not found under "
+            "AMENT_PREFIX_PATH / ROS_PACKAGE_PATH / CMAKE_PREFIX_PATH. "
+            "Source your ROS workspace (e.g. `source install/setup.bash`) "
+            "or install one of the resolvers.".format(ros_package))
     raise LookupError(
         "ROS package '{}' was not found by ament_index_python or rospkg. "
         "Did you forget to source your ROS workspace "

--- a/tests/skrobot_tests/utils_tests/test_urdf.py
+++ b/tests/skrobot_tests/utils_tests/test_urdf.py
@@ -268,3 +268,97 @@ class TestGlbExportPreservesMaterialColor(unittest.TestCase):
             np.testing.assert_array_equal(
                 np.unique(vertex_colors.reshape(-1, 4), axis=0),
                 np.array([color], dtype=np.uint8))
+
+
+class TestEnvPrefixResolver(unittest.TestCase):
+    """_try_env_prefixes resolves package:// from the shell environment alone,
+    so a frozen binary (no ament_index_python / rospkg) still finds meshes
+    after sourcing a workspace."""
+
+    _VARS = ('AMENT_PREFIX_PATH', 'COLCON_PREFIX_PATH', 'CMAKE_PREFIX_PATH',
+             'ROS_PACKAGE_PATH', 'ROS_VERSION')
+
+    def setUp(self):
+        urdf_utils.get_path_with_cache.cache_clear()
+        self._saved = {v: os.environ.pop(v, None) for v in self._VARS}
+        self._tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        urdf_utils.get_path_with_cache.cache_clear()
+        for v, val in self._saved.items():
+            if val is None:
+                os.environ.pop(v, None)
+            else:
+                os.environ[v] = val
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _make_package(self, directory, name):
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, 'package.xml'), 'w') as f:
+            f.write('<?xml version="1.0"?>\n'
+                    '<package><name>{}</name></package>\n'.format(name))
+        return directory
+
+    def test_resolves_via_ament_prefix_share_layout(self):
+        prefix = os.path.join(self._tmp, 'install')
+        share = self._make_package(
+            os.path.join(prefix, 'share', 'my_robot'), 'my_robot')
+        os.environ['AMENT_PREFIX_PATH'] = prefix
+        assert os.path.samefile(
+            urdf_utils._try_env_prefixes('my_robot'), share)
+
+    def test_resolves_via_ros_package_path_direct_child(self):
+        src = os.path.join(self._tmp, 'ws', 'src')
+        pkg = self._make_package(os.path.join(src, 'my_robot'), 'my_robot')
+        os.environ['ROS_PACKAGE_PATH'] = src
+        assert os.path.samefile(
+            urdf_utils._try_env_prefixes('my_robot'), pkg)
+
+    def test_resolves_via_ros_package_path_recursive_crawl(self):
+        src = os.path.join(self._tmp, 'ws', 'src')
+        pkg = self._make_package(
+            os.path.join(src, 'nested', 'my_robot'), 'my_robot')
+        os.environ['ROS_PACKAGE_PATH'] = src
+        assert os.path.samefile(
+            urdf_utils._try_env_prefixes('my_robot'), pkg)
+
+    def test_name_in_manifest_wins_over_directory_name(self):
+        # under ROS_PACKAGE_PATH the package.xml <name>, not the folder name,
+        # is authoritative (the ament share/<pkg> layout is name-keyed instead)
+        src = os.path.join(self._tmp, 'ws', 'src')
+        pkg = self._make_package(os.path.join(src, 'pkg_dir'), 'real_name')
+        os.environ['ROS_PACKAGE_PATH'] = src
+        assert urdf_utils._try_env_prefixes('pkg_dir') is None
+        assert os.path.samefile(
+            urdf_utils._try_env_prefixes('real_name'), pkg)
+
+    def test_returns_none_when_not_found(self):
+        os.environ['AMENT_PREFIX_PATH'] = self._tmp
+        os.environ['ROS_PACKAGE_PATH'] = self._tmp
+        assert urdf_utils._try_env_prefixes('absent') is None
+
+    def test_malformed_manifest_is_skipped_gracefully(self):
+        # a broken package.xml must not raise; the crawl just moves on
+        src = os.path.join(self._tmp, 'ws', 'src')
+        broken = os.path.join(src, 'broken')
+        os.makedirs(broken)
+        with open(os.path.join(broken, 'package.xml'), 'w') as f:
+            f.write('<package><name>oops')          # unterminated XML
+        good = self._make_package(os.path.join(src, 'good'), 'good')
+        os.environ['ROS_PACKAGE_PATH'] = src
+        assert urdf_utils._manifest_package_name(broken) is None
+        assert urdf_utils._try_env_prefixes('broken') is None
+        assert os.path.samefile(
+            urdf_utils._try_env_prefixes('good'), good)
+
+    def test_get_path_with_cache_falls_back_to_env(self):
+        prefix = os.path.join(self._tmp, 'install')
+        share = self._make_package(
+            os.path.join(prefix, 'share', 'my_robot'), 'my_robot')
+        os.environ['AMENT_PREFIX_PATH'] = prefix
+        # neither ROS Python resolver available -> env fallback must resolve
+        with mock.patch.object(urdf_utils, '_try_ament', return_value=None), \
+             mock.patch.object(urdf_utils, '_try_rospkg', return_value=None):
+            assert os.path.samefile(
+                urdf_utils.get_path_with_cache('my_robot'), share)


### PR DESCRIPTION
get_path_with_cache only knew ament_index_python and rospkg, so a PyInstaller-frozen binary -- which bundles neither -- could not resolve package:// mesh URIs even when launched from a sourced ROS workspace.

Add _try_env_prefixes, a dependency-free resolver that reads the standard search-path variables (AMENT_PREFIX_PATH / COLCON_PREFIX_PATH / CMAKE_PREFIX_PATH for the <prefix>/share/<pkg> layout, and ROS_PACKAGE_PATH for the catkin layouts, keyed on the package.xml <name>). It runs last in the resolver chain, so it only changes the outcome when the ROS Python resolvers are absent or come up empty; existing setups are unaffected.

Related to https://github.com/jsk-ros-pkg/solidworks_urdf_exporter2/pull/112