### PR TITLE
Add per-mesh primitive fitting API

### DIFF
--- a/skrobot/apps/convert_urdf_to_primitives.py
+++ b/skrobot/apps/convert_urdf_to_primitives.py
@@ -81,6 +81,16 @@ Examples:
     )
 
     parser.add_argument(
+        '--oriented',
+        type=str,
+        choices=['auto', 'true', 'false'],
+        default='auto',
+        help='Orientation policy for box/cylinder fits: auto (keep the '
+             'tighter of axis-aligned/oriented, default), true (force '
+             'oriented), false (force axis-aligned)'
+    )
+
+    parser.add_argument(
         '-v', '--verbose',
         action='store_true',
         help='Enable verbose output'
@@ -130,6 +140,8 @@ Examples:
 
     primitive_type = None if args.primitive_type == 'auto' else args.primitive_type
 
+    oriented = {'auto': None, 'true': True, 'false': False}[args.oriented]
+
     try:
         print(f"Loading URDF from: {input_path}")
         if args.preserve_visual:
@@ -149,7 +161,8 @@ Examples:
             str(output_path) if output_path else None,
             convert_visual=convert_visual,
             convert_collision=convert_collision,
-            primitive_type=primitive_type
+            primitive_type=primitive_type,
+            oriented=oriented
         )
 
         if modified_count > 0:

--- a/skrobot/urdf/primitives_converter.py
+++ b/skrobot/urdf/primitives_converter.py
@@ -6,10 +6,11 @@ from pathlib import Path
 from lxml import etree as ET
 import numpy as np
 
-from skrobot.coordinates.math import matrix2ypr
+from skrobot.coordinates.math import matrix2rpy
 from skrobot.coordinates.math import rotation_matrix_z_to_axis
 from skrobot.coordinates.math import rpy_matrix
 from skrobot.utils.primitive_fitting import fit_primitive_to_mesh
+from skrobot.utils.primitive_fitting import primitive_params_to_origin
 from skrobot.utils.urdf import get_filename
 from skrobot.utils.urdf import load_meshes
 
@@ -153,13 +154,14 @@ def create_primitive_geometry_element(primitive_params, indent_patterns):
     -------
     geometry : ET.Element
         XML geometry element.
-    origin_xyz : np.ndarray
-        Origin position for the primitive.
-    origin_rpy : np.ndarray
-        Origin rotation (RPY) for the primitive.
+
+    Notes
+    -----
+    This only builds the ``<geometry>`` element. The primitive's
+    ``<origin>`` (xyz, rpy) is computed separately via
+    :func:`skrobot.utils.primitive_fitting.primitive_params_to_origin`.
     """
     geometry = ET.Element('geometry')
-    center = primitive_params['center']
     prim_type = primitive_params['type']
 
     if prim_type == 'box':
@@ -168,37 +170,25 @@ def create_primitive_geometry_element(primitive_params, indent_patterns):
         box.set('size', f"{extents[0]} {extents[1]} {extents[2]}")
         box.tail = indent_patterns['primitive_tail']
 
-        rotation = primitive_params.get('rotation', np.eye(3))
-        ypr = matrix2ypr(rotation)
-        origin_rpy = np.array([ypr[2], ypr[1], ypr[0]])
-
     elif prim_type == 'sphere':
         radius = primitive_params['radius']
         sphere = ET.SubElement(geometry, 'sphere')
         sphere.set('radius', str(radius))
         sphere.tail = indent_patterns['primitive_tail']
 
-        origin_rpy = np.zeros(3)
-
     elif prim_type == 'cylinder':
         radius = primitive_params['radius']
         height = primitive_params['height']
-        axis = primitive_params['axis']
 
         cylinder = ET.SubElement(geometry, 'cylinder')
         cylinder.set('radius', str(radius))
         cylinder.set('length', str(height))
         cylinder.tail = indent_patterns['primitive_tail']
 
-        rotation = rotation_matrix_z_to_axis(axis)
-        ypr = matrix2ypr(rotation)
-        origin_rpy = np.array([ypr[2], ypr[1], ypr[0]])
-
     elif prim_type == 'capsule':
         logger.warning("Capsule primitives are not standard URDF. Converting to cylinder.")
         radius = primitive_params['radius']
         height = primitive_params['height']
-        axis = primitive_params['axis']
 
         cylinder = ET.SubElement(geometry, 'cylinder')
         cylinder.set('radius', str(radius))
@@ -206,16 +196,12 @@ def create_primitive_geometry_element(primitive_params, indent_patterns):
         cylinder.set('length', str(total_height))
         cylinder.tail = indent_patterns['primitive_tail']
 
-        rotation = rotation_matrix_z_to_axis(axis)
-        ypr = matrix2ypr(rotation)
-        origin_rpy = np.array([ypr[2], ypr[1], ypr[0]])
-
     else:
         raise ValueError(f"Unknown primitive type: {prim_type}")
 
     geometry.text = indent_patterns['geometry_text']
 
-    return geometry, center, origin_rpy
+    return geometry
 
 
 def convert_meshes_to_primitives(
@@ -223,7 +209,8 @@ def convert_meshes_to_primitives(
         output_file=None,
         convert_visual=True,
         convert_collision=True,
-        primitive_type=None):
+        primitive_type=None,
+        oriented=None):
     """Convert mesh geometries in URDF to primitive shapes.
 
     Parameters
@@ -239,6 +226,11 @@ def convert_meshes_to_primitives(
     primitive_type : str, optional
         Force a specific primitive type ('box', 'cylinder', 'sphere').
         If None, automatically detects the best fit for each mesh.
+    oriented : bool or None, optional
+        Orientation policy for box/cylinder fits. ``None`` (default) keeps the
+        tighter of the axis-aligned / oriented variants automatically; ``True``
+        forces oriented fits; ``False`` forces axis-aligned fits (see
+        :func:`skrobot.utils.primitive_fitting.fit_primitive_to_mesh`).
 
     Returns
     -------
@@ -317,20 +309,27 @@ def convert_meshes_to_primitives(
 
                 primitive_params = fit_primitive_to_mesh(
                     combined_mesh,
-                    primitive_type=primitive_type
+                    primitive_type=primitive_type,
+                    oriented=oriented
                 )
 
                 logger.info("    Fitted primitive: %s", primitive_params['type'])
 
+                # Origin of the primitive expressed in the mesh's own frame.
+                local_xyz, local_rpy = primitive_params_to_origin(
+                    primitive_params)
+
+                # Compose the primitive origin with the mesh element's URDF
+                # origin to obtain the primitive pose in the link frame.
                 rotation_urdf = rpy_matrix(
                     origin_rpy[2],
                     origin_rpy[1],
                     origin_rpy[0]
                 )
-                mesh_center_link = rotation_urdf @ primitive_params['center']
+                mesh_center_link = rotation_urdf @ local_xyz
                 primitive_center = origin_xyz + mesh_center_link
 
-                new_geometry, rel_center, rel_rpy = create_primitive_geometry_element(
+                new_geometry = create_primitive_geometry_element(
                     primitive_params,
                     indent_patterns
                 )
@@ -338,11 +337,16 @@ def convert_meshes_to_primitives(
                 if primitive_params['type'] in ['cylinder', 'capsule']:
                     axis_link = rotation_urdf @ primitive_params['axis']
                     primitive_rotation = rotation_matrix_z_to_axis(axis_link)
-                    combined_rotation = primitive_rotation
-                    ypr = matrix2ypr(combined_rotation)
-                    final_rpy = np.array([ypr[2], ypr[1], ypr[0]])
+                    final_rpy = matrix2rpy(primitive_rotation)
                 else:
-                    final_rpy = origin_rpy
+                    rotation_local = rpy_matrix(
+                        local_rpy[2], local_rpy[1], local_rpy[0])
+                    if np.allclose(rotation_local, np.eye(3)):
+                        # Axis-aligned box / sphere: preserve the element's
+                        # original URDF origin rpy exactly.
+                        final_rpy = origin_rpy
+                    else:
+                        final_rpy = matrix2rpy(rotation_urdf @ rotation_local)
 
                 original_order = []
                 material_elem = None

--- a/skrobot/utils/__init__.py
+++ b/skrobot/utils/__init__.py
@@ -15,3 +15,6 @@ from skrobot.utils.visualization import set_ik_visualization_enabled
 from skrobot.utils.visualization import get_ik_visualization_enabled
 
 from skrobot.utils.blender_mesh import remesh_with_blender
+
+from skrobot.utils.primitive_fitting import fit_primitive_to_mesh
+from skrobot.utils.primitive_fitting import primitive_params_to_origin

--- a/skrobot/utils/primitive_fitting.py
+++ b/skrobot/utils/primitive_fitting.py
@@ -10,7 +10,39 @@ from skrobot._lazy_imports import _lazy_trimesh
 logger = getLogger(__name__)
 
 
-def compute_mesh_primitive_iou(mesh, primitive_mesh, voxel_pitch=None):
+__all__ = [
+    'compute_mesh_primitive_iou',
+    'fit_box_to_mesh',
+    'fit_sphere_to_mesh',
+    'fit_cylinder_to_mesh',
+    'fit_capsule_to_mesh',
+    'create_primitive_mesh',
+    'estimate_best_primitive',
+    'fit_primitive_to_mesh',
+    'primitive_params_to_origin',
+]
+
+
+def _voxel_coord_set(mesh, voxel_pitch, fill=True):
+    """Voxelize a mesh and return the set of occupied integer voxel keys.
+
+    When ``fill`` is True the grid is solid-filled so the result represents the
+    mesh *volume*, not just its surface shell -- making IoU meaningful even for
+    thin, non-watertight surface meshes. Keys are ``round(point / pitch)``, the
+    same lattice used by :func:`_primitive_voxel_set`.
+    """
+    voxel = mesh.voxelized(pitch=voxel_pitch)
+    if fill:
+        try:
+            voxel = voxel.fill()
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Voxel fill failed (%s); using surface voxels", e)
+    coords = np.argwhere(voxel.matrix) * voxel_pitch + voxel.translation
+    return set(map(tuple, np.round(coords / voxel_pitch).astype(int)))
+
+
+def compute_mesh_primitive_iou(mesh, primitive_mesh, voxel_pitch=None,
+                               fill=True):
     """Compute intersection over union between mesh and primitive using voxelization.
 
     Parameters
@@ -21,6 +53,11 @@ def compute_mesh_primitive_iou(mesh, primitive_mesh, voxel_pitch=None):
         Primitive approximation mesh.
     voxel_pitch : float, optional
         Voxel size for discretization. If None, automatically determined.
+    fill : bool, optional
+        If True (default), solid-fill both voxelizations so the IoU reflects
+        volumetric overlap. If False, compare surface voxels only (the old
+        behavior), which systematically under-counts overlap for solid
+        primitives versus thin surface meshes.
 
     Returns
     -------
@@ -36,23 +73,8 @@ def compute_mesh_primitive_iou(mesh, primitive_mesh, voxel_pitch=None):
     if voxel_pitch is None:
         voxel_pitch = max_dim / 32
 
-    mesh_voxel = mesh.voxelized(pitch=voxel_pitch)
-    prim_voxel = primitive_mesh.voxelized(pitch=voxel_pitch)
-
-    mesh_grid = mesh_voxel.matrix
-    prim_grid = prim_voxel.matrix
-
-    mesh_origin = mesh_voxel.translation
-    prim_origin = prim_voxel.translation
-
-    mesh_indices = np.argwhere(mesh_grid)
-    prim_indices = np.argwhere(prim_grid)
-
-    mesh_coords = mesh_indices * voxel_pitch + mesh_origin
-    prim_coords = prim_indices * voxel_pitch + prim_origin
-
-    mesh_set = set(map(tuple, np.round(mesh_coords / voxel_pitch).astype(int)))
-    prim_set = set(map(tuple, np.round(prim_coords / voxel_pitch).astype(int)))
+    mesh_set = _voxel_coord_set(mesh, voxel_pitch, fill=fill)
+    prim_set = _voxel_coord_set(primitive_mesh, voxel_pitch, fill=fill)
 
     intersection_count = len(mesh_set & prim_set)
     union_count = len(mesh_set | prim_set)
@@ -68,23 +90,40 @@ def compute_mesh_primitive_iou(mesh, primitive_mesh, voxel_pitch=None):
     return iou
 
 
-def fit_box_to_mesh(mesh):
+def fit_box_to_mesh(mesh, oriented=False):
     """Fit a box primitive to a mesh.
 
     Parameters
     ----------
     mesh : trimesh.Trimesh
         Input mesh to fit a box to.
+    oriented : bool, optional
+        If True, fit an oriented bounding box (OBB) using
+        ``trimesh.bounds.oriented_bounds``, returning a real (possibly
+        non-identity) rotation. If False (default), fit an axis-aligned
+        bounding box (AABB) with identity rotation.
 
     Returns
     -------
     extents : np.ndarray
-        Box dimensions [x, y, z].
+        Box dimensions [x, y, z] (in the box's own frame).
     center : np.ndarray
-        Center position of the box.
+        Center position of the box (in the mesh frame).
     rotation : np.ndarray
-        Rotation matrix (3x3) of the box. Currently returns identity.
+        Rotation matrix (3x3) of the box in the mesh frame. Identity when
+        ``oriented`` is False.
     """
+    if oriented:
+        trimesh = _lazy_trimesh()
+        # to_origin maps the mesh so the OBB is centered at the origin and
+        # axis-aligned. The box pose in the mesh frame is therefore its
+        # inverse.
+        to_origin, extents = trimesh.bounds.oriented_bounds(mesh)
+        transform = np.linalg.inv(to_origin)
+        rotation = transform[:3, :3].copy()
+        center = transform[:3, 3].copy()
+        return np.asarray(extents, dtype=float), center, rotation
+
     bounds = mesh.bounds
     center = (bounds[0] + bounds[1]) / 2
     extents = bounds[1] - bounds[0]
@@ -116,16 +155,18 @@ def fit_sphere_to_mesh(mesh):
     return radius, center
 
 
-def fit_cylinder_to_mesh(mesh):
+def fit_cylinder_to_mesh(mesh, oriented=False):
     """Fit a cylinder primitive to a mesh.
-
-    This function analyzes the mesh bounding box and assumes the smallest
-    dimension is the cylinder's height (axis direction).
 
     Parameters
     ----------
     mesh : trimesh.Trimesh
         Input mesh to fit a cylinder to.
+    oriented : bool, optional
+        If True, fit a minimum-volume cylinder with an arbitrary axis
+        direction using ``trimesh.bounds.minimum_cylinder``. If False
+        (default), analyze the mesh bounding box and assume the smallest
+        dimension is the cylinder's height (an axis-aligned axis).
 
     Returns
     -------
@@ -138,6 +179,18 @@ def fit_cylinder_to_mesh(mesh):
     center : np.ndarray
         Center position of the cylinder.
     """
+    if oriented:
+        trimesh = _lazy_trimesh()
+        result = trimesh.bounds.minimum_cylinder(mesh)
+        transform = np.asarray(result['transform'], dtype=float)
+        radius = float(result['radius'])
+        height = float(result['height'])
+        # trimesh cylinders are defined along the local Z-axis; the fitted
+        # axis direction is that Z-axis transformed into the mesh frame.
+        axis = transform[:3, 2].copy()
+        center = transform[:3, 3].copy()
+        return radius, height, axis, center
+
     bounds = mesh.bounds
     center = (bounds[0] + bounds[1]) / 2
     dimensions = bounds[1] - bounds[0]
@@ -213,6 +266,11 @@ def create_primitive_mesh(primitive_params):
     if prim_type == 'box':
         extents = primitive_params['extents']
         mesh = trimesh.creation.box(extents=extents)
+        rotation = primitive_params.get('rotation', None)
+        if rotation is not None and not np.allclose(rotation, np.eye(3)):
+            transform = np.eye(4)
+            transform[:3, :3] = rotation
+            mesh.apply_transform(transform)
         mesh.apply_translation(center)
         return mesh
 
@@ -252,16 +310,146 @@ def create_primitive_mesh(primitive_params):
         raise ValueError(f"Unknown primitive type: {prim_type}")
 
 
-def estimate_best_primitive(mesh):
+def _fit_type_variants(mesh, primitive_type, oriented=None):
+    """Build candidate fits for one primitive type.
+
+    ``oriented`` selects which orientation variants to build for box/cylinder:
+    ``None`` builds both an axis-aligned and an oriented (OBB / minimum-volume)
+    fit so the caller can keep whichever scores better; ``True`` builds only
+    the oriented fit; ``False`` builds only the axis-aligned fit. Spheres and
+    capsules yield a single candidate regardless. Failing fitters are skipped
+    rather than raising.
+    """
+    orientations = (False, True) if oriented is None else (bool(oriented),)
+    variants = []
+    if primitive_type == 'box':
+        for o in orientations:
+            try:
+                extents, center, rotation = fit_box_to_mesh(mesh, oriented=o)
+                variants.append({'type': 'box', 'extents': extents,
+                                 'center': center, 'rotation': rotation})
+            except Exception as e:  # noqa: BLE001
+                logger.debug("box fit (oriented=%s) failed: %s", o, e)
+    elif primitive_type == 'cylinder':
+        for o in orientations:
+            try:
+                radius, height, axis, center = fit_cylinder_to_mesh(
+                    mesh, oriented=o)
+                variants.append({'type': 'cylinder', 'radius': radius,
+                                 'height': height, 'axis': axis,
+                                 'center': center})
+            except Exception as e:  # noqa: BLE001
+                logger.debug("cylinder fit (oriented=%s) failed: %s", o, e)
+    elif primitive_type == 'sphere':
+        radius, center = fit_sphere_to_mesh(mesh)
+        variants.append({'type': 'sphere', 'radius': radius, 'center': center})
+    elif primitive_type == 'capsule':
+        radius, height, axis, center = fit_capsule_to_mesh(mesh)
+        variants.append({'type': 'capsule', 'radius': radius, 'height': height,
+                         'axis': axis, 'center': center})
+    else:
+        raise ValueError(f"Unknown primitive type: {primitive_type}")
+    return variants
+
+
+def _primitive_voxel_set(params, pitch):
+    """Integer voxel keys a primitive occupies, via analytic containment.
+
+    Enumerate the integer lattice over the primitive's bounding box and test
+    each voxel center (``key * pitch``) for containment analytically -- no
+    voxelization. ``margin`` (half a voxel) dilates the primitive to match the
+    outward inflation of trimesh surface voxelization, keeping the occupancy
+    discretization-consistent with :func:`_voxel_coord_set`.
+    """
+    prim_type = params['type']
+    center = np.asarray(params['center'], dtype=float)
+    margin = pitch / 2.0
+    bounds = create_primitive_mesh(params).bounds
+    lo = np.floor((bounds[0] - margin) / pitch).astype(int)
+    hi = np.ceil((bounds[1] + margin) / pitch).astype(int)
+    ranges = [np.arange(lo[i], hi[i] + 1) for i in range(3)]
+    if any(r.size == 0 for r in ranges):
+        return set()
+    grid = np.stack([g.ravel() for g in np.meshgrid(*ranges, indexing='ij')],
+                    axis=1)
+    d = grid * pitch - center
+    if prim_type == 'box':
+        rotation = np.asarray(params.get('rotation', np.eye(3)), dtype=float)
+        half = np.asarray(params['extents'], dtype=float) / 2.0 + margin
+        inside = np.all(np.abs(d @ rotation) <= half, axis=1)
+    elif prim_type == 'sphere':
+        r = float(params['radius']) + margin
+        inside = np.sum(d * d, axis=1) <= r * r
+    elif prim_type in ('cylinder', 'capsule'):
+        r = float(params['radius'])
+        h = float(params['height'])
+        if prim_type == 'capsule':
+            h = h + 2.0 * r
+        axis = np.asarray(params['axis'], dtype=float)
+        axis = axis / np.linalg.norm(axis)
+        along = d @ axis
+        inside = (np.abs(along) <= h / 2.0 + margin) \
+            & (np.sum(d * d, axis=1) - along * along <= (r + margin) ** 2)
+    else:
+        raise ValueError(f"Unknown primitive type: {prim_type}")
+    return set(map(tuple, grid[inside]))
+
+
+def _select_best_primitive(mesh, candidates):
+    """Return the candidate params with the highest solid voxel IoU, and score.
+
+    The mesh is voxel-filled once; each candidate is scored by analytic
+    containment on the same lattice (no per-candidate voxelization), which is
+    where the bulk of the cost used to be.
+    """
+    if not candidates:
+        raise ValueError("No candidate primitives to select from")
+    if len(candidates) == 1:
+        return candidates[0], 0.0
+
+    max_dim = float(np.max(mesh.bounds[1] - mesh.bounds[0]))
+    if max_dim <= 0:
+        return candidates[0], 0.0
+    pitch = max_dim / 32.0
+
+    mesh_set = _voxel_coord_set(mesh, pitch, fill=True)
+    if not mesh_set:
+        return candidates[0], 0.0
+
+    best_params = None
+    best_score = -1.0
+    for params in candidates:
+        try:
+            prim_set = _primitive_voxel_set(params, pitch)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("scoring %s failed: %s", params.get('type'), e)
+            continue
+        union = len(mesh_set | prim_set)
+        score = len(mesh_set & prim_set) / union if union else 0.0
+        logger.debug("candidate %s IoU=%.4f", params['type'], score)
+        if score > best_score:
+            best_score = score
+            best_params = params
+
+    if best_params is None:
+        return candidates[0], 0.0
+    return best_params, best_score
+
+
+def estimate_best_primitive(mesh, oriented=None):
     """Estimate which primitive shape best fits a mesh using volume IoU.
 
-    This function tries fitting box, cylinder, and sphere primitives and
-    selects the one with the highest intersection over union (IoU) ratio.
+    Fits box, cylinder, and sphere candidates and returns the type of the one
+    with the highest solid voxel intersection-over-union.
 
     Parameters
     ----------
     mesh : trimesh.Trimesh
         Input mesh to analyze.
+    oriented : bool or None, optional
+        Orientation policy for box/cylinder candidates, see
+        :func:`fit_primitive_to_mesh`. ``None`` (default) considers both
+        axis-aligned and oriented fits.
 
     Returns
     -------
@@ -279,55 +467,45 @@ def estimate_best_primitive(mesh):
     else:
         combined_mesh = mesh
 
-    candidates = []
+    candidates = (_fit_type_variants(combined_mesh, 'box', oriented)
+                  + _fit_type_variants(combined_mesh, 'cylinder', oriented)
+                  + _fit_type_variants(combined_mesh, 'sphere', oriented))
+    best_params, best_score = _select_best_primitive(combined_mesh, candidates)
 
-    try:
-        box_params = fit_primitive_to_mesh(combined_mesh, primitive_type='box')
-        box_mesh = create_primitive_mesh(box_params)
-        box_iou = compute_mesh_primitive_iou(combined_mesh, box_mesh)
-        candidates.append(('box', box_iou))
-        logger.debug("Box IoU: %.4f", box_iou)
-    except Exception as e:
-        logger.debug("Box fitting failed: %s", e)
-        candidates.append(('box', 0.0))
+    logger.info("Best primitive: %s (IoU: %.4f)",
+                best_params['type'], best_score)
 
-    try:
-        sphere_params = fit_primitive_to_mesh(combined_mesh, primitive_type='sphere')
-        sphere_mesh = create_primitive_mesh(sphere_params)
-        sphere_iou = compute_mesh_primitive_iou(combined_mesh, sphere_mesh)
-        candidates.append(('sphere', sphere_iou))
-        logger.debug("Sphere IoU: %.4f", sphere_iou)
-    except Exception as e:
-        logger.debug("Sphere fitting failed: %s", e)
-        candidates.append(('sphere', 0.0))
-
-    try:
-        cylinder_params = fit_primitive_to_mesh(combined_mesh, primitive_type='cylinder')
-        cylinder_mesh = create_primitive_mesh(cylinder_params)
-        cylinder_iou = compute_mesh_primitive_iou(combined_mesh, cylinder_mesh)
-        candidates.append(('cylinder', cylinder_iou))
-        logger.debug("Cylinder IoU: %.4f", cylinder_iou)
-    except Exception as e:
-        logger.debug("Cylinder fitting failed: %s", e)
-        candidates.append(('cylinder', 0.0))
-
-    best_primitive, best_score = max(candidates, key=lambda x: x[1])
-
-    logger.info("Best primitive: %s (IoU: %.4f)", best_primitive, best_score)
-
-    return best_primitive, best_score
+    return best_params['type'], best_score
 
 
-def fit_primitive_to_mesh(mesh, primitive_type=None):
+def fit_primitive_to_mesh(mesh, primitive_type=None, oriented=None):
     """Fit a primitive shape to a mesh.
+
+    This is the primary public entry point for per-mesh primitive fitting.
+    It operates purely on a :class:`trimesh.Trimesh` (or a list of them) and
+    returns a plain parameter dictionary, with no file or URDF I/O, so it can
+    be composed into other pipelines.
 
     Parameters
     ----------
-    mesh : trimesh.Trimesh
-        Input mesh to fit a primitive to.
+    mesh : trimesh.Trimesh or list of trimesh.Trimesh
+        Input mesh to fit a primitive to. A list is concatenated first.
     primitive_type : str, optional
         Type of primitive to fit: 'box', 'cylinder', 'sphere', or 'capsule'.
-        If None, automatically estimates the best primitive type.
+        If None, automatically selects the best-fitting type across box,
+        cylinder, and sphere (see :func:`estimate_best_primitive`).
+    oriented : bool or None, optional
+        Orientation policy for box and cylinder fits:
+
+        - ``None`` (default): produce both an axis-aligned and an oriented
+          (OBB / minimum-volume) candidate and keep whichever has the higher
+          solid voxel IoU -- the tighter fit when it genuinely helps, the
+          conservative axis-aligned fit otherwise, without the caller having
+          to choose.
+        - ``True``: force the oriented fit (real OBB rotation / arbitrary
+          cylinder axis).
+        - ``False``: force the axis-aligned fit (identity box rotation /
+          axis-aligned cylinder axis).
 
     Returns
     -------
@@ -339,6 +517,11 @@ def fit_primitive_to_mesh(mesh, primitive_type=None):
         - For 'cylinder': 'radius', 'height', 'axis'
         - For 'sphere': 'radius'
         - For 'capsule': 'radius', 'height', 'axis'
+
+    See Also
+    --------
+    primitive_params_to_origin : Convert the returned params into a URDF
+        ``<origin>`` (xyz, rpy) pair.
     """
     trimesh = _lazy_trimesh()
 
@@ -350,41 +533,64 @@ def fit_primitive_to_mesh(mesh, primitive_type=None):
         combined_mesh = mesh
 
     if primitive_type is None:
-        primitive_type, _ = estimate_best_primitive(combined_mesh)
-        logger.info("Auto-detected primitive type: %s", primitive_type)
-
-    if primitive_type == 'box':
-        extents, center, rotation = fit_box_to_mesh(combined_mesh)
-        return {
-            'type': 'box',
-            'extents': extents,
-            'center': center,
-            'rotation': rotation
-        }
-    elif primitive_type == 'sphere':
-        radius, center = fit_sphere_to_mesh(combined_mesh)
-        return {
-            'type': 'sphere',
-            'radius': radius,
-            'center': center
-        }
-    elif primitive_type == 'cylinder':
-        radius, height, axis, center = fit_cylinder_to_mesh(combined_mesh)
-        return {
-            'type': 'cylinder',
-            'radius': radius,
-            'height': height,
-            'axis': axis,
-            'center': center
-        }
-    elif primitive_type == 'capsule':
-        radius, height, axis, center = fit_capsule_to_mesh(combined_mesh)
-        return {
-            'type': 'capsule',
-            'radius': radius,
-            'height': height,
-            'axis': axis,
-            'center': center
-        }
+        candidates = (_fit_type_variants(combined_mesh, 'box', oriented)
+                      + _fit_type_variants(combined_mesh, 'cylinder', oriented)
+                      + _fit_type_variants(combined_mesh, 'sphere', oriented))
     else:
-        raise ValueError(f"Unknown primitive type: {primitive_type}")
+        candidates = _fit_type_variants(combined_mesh, primitive_type, oriented)
+
+    best_params, _ = _select_best_primitive(combined_mesh, candidates)
+    logger.info("Fitted primitive: %s", best_params['type'])
+    return best_params
+
+
+def primitive_params_to_origin(primitive_params):
+    """Compute the URDF ``<origin>`` for a fitted primitive.
+
+    Given the parameter dictionary returned by :func:`fit_primitive_to_mesh`,
+    return the ``(xyz, rpy)`` origin of the primitive expressed in the frame
+    of the mesh that was fitted. This decouples the origin computation from
+    any XML / indentation handling, so consumers can emit their own
+    ``<geometry>`` element and only need the params plus this origin.
+
+    Parameters
+    ----------
+    primitive_params : dict
+        Primitive parameters from :func:`fit_primitive_to_mesh`.
+
+    Returns
+    -------
+    xyz : np.ndarray
+        Translation [x, y, z] of the primitive origin (the fitted center).
+    rpy : np.ndarray
+        Roll-pitch-yaw [roll, pitch, yaw] of the primitive origin, in the
+        URDF fixed-axis convention.
+
+    Notes
+    -----
+    - For 'box', the rotation is taken from ``params['rotation']`` (identity
+      for an axis-aligned fit, a real rotation for an oriented fit).
+    - For 'sphere', the rotation is identity (spheres are isotropic).
+    - For 'cylinder' and 'capsule', the rotation aligns the primitive's
+      local Z-axis with the fitted ``axis`` direction.
+    """
+    from skrobot.coordinates.math import matrix2rpy
+    from skrobot.coordinates.math import rotation_matrix_z_to_axis
+
+    prim_type = primitive_params['type']
+    xyz = np.asarray(primitive_params['center'], dtype=float)
+
+    if prim_type == 'box':
+        rotation = np.asarray(
+            primitive_params.get('rotation', np.eye(3)), dtype=float)
+        rpy = matrix2rpy(rotation)
+    elif prim_type == 'sphere':
+        rpy = np.zeros(3)
+    elif prim_type in ('cylinder', 'capsule'):
+        axis = np.asarray(primitive_params['axis'], dtype=float)
+        rotation = rotation_matrix_z_to_axis(axis)
+        rpy = matrix2rpy(rotation)
+    else:
+        raise ValueError(f"Unknown primitive type: {prim_type}")
+
+    return xyz, np.asarray(rpy, dtype=float)

--- a/tests/skrobot_tests/utils_tests/test_primitive_fitting.py
+++ b/tests/skrobot_tests/utils_tests/test_primitive_fitting.py
@@ -1,0 +1,191 @@
+import unittest
+
+import numpy as np
+import trimesh
+
+from skrobot.coordinates.math import rpy_matrix
+from skrobot.utils.primitive_fitting import fit_primitive_to_mesh
+from skrobot.utils.primitive_fitting import primitive_params_to_origin
+
+
+def _rotated_box(extents, roll, pitch, yaw, center):
+    """Create a box mesh rotated by (roll, pitch, yaw) and translated."""
+    mesh = trimesh.creation.box(extents=extents)
+    rotation = rpy_matrix(yaw, pitch, roll)
+    transform = np.eye(4)
+    transform[:3, :3] = rotation
+    transform[:3, 3] = center
+    mesh.apply_transform(transform)
+    return mesh, rotation
+
+
+class TestFitBox(unittest.TestCase):
+
+    def test_rotated_box_auto_selects_oriented_fit(self):
+        # A clearly rotated box: the oriented candidate is much tighter than
+        # the axis-aligned one, so auto-selection must return it.
+        true_extents = np.array([0.30, 0.12, 0.06])
+        center = np.array([0.5, -0.2, 1.0])
+        mesh, _ = _rotated_box(
+            true_extents, roll=0.3, pitch=-0.4, yaw=0.5, center=center)
+
+        params = fit_primitive_to_mesh(mesh, primitive_type='box')
+
+        self.assertEqual(params['type'], 'box')
+        # Extents match the true box dimensions (OBB order is arbitrary).
+        np.testing.assert_allclose(
+            np.sort(params['extents']), np.sort(true_extents), atol=1e-6)
+        np.testing.assert_allclose(params['center'], center, atol=1e-6)
+        # A proper, non-identity rotation was recovered.
+        self.assertFalse(np.allclose(params['rotation'], np.eye(3)))
+        self.assertAlmostEqual(
+            np.linalg.det(params['rotation']), 1.0, places=6)
+        np.testing.assert_allclose(
+            params['rotation'] @ params['rotation'].T, np.eye(3), atol=1e-6)
+
+    def test_axis_aligned_box_recovers_extents(self):
+        true_extents = np.array([0.30, 0.12, 0.06])
+        center = np.array([0.5, -0.2, 1.0])
+        mesh = trimesh.creation.box(extents=true_extents)
+        mesh.apply_translation(center)
+
+        params = fit_primitive_to_mesh(mesh, primitive_type='box')
+
+        np.testing.assert_allclose(
+            np.sort(params['extents']), np.sort(true_extents), atol=1e-6)
+        np.testing.assert_allclose(params['center'], center, atol=1e-6)
+
+    def test_oriented_flag_forces_orientation(self):
+        # Same rotated box, forced axis-aligned vs forced oriented.
+        true_extents = np.array([0.30, 0.12, 0.06])
+        center = np.array([0.5, -0.2, 1.0])
+        mesh, _ = _rotated_box(
+            true_extents, roll=0.3, pitch=-0.4, yaw=0.5, center=center)
+
+        aabb = fit_primitive_to_mesh(
+            mesh, primitive_type='box', oriented=False)
+        obb = fit_primitive_to_mesh(
+            mesh, primitive_type='box', oriented=True)
+
+        # oriented=False -> axis-aligned (identity rotation, loose extents).
+        np.testing.assert_allclose(aabb['rotation'], np.eye(3), atol=1e-9)
+        # oriented=True -> real OBB recovering the true extents / rotation.
+        self.assertFalse(np.allclose(obb['rotation'], np.eye(3)))
+        np.testing.assert_allclose(
+            np.sort(obb['extents']), np.sort(true_extents), atol=1e-6)
+
+
+class TestFitCylinder(unittest.TestCase):
+
+    def test_tilted_cylinder_auto_recovers_axis(self):
+        radius = 0.1
+        height = 0.5
+        axis = np.array([0.3, 0.4, np.sqrt(1.0 - 0.25)])
+        axis /= np.linalg.norm(axis)
+
+        mesh = trimesh.creation.cylinder(radius=radius, height=height)
+        z = np.array([0.0, 0.0, 1.0])
+        v = np.cross(z, axis)
+        s = np.linalg.norm(v)
+        c = np.dot(z, axis)
+        skew = np.array([[0, -v[2], v[1]],
+                         [v[2], 0, -v[0]],
+                         [-v[1], v[0], 0]])
+        rotation = np.eye(3) + skew + skew @ skew * ((1 - c) / (s ** 2))
+        transform = np.eye(4)
+        transform[:3, :3] = rotation
+        transform[:3, 3] = np.array([0.2, 0.3, 0.4])
+        mesh.apply_transform(transform)
+
+        params = fit_primitive_to_mesh(mesh, primitive_type='cylinder')
+
+        self.assertEqual(params['type'], 'cylinder')
+        self.assertAlmostEqual(params['radius'], radius, places=2)
+        self.assertAlmostEqual(params['height'], height, places=2)
+        fitted_axis = params['axis'] / np.linalg.norm(params['axis'])
+        # Axis is recovered up to sign.
+        self.assertAlmostEqual(abs(np.dot(fitted_axis, axis)), 1.0, places=2)
+
+
+class TestAutoTypeSelection(unittest.TestCase):
+
+    def test_boxy_mesh_selects_box(self):
+        mesh = trimesh.creation.box(extents=[0.3, 0.12, 0.06])
+        params = fit_primitive_to_mesh(mesh)
+        self.assertEqual(params['type'], 'box')
+
+    def test_round_mesh_selects_sphere(self):
+        mesh = trimesh.creation.icosphere(radius=0.2, subdivisions=3)
+        params = fit_primitive_to_mesh(mesh)
+        self.assertEqual(params['type'], 'sphere')
+
+    def test_cylindrical_mesh_selects_cylinder(self):
+        mesh = trimesh.creation.cylinder(radius=0.1, height=0.6)
+        params = fit_primitive_to_mesh(mesh)
+        self.assertEqual(params['type'], 'cylinder')
+
+
+class TestPrimitiveParamsToOrigin(unittest.TestCase):
+
+    def test_box_roundtrips_center_and_rpy(self):
+        roll, pitch, yaw = 0.2, 0.35, -0.6
+        rotation = rpy_matrix(yaw, pitch, roll)
+        center = np.array([1.0, 2.0, 3.0])
+        params = {
+            'type': 'box',
+            'center': center,
+            'extents': np.array([1.0, 2.0, 3.0]),
+            'rotation': rotation,
+        }
+
+        xyz, rpy = primitive_params_to_origin(params)
+
+        np.testing.assert_allclose(xyz, center)
+        np.testing.assert_allclose(rpy, [roll, pitch, yaw], atol=1e-9)
+        # rpy reconstructs the original rotation.
+        np.testing.assert_allclose(
+            rpy_matrix(rpy[2], rpy[1], rpy[0]), rotation, atol=1e-9)
+
+    def test_oriented_box_origin_reconstructs_rotation(self):
+        true_extents = np.array([0.30, 0.12, 0.06])
+        center = np.array([0.5, -0.2, 1.0])
+        mesh, _ = _rotated_box(
+            true_extents, roll=0.3, pitch=-0.4, yaw=0.5, center=center)
+        params = fit_primitive_to_mesh(mesh, primitive_type='box')
+
+        xyz, rpy = primitive_params_to_origin(params)
+
+        np.testing.assert_allclose(xyz, params['center'])
+        np.testing.assert_allclose(
+            rpy_matrix(rpy[2], rpy[1], rpy[0]), params['rotation'], atol=1e-6)
+
+    def test_sphere_has_zero_rotation(self):
+        center = np.array([1.0, 2.0, 3.0])
+        params = {'type': 'sphere', 'center': center, 'radius': 0.5}
+
+        xyz, rpy = primitive_params_to_origin(params)
+
+        np.testing.assert_allclose(xyz, center)
+        np.testing.assert_allclose(rpy, np.zeros(3))
+
+    def test_cylinder_axis_maps_to_z(self):
+        axis = np.array([0.0, 1.0, 0.0])
+        center = np.array([0.1, 0.2, 0.3])
+        params = {
+            'type': 'cylinder',
+            'center': center,
+            'radius': 0.1,
+            'height': 0.5,
+            'axis': axis,
+        }
+
+        xyz, rpy = primitive_params_to_origin(params)
+
+        np.testing.assert_allclose(xyz, center)
+        rotation = rpy_matrix(rpy[2], rpy[1], rpy[0])
+        # The primitive local Z-axis is aligned with the fitted axis.
+        np.testing.assert_allclose(rotation @ [0, 0, 1], axis, atol=1e-9)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Expose per-mesh primitive fitting so external tools can turn a trimesh into box/cylinder/sphere geometry without URDF file I/O:

- Make fit_primitive_to_mesh a public API and add primitive_params_to_origin, which computes the URDF <origin> (xyz, rpy) from fitted params.
- oriented=None (default) picks the better of axis-aligned / oriented (OBB / minimum-volume) fits by solid voxel IoU; oriented=True/False force one. Threaded through convert_meshes_to_primitives and its CLI.

Add unit tests.
<img width="1940" height="1100" alt="スクリーンショット 2026-07-06 144309" src="https://github.com/user-attachments/assets/5eec17dd-4f8c-45f6-9817-1ea4305fca7f" />
