### PR TITLE
Add coordinate-math helpers: vector alignment, xyz-rpy and relative t…

### DIFF
--- a/skrobot/coordinates/__init__.py
+++ b/skrobot/coordinates/__init__.py
@@ -19,11 +19,17 @@ from skrobot.coordinates.math import look_at_rotation
 from skrobot.coordinates.math import make_matrix
 from skrobot.coordinates.math import manipulability
 from skrobot.coordinates.math import matrix2quaternion
+from skrobot.coordinates.math import matrix2xyzrpy
+from skrobot.coordinates.math import matrix_relative
 from skrobot.coordinates.math import normalize_mask
 from skrobot.coordinates.math import normalize_vector
 from skrobot.coordinates.math import quaternion2rpy
+from skrobot.coordinates.math import quaternion_from_vectors
 from skrobot.coordinates.math import rotation_geodesic_distance
+from skrobot.coordinates.math import rotation_matrix_from_vectors
 from skrobot.coordinates.math import rotation_matrix_to_axis_angle_vector
+from skrobot.coordinates.math import rpy2homogeneous
 from skrobot.coordinates.math import rpy_angle
 from skrobot.coordinates.math import rpy_matrix
 from skrobot.coordinates.math import sr_inverse
+from skrobot.coordinates.math import xyzrpy2matrix

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -1195,6 +1195,44 @@ def rpy2matrix(roll, pitch, yaw):
     return rpy_matrix(yaw, pitch, roll)
 
 
+def rpy2homogeneous(roll, pitch, yaw):
+    """Create a 4x4 homogeneous transform (rotation only) from roll/pitch/yaw.
+
+    Convenience wrapper that embeds :func:`rpy2matrix` in a 4x4 homogeneous
+    matrix with zero translation.  ``rpy`` is the extrinsic X-Y-Z (fixed-axis)
+    roll, pitch, yaw triple, i.e. ``R = Rz(yaw) @ Ry(pitch) @ Rx(roll)`` -- the
+    same convention as URDF ``<origin rpy="...">``.  Use :func:`xyzrpy2matrix`
+    when you also need a translation, and :func:`matrix2xyzrpy` to invert.
+
+    Parameters
+    ----------
+    roll : float
+        Rotation around the X-axis in radians.
+    pitch : float
+        Rotation around the Y-axis in radians.
+    yaw : float
+        Rotation around the Z-axis in radians.
+
+    Returns
+    -------
+    matrix : numpy.ndarray
+        4x4 homogeneous transformation matrix.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skrobot.coordinates.math import rpy2homogeneous
+    >>> T = rpy2homogeneous(0.1, 0.2, 0.3)
+    >>> T.shape
+    (4, 4)
+    >>> np.allclose(T[:3, 3], 0)
+    True
+    """
+    matrix = np.eye(4)
+    matrix[:3, :3] = rpy2matrix(roll, pitch, yaw)
+    return matrix
+
+
 def normalize_vector(v, ord=2):
     """Return normalized vector
 
@@ -2899,6 +2937,161 @@ def look_at_rotation(camera_pos, target=None, up=None, return_matrix=True):
     if return_matrix:
         return R
     return rotation_matrix_to_axis_angle_vector(R)
+
+
+def rotation_matrix_from_vectors(a, b):
+    """Return the 3x3 rotation matrix that rotates direction ``a`` onto ``b``.
+
+    Computes the shortest-arc rotation about the axis ``a x b``.  The inputs
+    need not be unit vectors; only their directions matter.  Degenerate
+    directions are handled explicitly instead of producing ``nan``:
+
+    - ``a`` parallel to ``b``      -> identity
+    - ``a`` anti-parallel to ``b`` -> a 180 deg rotation about an arbitrary
+      axis perpendicular to ``a``
+
+    Parameters
+    ----------
+    a : list or tuple or numpy.ndarray
+        source direction, shape (3,), nonzero.
+    b : list or tuple or numpy.ndarray
+        target direction, shape (3,), nonzero.
+
+    Returns
+    -------
+    matrix : numpy.ndarray
+        3x3 rotation matrix ``R`` such that
+        ``R.dot(a / norm(a))`` equals ``b / norm(b)``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skrobot.coordinates.math import rotation_matrix_from_vectors
+    >>> R = rotation_matrix_from_vectors([1, 0, 0], [0, 1, 0])
+    >>> np.allclose(R.dot([1, 0, 0]), [0, 1, 0])
+    True
+    """
+    a = normalize_vector(np.array(a, dtype=np.float64))
+    b = normalize_vector(np.array(b, dtype=np.float64))
+    axis = np.cross(a, b)
+    axis_norm = np.linalg.norm(axis)
+    dot = float(np.clip(np.dot(a, b), -1.0, 1.0))
+    if axis_norm < 1e-12:
+        if dot > 0.0:  # already aligned
+            return np.eye(3)
+        # anti-parallel: rotate 180 deg about any axis perpendicular to a
+        perp = np.cross(a, np.array([1.0, 0.0, 0.0]))
+        if np.linalg.norm(perp) < 1e-12:
+            perp = np.cross(a, np.array([0.0, 1.0, 0.0]))
+        return rotation_matrix(pi, normalize_vector(perp))
+    return rotation_matrix(acos(dot), axis / axis_norm,
+                           skip_normalization=True)
+
+
+def quaternion_from_vectors(a, b):
+    """Return the ``[w, x, y, z]`` quaternion rotating ``a`` onto ``b``.
+
+    Shortest-arc rotation; see :func:`rotation_matrix_from_vectors` for the
+    degenerate-direction handling.
+
+    Parameters
+    ----------
+    a : list or tuple or numpy.ndarray
+        source direction, shape (3,), nonzero.
+    b : list or tuple or numpy.ndarray
+        target direction, shape (3,), nonzero.
+
+    Returns
+    -------
+    quaternion : numpy.ndarray
+        quaternion ``[w, x, y, z]``.
+    """
+    return matrix2quaternion(rotation_matrix_from_vectors(a, b))
+
+
+def matrix2xyzrpy(matrix):
+    """Split a 4x4 homogeneous transform into translation and roll-pitch-yaw.
+
+    ``rpy`` uses the URDF convention (extrinsic X-Y-Z, ``R = Rz @ Ry @ Rx``),
+    matching :func:`matrix2rpy` and :func:`xyzrpy2matrix`.
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray
+        4x4 homogeneous transformation matrix.
+
+    Returns
+    -------
+    xyz : numpy.ndarray
+        translation, shape (3,).
+    rpy : numpy.ndarray
+        ``[roll, pitch, yaw]`` in radians.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skrobot.coordinates.math import matrix2xyzrpy, xyzrpy2matrix
+    >>> T = xyzrpy2matrix([1, 2, 3], [0.1, 0.2, 0.3])
+    >>> xyz, rpy = matrix2xyzrpy(T)
+    >>> np.allclose(xyz, [1, 2, 3]) and np.allclose(rpy, [0.1, 0.2, 0.3])
+    True
+    """
+    matrix = np.array(matrix, dtype=np.float64)
+    return matrix[:3, 3].copy(), matrix2rpy(matrix[:3, :3])
+
+
+def xyzrpy2matrix(xyz, rpy):
+    """Build a 4x4 homogeneous transform from translation and roll-pitch-yaw.
+
+    Inverse of :func:`matrix2xyzrpy`; ``rpy`` is the URDF convention
+    (``R = Rz @ Ry @ Rx``).
+
+    Parameters
+    ----------
+    xyz : list or tuple or numpy.ndarray
+        translation, shape (3,).
+    rpy : list or tuple or numpy.ndarray
+        ``[roll, pitch, yaw]`` in radians.
+
+    Returns
+    -------
+    matrix : numpy.ndarray
+        4x4 homogeneous transformation matrix.
+    """
+    roll, pitch, yaw = rpy
+    matrix = np.eye(4)
+    matrix[:3, :3] = rpy2matrix(roll, pitch, yaw)
+    matrix[:3, 3] = np.array(xyz, dtype=np.float64)
+    return matrix
+
+
+def matrix_relative(parent, child):
+    """Express one homogeneous transform relative to another.
+
+    Returns ``inv(parent) @ child`` -- the pose of ``child`` seen from the
+    ``parent`` frame, where both are 4x4 matrices in a common frame.  The
+    inverse is built from the rotation transpose + translation (assuming a
+    rigid transform), so no general ``np.linalg.inv`` on the 4x4 is needed.
+
+    Parameters
+    ----------
+    parent : numpy.ndarray
+        4x4 homogeneous transform of the reference frame.
+    child : numpy.ndarray
+        4x4 homogeneous transform to re-express.
+
+    Returns
+    -------
+    matrix : numpy.ndarray
+        4x4 homogeneous transform of ``child`` in ``parent``'s frame.
+    """
+    parent = np.array(parent, dtype=np.float64)
+    child = np.array(child, dtype=np.float64)
+    rot = parent[:3, :3]
+    inv = np.eye(4)
+    inv[:3, :3] = rot.T
+    inv[:3, 3] = -rot.T.dot(parent[:3, 3])
+    return inv.dot(child)
 
 
 inverse_rodrigues = rotation_angle

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -17,13 +17,16 @@ from skrobot.coordinates.math import interpolate_rotation_matrices
 from skrobot.coordinates.math import invert_yaw_pitch_roll
 from skrobot.coordinates.math import matrix2quaternion
 from skrobot.coordinates.math import matrix2rpy
+from skrobot.coordinates.math import matrix2xyzrpy
 from skrobot.coordinates.math import matrix2ypr
+from skrobot.coordinates.math import matrix_relative
 from skrobot.coordinates.math import normalize_vector
 from skrobot.coordinates.math import quaternion2matrix
 from skrobot.coordinates.math import quaternion2rpy
 from skrobot.coordinates.math import quaternion_conjugate
 from skrobot.coordinates.math import quaternion_distance
 from skrobot.coordinates.math import quaternion_from_axis_angle
+from skrobot.coordinates.math import quaternion_from_vectors
 from skrobot.coordinates.math import quaternion_inverse
 from skrobot.coordinates.math import quaternion_multiply
 from skrobot.coordinates.math import quaternion_norm
@@ -40,14 +43,17 @@ from skrobot.coordinates.math import rotation_distance
 from skrobot.coordinates.math import rotation_matrix
 from skrobot.coordinates.math import rotation_matrix_from_axis
 from skrobot.coordinates.math import rotation_matrix_from_rpy
+from skrobot.coordinates.math import rotation_matrix_from_vectors
 from skrobot.coordinates.math import rotation_matrix_to_axis_angle_vector
 from skrobot.coordinates.math import rotation_vector_to_quaternion
+from skrobot.coordinates.math import rpy2homogeneous
 from skrobot.coordinates.math import rpy2matrix
 from skrobot.coordinates.math import rpy2quaternion
 from skrobot.coordinates.math import rpy_matrix
 from skrobot.coordinates.math import skew_symmetric_matrix
 from skrobot.coordinates.math import triple_product
 from skrobot.coordinates.math import wxyz2xyzw
+from skrobot.coordinates.math import xyzrpy2matrix
 from skrobot.coordinates.math import xyzw2wxyz
 from skrobot.coordinates.math import ypr2matrix
 
@@ -788,3 +794,83 @@ class TestMath(unittest.TestCase):
         rot = rpy2matrix(roll, pitch, yaw)
         recovered_rpy = matrix2rpy(rot)
         testing.assert_almost_equal(recovered_rpy, np.array([roll, pitch, yaw]))
+
+    def test_rotation_matrix_from_vectors(self):
+        # random directions: R maps a onto b exactly
+        rng = np.random.RandomState(0)
+        for _ in range(50):
+            a = rng.randn(3)
+            b = rng.randn(3)
+            rot = rotation_matrix_from_vectors(a, b)
+            # valid rotation
+            testing.assert_almost_equal(rot.T.dot(rot), np.eye(3))
+            testing.assert_almost_equal(np.linalg.det(rot), 1.0)
+            # a maps onto b (directions)
+            mapped = rot.dot(normalize_vector(a))
+            testing.assert_almost_equal(mapped, normalize_vector(b))
+
+        # already-aligned -> identity
+        testing.assert_almost_equal(
+            rotation_matrix_from_vectors([0, 0, 2], [0, 0, 5]), np.eye(3))
+
+        # anti-parallel -> 180 deg (maps a onto -a) and stays a valid rotation
+        for a in ([0, 0, 1], [1, 0, 0], [0, 1, 0], [1, 2, 3]):
+            a = np.array(a, dtype=np.float64)
+            rot = rotation_matrix_from_vectors(a, -a)
+            testing.assert_almost_equal(rot.T.dot(rot), np.eye(3))
+            testing.assert_almost_equal(np.linalg.det(rot), 1.0)
+            testing.assert_almost_equal(
+                rot.dot(normalize_vector(a)), -normalize_vector(a))
+
+    def test_quaternion_from_vectors(self):
+        rng = np.random.RandomState(1)
+        for _ in range(50):
+            a = rng.randn(3)
+            b = rng.randn(3)
+            q = quaternion_from_vectors(a, b)
+            testing.assert_almost_equal(np.linalg.norm(q), 1.0)
+            rot = quaternion2matrix(q)
+            testing.assert_almost_equal(
+                rot.dot(normalize_vector(a)), normalize_vector(b))
+
+    def test_rpy2homogeneous(self):
+        rng = np.random.RandomState(4)
+        for _ in range(50):
+            roll, pitch, yaw = rng.uniform(-pi, pi, 3)
+            mat = rpy2homogeneous(roll, pitch, yaw)
+            self.assertEqual(mat.shape, (4, 4))
+            # rotation-only: zero translation, bottom row [0, 0, 0, 1]
+            testing.assert_almost_equal(mat[:3, 3], np.zeros(3))
+            testing.assert_almost_equal(mat[3], np.array([0, 0, 0, 1]))
+            # rotation block matches rpy2matrix
+            testing.assert_almost_equal(mat[:3, :3], rpy2matrix(roll, pitch, yaw))
+            # consistent with xyzrpy2matrix at zero translation
+            testing.assert_almost_equal(
+                mat, xyzrpy2matrix([0, 0, 0], [roll, pitch, yaw]))
+
+    def test_xyzrpy_matrix_roundtrip(self):
+        rng = np.random.RandomState(2)
+        for _ in range(50):
+            xyz = rng.uniform(-5, 5, 3)
+            rpy = np.array([rng.uniform(-pi, pi),
+                            rng.uniform(-pi / 2 + 0.05, pi / 2 - 0.05),
+                            rng.uniform(-pi, pi)])
+            mat = xyzrpy2matrix(xyz, rpy)
+            self.assertEqual(mat.shape, (4, 4))
+            testing.assert_almost_equal(mat[:3, :3], rpy2matrix(*rpy))
+            r_xyz, r_rpy = matrix2xyzrpy(mat)
+            testing.assert_almost_equal(r_xyz, xyz)
+            testing.assert_almost_equal(r_rpy, rpy)
+
+    def test_matrix_relative(self):
+        rng = np.random.RandomState(3)
+        for _ in range(50):
+            parent = xyzrpy2matrix(rng.uniform(-3, 3, 3), rng.uniform(-1, 1, 3))
+            child = xyzrpy2matrix(rng.uniform(-3, 3, 3), rng.uniform(-1, 1, 3))
+            rel = matrix_relative(parent, child)
+            # matches the plain inverse, and parent @ rel reconstructs child
+            testing.assert_almost_equal(rel, np.linalg.inv(parent).dot(child))
+            testing.assert_almost_equal(parent.dot(rel), child)
+        # relative of a frame to itself is the identity
+        p = xyzrpy2matrix([1, 2, 3], [0.1, 0.2, 0.3])
+        testing.assert_almost_equal(matrix_relative(p, p), np.eye(4))


### PR DESCRIPTION
…ransforms

Add to skrobot.coordinates.math:
- rotation_matrix_from_vectors / quaternion_from_vectors: shortest-arc rotation mapping one direction onto another, with parallel / anti-parallel handling.
- rpy2homogeneous: 4x4 rotation-only transform from roll/pitch/yaw (URDF convention R = Rz @ Ry @ Rx).
- matrix2xyzrpy / xyzrpy2matrix: 4x4 <-> (xyz, rpy) round-trip helpers.
- matrix_relative: express one homogeneous transform relative to another (inv(parent) @ child) via the rigid inverse.

Export the new functions from skrobot.coordinates and cover them with unit tests.