### PR TITLE
Add CoACD approximate convex decomposition to skrobot.utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ if (sys.version_info.major > 2):
         extra_all_requires.append('open3d')
     extra_all_requires.append('fast-simplification')
     extra_all_requires.append('DracoPy')
+    # CoACD approximate convex decomposition
+    # (skrobot.utils.convex_decomposition)
+    extra_all_requires.append('coacd')
     # JAX requires Python 3.10+
     if (sys.version_info.major, sys.version_info.minor) >= (3, 10):
         extra_all_requires.extend(['jax', 'jaxlib', 'jaxlie'])
@@ -123,6 +126,11 @@ setup(
     },
     extras_require={
         'docs': docs_install_requires,
+        # CoACD approximate convex decomposition
+        # (skrobot.utils.convex_decomposition).  Also part of 'all'; this
+        # dedicated extra allows a minimal install.  The API raises a clear
+        # error when coacd is not installed.
+        'coacd': ['coacd'],
         'all': extra_all_requires,
     },
 )

--- a/skrobot/utils/__init__.py
+++ b/skrobot/utils/__init__.py
@@ -16,5 +16,8 @@ from skrobot.utils.visualization import get_ik_visualization_enabled
 
 from skrobot.utils.blender_mesh import remesh_with_blender
 
+from skrobot.utils.convex_decomposition import convex_decomposition
+from skrobot.utils.convex_decomposition import is_coacd_available
+
 from skrobot.utils.primitive_fitting import fit_primitive_to_mesh
 from skrobot.utils.primitive_fitting import primitive_params_to_origin

--- a/skrobot/utils/convex_decomposition.py
+++ b/skrobot/utils/convex_decomposition.py
@@ -1,0 +1,125 @@
+"""Approximate convex decomposition of meshes using CoACD."""
+
+from logging import getLogger
+
+import numpy as np
+
+from skrobot._lazy_imports import _lazy_trimesh
+
+
+logger = getLogger(__name__)
+
+
+__all__ = [
+    'COACD_PRESETS',
+    'is_coacd_available',
+    'convex_decomposition',
+]
+
+
+# CoACD parameters per quality preset.  CoACD's cost is dominated by its MCTS
+# search, which runs until ``max_convex_hull`` cuts whenever ``threshold`` is
+# too low to stop earlier -- so a low threshold + high part cap + many MCTS
+# iterations makes every mesh (even a tiny one) pay the full search.
+# 'balanced' keeps the search shallow (seconds to tens of seconds per mesh);
+# 'fine' trades runtime for a tighter fit.
+COACD_PRESETS = {
+    'balanced': {'threshold': 0.2, 'max_convex_hull': 6,
+                 'preprocess_resolution': 30, 'mcts_iterations': 30},
+    'fine': {'threshold': 0.1, 'max_convex_hull': 8,
+             'preprocess_resolution': 40, 'mcts_iterations': 60},
+}
+
+
+def is_coacd_available():
+    """Return True if the optional ``coacd`` package is importable.
+
+    CoACD is an optional dependency (install with ``pip install coacd`` or
+    ``pip install scikit-robot[coacd]``); use this to check for it without
+    paying the import cost.
+
+    Returns
+    -------
+    available : bool
+        True if ``import coacd`` would succeed.
+    """
+    import importlib.util
+    return importlib.util.find_spec('coacd') is not None
+
+
+def convex_decomposition(mesh, quality='balanced', **params):
+    """Decompose a mesh into approximate convex parts using CoACD.
+
+    Convex parts are what physics engines (Gazebo / Bullet / MuJoCo) actually
+    want as collision geometry; reusing a concave visual mesh works but is
+    slow and can produce wrong contacts.  Each returned part is passed
+    through its convex hull, so the results are clean watertight convex
+    meshes.
+
+    Note that CoACD is slow (seconds to tens of seconds per mesh depending on
+    complexity and preset); callers that decompose repeatedly should cache the
+    result keyed by mesh content and parameters.
+
+    Parameters
+    ----------
+    mesh : trimesh.Trimesh
+        Input mesh to decompose.
+    quality : str, optional
+        Preset name, one of ``COACD_PRESETS`` keys ('balanced' or 'fine').
+        'balanced' (default) is a few times faster; 'fine' fits tighter.
+    **params
+        Explicit CoACD parameters (e.g. ``threshold``, ``max_convex_hull``,
+        ``preprocess_resolution``, ``mcts_iterations``).  These override the
+        preset values and are forwarded to ``coacd.run_coacd``.
+
+    Returns
+    -------
+    parts : list of trimesh.Trimesh
+        The convex parts covering the input mesh.
+
+    Raises
+    ------
+    RuntimeError
+        If the optional ``coacd`` package is not installed.
+    ValueError
+        If ``quality`` is not a known preset name.
+
+    Examples
+    --------
+    >>> import trimesh
+    >>> from skrobot.utils.convex_decomposition import convex_decomposition
+    >>> mesh = trimesh.creation.annulus(r_min=0.5, r_max=1.0, height=0.3)
+    >>> parts = convex_decomposition(mesh)
+    >>> all(part.is_watertight for part in parts)
+    True
+    """
+    trimesh = _lazy_trimesh()
+    if quality not in COACD_PRESETS:
+        raise ValueError(
+            'unsupported quality: {!r} (expected one of {})'.format(
+                quality, sorted(COACD_PRESETS)))
+    if not is_coacd_available():
+        raise RuntimeError(
+            "CoACD convex decomposition needs the optional 'coacd' package"
+            ' -- install it with: pip install coacd')
+    import coacd
+
+    run_params = dict(COACD_PRESETS[quality])
+    run_params.update(params)
+    coacd.set_log_level('error')
+    coacd_mesh = coacd.Mesh(
+        np.asarray(mesh.vertices, dtype=np.float64),
+        np.asarray(mesh.faces, dtype=np.int64))
+    raw_parts = coacd.run_coacd(coacd_mesh, merge=True, **run_params)
+
+    parts = []
+    for vertices, faces in raw_parts:
+        # CoACD parts are convex by construction; taking the convex hull
+        # drops any sliver faces and guarantees a watertight mesh.
+        part = trimesh.Trimesh(
+            vertices=np.asarray(vertices),
+            faces=np.asarray(faces),
+            process=False).convex_hull
+        parts.append(part)
+    logger.debug('CoACD decomposed mesh into %d convex part(s)', len(parts))
+    return parts

--- a/tests/skrobot_tests/utils_tests/test_convex_decomposition.py
+++ b/tests/skrobot_tests/utils_tests/test_convex_decomposition.py
@@ -1,0 +1,56 @@
+import unittest
+
+import numpy as np
+import trimesh
+
+from skrobot.utils.convex_decomposition import convex_decomposition
+from skrobot.utils.convex_decomposition import is_coacd_available
+
+
+# keep the MCTS search shallow so the test suite stays fast; the defaults are
+# tuned for real CAD parts, not unit tests
+_FAST_PARAMS = {'preprocess_resolution': 20, 'mcts_iterations': 10}
+
+
+class TestConvexDecomposition(unittest.TestCase):
+
+    def test_is_coacd_available_returns_bool(self):
+        self.assertIsInstance(is_coacd_available(), bool)
+
+    def test_unknown_quality_raises(self):
+        mesh = trimesh.creation.box(extents=(1.0, 1.0, 1.0))
+        with self.assertRaises(ValueError):
+            convex_decomposition(mesh, quality='ultra')
+
+    @unittest.skipUnless(is_coacd_available(), 'coacd is not installed')
+    def test_convex_box_yields_single_part(self):
+        mesh = trimesh.creation.box(extents=(1.0, 0.5, 0.25))
+        parts = convex_decomposition(mesh, **_FAST_PARAMS)
+        self.assertEqual(len(parts), 1)
+        part = parts[0]
+        self.assertTrue(part.is_watertight)
+        self.assertTrue(part.is_convex)
+        # an approximate decomposition of a box should stay close to it
+        self.assertAlmostEqual(
+            part.volume, mesh.volume, delta=0.15 * mesh.volume)
+
+    @unittest.skipUnless(is_coacd_available(), 'coacd is not installed')
+    def test_concave_mesh_yields_multiple_convex_parts(self):
+        # a hollow ring is strongly concave: no single convex body fits it
+        mesh = trimesh.creation.annulus(r_min=0.5, r_max=1.0, height=0.3)
+        parts = convex_decomposition(mesh, **_FAST_PARAMS)
+        self.assertGreaterEqual(len(parts), 2)
+        for part in parts:
+            self.assertTrue(part.is_watertight)
+            self.assertTrue(part.is_convex)
+        # the union of the parts should roughly cover the input footprint
+        combined = np.vstack([part.bounds for part in parts])
+        combined_min = combined.min(axis=0)
+        combined_max = combined.max(axis=0)
+        extent = combined_max - combined_min
+        expected = mesh.bounds[1] - mesh.bounds[0]
+        np.testing.assert_allclose(extent, expected, rtol=0.2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

- `skrobot.utils.convex_decomposition.convex_decomposition(mesh, quality='balanced', **params)` -> list of watertight convex `trimesh.Trimesh` parts. The `'balanced'` / `'fine'` presets tune CoACD's MCTS search; explicit params override the preset.
- `is_coacd_available()` for capability checks.
- `coacd` stays optional: installable via the new `coacd` extra and included in `all`, with a clear `RuntimeError` when missing (no silent fallback).

## Why

Physics engines (Gazebo / Bullet / MuJoCo) want convex collision geometry. skrobot ships the per-mesh primitive-fitting API but had no convex-decomposition counterpart, so downstream tools carry their own CoACD glue.

## Verification

- 4 unit tests (skipped when coacd is not installed): a convex box decomposes to a single near-exact part (volume within 15%), a hollow ring to multiple watertight convex parts. All pass with coacd installed (~3 s).
- `ruff check` / `flake8` / `typos` clean.