### PR TITLE
Use rpy2matrix and quaternion-order helpers at internal call sites

### DIFF
--- a/skrobot/interfaces/_pybullet.py
+++ b/skrobot/interfaces/_pybullet.py
@@ -6,6 +6,7 @@ import numpy as np
 from skrobot.coordinates import Coordinates
 from skrobot.coordinates import matrix2quaternion
 from skrobot.coordinates import quaternion2rpy
+from skrobot.coordinates.math import wxyz2xyzw
 from skrobot.coordinates.math import xyzw2wxyz
 
 
@@ -331,9 +332,8 @@ class PybulletRobotInterface(Coordinates):
             joint_state = p.getJointState(self.robot_id,
                                           idx)
             joint.joint_angle(joint_state[0])
-        pos, orientation = p.getBasePositionAndOrientation(self.robot_id)
-        rpy, _ = quaternion2rpy([orientation[3], orientation[0],
-                                 orientation[1], orientation[2]])
+        pos, orientation_xyzw = p.getBasePositionAndOrientation(self.robot_id)
+        rpy, _ = quaternion2rpy(xyzw2wxyz(orientation_xyzw))
         self.robot.root_link.newcoords(np.array([rpy[0], rpy[1], rpy[2]]),
                                        pos=pos)
         return self.angle_vector()
@@ -364,13 +364,9 @@ def draw(c,
         remove_body_indices.append(idx)
         return
     coord = c.copy_worldcoords()
-    orientation = matrix2quaternion(coord.worldrot())
-    orientation = np.array([orientation[1],
-                            orientation[2],
-                            orientation[3],
-                            orientation[0]])
+    orientation_xyzw = wxyz2xyzw(matrix2quaternion(coord.worldrot()))
     create_pose_marker(c.worldpos(),
-                       orientation,
+                       orientation_xyzw,
                        text=text,
                        lineWidth=line_width,
                        lineLength=line_length,

--- a/skrobot/planner/utils.py
+++ b/skrobot/planner/utils.py
@@ -3,7 +3,7 @@ import numpy as np
 from skrobot.coordinates import CascadedCoords
 from skrobot.coordinates import Coordinates
 from skrobot.coordinates.math import matrix2ypr
-from skrobot.coordinates.math import rpy_matrix
+from skrobot.coordinates.math import rpy2matrix
 
 
 def scipinize(fun):
@@ -63,7 +63,7 @@ def set_robot_config(robot_model, joint_list, av, with_base=False):
     if with_base:
         av_joint, av_base = av[:-3], av[-3:]
         x, y, theta = av_base
-        co = Coordinates(pos=[x, y, 0.0], rot=rpy_matrix(theta, 0.0, 0.0))
+        co = Coordinates(pos=[x, y, 0.0], rot=rpy2matrix(0.0, 0.0, theta))
         robot_model.newcoords(co)
     else:
         av_joint = av

--- a/skrobot/urdf/primitives_converter.py
+++ b/skrobot/urdf/primitives_converter.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from skrobot.coordinates.math import matrix2rpy
 from skrobot.coordinates.math import rotation_matrix_z_to_axis
-from skrobot.coordinates.math import rpy_matrix
+from skrobot.coordinates.math import rpy2matrix
 from skrobot.utils.primitive_fitting import fit_primitive_to_mesh
 from skrobot.utils.primitive_fitting import primitive_params_to_origin
 from skrobot.utils.urdf import get_filename
@@ -321,10 +321,10 @@ def convert_meshes_to_primitives(
 
                 # Compose the primitive origin with the mesh element's URDF
                 # origin to obtain the primitive pose in the link frame.
-                rotation_urdf = rpy_matrix(
-                    origin_rpy[2],
+                rotation_urdf = rpy2matrix(
+                    origin_rpy[0],
                     origin_rpy[1],
-                    origin_rpy[0]
+                    origin_rpy[2]
                 )
                 mesh_center_link = rotation_urdf @ local_xyz
                 primitive_center = origin_xyz + mesh_center_link
@@ -339,8 +339,8 @@ def convert_meshes_to_primitives(
                     primitive_rotation = rotation_matrix_z_to_axis(axis_link)
                     final_rpy = matrix2rpy(primitive_rotation)
                 else:
-                    rotation_local = rpy_matrix(
-                        local_rpy[2], local_rpy[1], local_rpy[0])
+                    rotation_local = rpy2matrix(
+                        local_rpy[0], local_rpy[1], local_rpy[2])
                     if np.allclose(rotation_local, np.eye(3)):
                         # Axis-aligned box / sphere: preserve the element's
                         # original URDF origin rpy exactly.

--- a/skrobot/urdf/wheel_collision_converter.py
+++ b/skrobot/urdf/wheel_collision_converter.py
@@ -7,7 +7,7 @@ import numpy as np
 from skrobot._lazy_imports import _lazy_trimesh
 from skrobot.coordinates.math import matrix2ypr
 from skrobot.coordinates.math import rotation_matrix_z_to_axis
-from skrobot.coordinates.math import rpy_matrix
+from skrobot.coordinates.math import rpy2matrix
 from skrobot.utils.urdf import get_filename
 from skrobot.utils.urdf import load_meshes
 
@@ -185,7 +185,7 @@ def convert_wheel_collisions_to_cylinders(urdf_file, output_file=None):
             origin_xyz = np.zeros(3)
             origin_rpy = np.zeros(3)
 
-        rotation_urdf = rpy_matrix(origin_rpy[2], origin_rpy[1], origin_rpy[0])
+        rotation_urdf = rpy2matrix(origin_rpy[0], origin_rpy[1], origin_rpy[2])
         radius, height, axis, mesh_center_offset = get_mesh_dimensions(mesh_file, scale, urdf_dir)
 
         if radius is None:

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -27,8 +27,8 @@ import six
 
 from skrobot._lazy_imports import _lazy_trimesh
 from skrobot.coordinates import normalize_vector
-from skrobot.coordinates import rpy_matrix
 from skrobot.coordinates.math import matrix2ypr
+from skrobot.coordinates.math import rpy2matrix
 from skrobot.pycompat import lru_cache
 
 
@@ -189,7 +189,7 @@ def parse_origin(node):
         if 'rpy' in origin_node.attrib:
             rpy = np.fromstring(origin_node.attrib['rpy'], sep=' ')
             roll, pitch, yaw = rpy
-            matrix[:3, :3] = rpy_matrix(yaw, pitch, roll)
+            matrix[:3, :3] = rpy2matrix(roll, pitch, yaw)
     return matrix
 
 
@@ -711,7 +711,7 @@ def configure_origin(value):
             value = np.eye(4).astype(np.float64)
             value[:3, 3] = value[:3]
             roll, pitch, yaw = value[3:]
-            value[:3, :3] = rpy_matrix(yaw, pitch, roll)
+            value[:3, :3] = rpy2matrix(roll, pitch, yaw)
         elif value.shape != (4, 4):
             raise ValueError('Origin must be specified as a 4x4 '
                              'homogenous transformation matrix')


### PR DESCRIPTION
## What

Behavior-preserving refactor:

- Replace internal calls to the legacy `rpy_matrix(yaw, pitch, roll)` with the identical `rpy2matrix(roll, pitch, yaw)` (6 sites: `urdf/wheel_collision_converter.py`, `urdf/primitives_converter.py` x2, `planner/utils.py`, `utils/urdf.py` x2), aligning the argument order with the URDF (roll, pitch, yaw) convention. `rpy_matrix` itself stays (public API); only call sites move.
- Replace hand-rolled xyzw<->wxyz reorders in `interfaces/_pybullet.py` with `xyzw2wxyz` / `wxyz2xyzw`, and give the affected quaternion variables an order suffix (`orientation_xyzw`).

## Verification

- `rpy2matrix(r, p, y)` is `rpy_matrix(y, p, r)` by definition; spot-checked bit-identical (max diff 0.0 over 999 samples).
- pytest (urdf / planner / coordinates / utils suites): 225 passed, 23 skipped.
- `ruff check` / `flake8` / `typos` clean.