### PR TITLE
Fix geometry loss in URDF root-link changing

### DIFF
--- a/skrobot/urdf/xml_root_link_changer.py
+++ b/skrobot/urdf/xml_root_link_changer.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 import xml.etree.ElementTree as ET
 
 import numpy as np
@@ -15,19 +14,15 @@ class URDFXMLRootLinkChanger:
     to change the root link to any specified link, then writes the modified
     URDF back to a file.
 
-    .. warning::
-
-        This class assumes that all visual/collision elements have zero-offset
-        origins (xyz="0 0 0" rpy="0 0 0"). URDFs with non-zero visual/collision
-        offsets will not work correctly after root link change.
-
-        Use the ``convert-urdf-mesh`` command to preprocess URDFs with non-zero
-        offsets before using this class. See:
-        https://scikit-robot.readthedocs.io/en/latest/reference/how_to_create_urdf_from_cad.html#how-to-create-urdf-from-cad-software
-
-    .. todo::
-
-        Add support for URDFs with non-zero visual/collision offsets.
+    Re-rooting reverses the joints along the path from the new root to the
+    old root.  A reversed revolute/prismatic joint must rotate its new child
+    about an axis through that child's frame origin, so the frames of the
+    links along the path are relocated onto their former joint frames; the
+    visual, collision and inertial origins of those links are re-expressed
+    accordingly (composed with any existing offset, which is created when
+    absent), preserving the physical geometry exactly.  External references
+    to the frames of relocated links (everything on the path except the new
+    root) must be re-derived after the change.
     """
 
     def __init__(self, urdf_path, warn_non_zero_offsets=True):
@@ -38,8 +33,10 @@ class URDFXMLRootLinkChanger:
         urdf_path : str
             Path to the input URDF file
         warn_non_zero_offsets : bool
-            If True, emit a warning when URDF contains non-zero
-            visual/collision offsets. Default is True.
+            Deprecated and ignored.  Non-zero visual/collision offsets are
+            fully supported: the frame relocation composes with existing
+            origins, so there is nothing to warn about.  The parameter is
+            kept for backward compatibility.
 
         Raises
         ------
@@ -61,55 +58,11 @@ class URDFXMLRootLinkChanger:
         self.joints = self._parse_joints()
         self.joint_tree = self._build_joint_tree()
 
-        # Check for non-zero visual/collision offsets
-        if warn_non_zero_offsets:
-            self._warn_if_non_zero_offsets()
-
-    def _warn_if_non_zero_offsets(self):
-        """Check for non-zero visual/collision offsets and emit warning."""
-        non_zero_links = []
-        for link_name, link in self.links.items():
-            for elem_type in ['visual', 'collision']:
-                for elem in link.findall(elem_type):
-                    origin = elem.find('origin')
-                    if origin is not None:
-                        xyz_str = origin.get('xyz', '0 0 0')
-                        rpy_str = origin.get('rpy', '0 0 0')
-                        xyz = [float(x) for x in xyz_str.split()]
-                        rpy = [float(x) for x in rpy_str.split()]
-                        if any(abs(v) > 1e-6 for v in xyz + rpy):
-                            non_zero_links.append((link_name, elem_type))
-                            break
-
-        if non_zero_links:
-            # ANSI escape codes for orange/yellow color
-            orange = '\033[93m'
-            reset = '\033[0m'
-
-            link_list = '\n'.join(
-                '    - {} ({})'.format(name, typ)
-                for name, typ in non_zero_links[:5]
-            )
-            if len(non_zero_links) > 5:
-                link_list += '\n    ... and {} more'.format(
-                    len(non_zero_links) - 5
-                )
-
-            message = (
-                "\n{orange}"
-                "WARNING: URDF contains non-zero visual/collision offsets.\n"
-                "Root link change may produce incorrect results.\n"
-                "\n"
-                "Affected links:\n"
-                "{link_list}\n"
-                "\n"
-                "Solution: Use 'convert-urdf-mesh' command to preprocess the URDF.\n"
-                "See: https://scikit-robot.readthedocs.io/en/latest/reference/"
-                "how_to_create_urdf_from_cad.html#how-to-create-urdf-from-cad-software"
-                "{reset}"
-            ).format(orange=orange, link_list=link_list, reset=reset)
-
-            warnings.warn(message, UserWarning, stacklevel=3)
+        # Non-zero visual/collision offsets are fully supported now that
+        # frame relocation composes with existing origins, so the historical
+        # warning is gone; the parameter is accepted and ignored for
+        # backward compatibility.
+        del warn_non_zero_offsets
 
     def _parse_links(self):
         """Parse all links from the URDF.
@@ -399,7 +352,11 @@ class URDFXMLRootLinkChanger:
             inv_axis_xyz = [-float(x) for x in axis_xyz_str.split()]
             axis.set('xyz', ' '.join(map(str, inv_axis_xyz)))
 
-        # Adjust visual and collision origin
+        # The joint's old parent link frame is relocated onto this joint's
+        # frame; re-express everything attached to that link (visuals,
+        # collisions, inertials) by the inverse relocation.  The origin
+        # element is created when absent and the correction is COMPOSED
+        # with any existing offset.
         parent_elem = joint.find('parent')
         if parent_elem is None:
             return
@@ -407,18 +364,7 @@ class URDFXMLRootLinkChanger:
         if parent_name not in self.links:
             return
         parent = self.links[parent_name]
-        parent_visual = parent.find('visual')
-        if parent_visual is not None:
-            parent_visual_origin = parent_visual.find('origin')
-            if parent_visual_origin is not None:
-                parent_visual_origin.set('xyz', ' '.join(map(str, inv_current_xyz)))
-                parent_visual_origin.set('rpy', ' '.join(map(str, inv_current_rpy)))
-        parent_collision = parent.find('collision')
-        if parent_collision is not None:
-            parent_collision_origin = parent_collision.find('origin')
-            if parent_collision_origin is not None:
-                parent_collision_origin.set('xyz', ' '.join(map(str, inv_current_xyz)))
-                parent_collision_origin.set('rpy', ' '.join(map(str, inv_current_rpy)))
+        self._relocate_link_frame_elements(parent, inv_current_pose)
 
         # When the parent link of this joint is the current base_link
         base_link_name = path_to_current_root[-1][0]
@@ -462,6 +408,29 @@ class URDFXMLRootLinkChanger:
                 # Set new pose to child joint
                 child_origin.set('xyz', ' '.join(map(str, new_child_xyz)))
                 child_origin.set('rpy', ' '.join(map(str, new_child_rpy)))
+
+    def _relocate_link_frame_elements(self, link_elem, delta_inv_pose):
+        """Re-express a link's visual/collision/inertial origins after its
+        frame was relocated by ``delta`` (``delta_inv_pose`` = inv(delta)).
+
+        Creates the ``<origin>`` element when it is absent (URDF default =
+        identity) and COMPOSES the correction with the existing origin, so
+        non-zero offsets are fully supported.
+        """
+        for tag in ('visual', 'collision', 'inertial'):
+            for sub in link_elem.findall(tag):
+                origin = sub.find('origin')
+                if origin is None:
+                    origin = ET.SubElement(sub, 'origin')
+                    origin.set('xyz', '0 0 0')
+                    origin.set('rpy', '0 0 0')
+                xyz = [float(v) for v in origin.get('xyz', '0 0 0').split()]
+                rpy = [float(v) for v in origin.get('rpy', '0 0 0').split()]
+                old_pose = self._pose_to_matrix(xyz, rpy)
+                new_xyz, new_rpy = self._matrix_to_pose(
+                    np.dot(delta_inv_pose, old_pose))
+                origin.set('xyz', ' '.join(map(str, new_xyz)))
+                origin.set('rpy', ' '.join(map(str, new_rpy)))
 
     def _pose_to_matrix(self, xyz, rpy):
         rot = R.from_euler('xyz', rpy)

--- a/tests/skrobot_tests/urdf_tests/test_xml_root_link_changer.py
+++ b/tests/skrobot_tests/urdf_tests/test_xml_root_link_changer.py
@@ -4,10 +4,12 @@ import os
 import sys
 import tempfile
 import unittest
+import xml.etree.ElementTree as ET
 
 import pytest
 
 from skrobot.data import kuka_urdfpath
+from skrobot.urdf import change_urdf_root_link
 from skrobot.urdf import URDFXMLRootLinkChanger
 
 
@@ -305,3 +307,134 @@ class TestURDFXMLRootLinkChanger(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestGeometricFidelity(unittest.TestCase):
+    """Re-rooting must preserve the physical geometry exactly.
+
+    Link frames along the path are relocated by design (a reversed
+    revolute joint must rotate its new child about an axis through that
+    child's origin), so fidelity is measured on the visual-mesh world
+    poses, which the relocation compensates through the visual origins.
+    """
+
+    _BOX = ('<visual><geometry><box size="0.05 0.05 0.05"/></geometry>'
+            '</visual>')
+    _BOX_OFFSET = ('<visual><origin xyz="0.02 -0.01 0.03" rpy="0.2 0.1 -0.3"/>'
+                   '<geometry><box size="0.05 0.05 0.05"/></geometry>'
+                   '</visual>')
+    _INERTIAL = ('<inertial><origin xyz="0.01 0.02 0.03" rpy="0 0 0"/>'
+                 '<mass value="1"/><inertia ixx="0.001" ixy="0" ixz="0" '
+                 'iyy="0.001" iyz="0" izz="0.001"/></inertial>')
+
+    @staticmethod
+    def _urdf(link_extra, branch=False):
+        branch_part = ''
+        if branch:
+            branch_part = (
+                f'<link name="branch">{link_extra}</link>'
+                '<joint name="j3" type="fixed">'
+                '<parent link="mid"/><child link="branch"/>'
+                '<origin xyz="-0.05 0.02 0.08" rpy="0.4 -0.1 0.2"/></joint>')
+        return f"""<?xml version="1.0"?>
+<robot name="m">
+  <link name="base_link">{link_extra}</link>
+  <link name="mid">{link_extra}</link>
+  <link name="dummy_link1">{link_extra}</link>
+  <joint name="j1" type="revolute">
+    <parent link="base_link"/><child link="mid"/>
+    <origin xyz="0.1 0.05 0.2" rpy="0.3 -0.2 0.5"/><axis xyz="0 0 1"/>
+    <limit lower="-1" upper="0.8" effort="1" velocity="1"/>
+  </joint>
+  <joint name="j2" type="fixed">
+    <parent link="mid"/><child link="dummy_link1"/>
+    <origin xyz="0 0.15 0.05" rpy="0.1 0.4 -0.3"/>
+  </joint>
+  {branch_part}
+</robot>"""
+
+    @staticmethod
+    def _mesh_world_poses(path, joint_angle):
+        import numpy as np
+
+        from skrobot.coordinates.math import xyzrpy2matrix
+        from skrobot.models.urdf import RobotModelFromURDF
+        robot = RobotModelFromURDF(urdf_file=path)
+        if hasattr(robot, 'j1'):
+            robot.j1.joint_angle(joint_angle)
+        root = ET.parse(path).getroot()
+        poses = {}
+        links = {link.name: link for link in robot.link_list}
+        for link in root.findall('link'):
+            visual = link.find('visual')
+            if visual is None:
+                continue
+            origin = visual.find('origin')
+            xyz = [float(v) for v in
+                   (origin.get('xyz', '0 0 0') if origin is not None
+                    else '0 0 0').split()]
+            rpy = [float(v) for v in
+                   (origin.get('rpy', '0 0 0') if origin is not None
+                    else '0 0 0').split()]
+            name = link.get('name')
+            poses[name] = (links[name].worldcoords().T()
+                           @ xyzrpy2matrix(xyz, rpy))
+        reference = poses['dummy_link1']
+        return {n: np.linalg.inv(reference) @ T for n, T in poses.items()}
+
+    def _assert_fidelity(self, urdf):
+        import numpy as np
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, 'm.urdf')
+            with open(src, 'w') as f:
+                f.write(urdf)
+            dst = os.path.join(tmp, 'r.urdf')
+            change_urdf_root_link(src, 'dummy_link1', dst)
+            for q in (0.0, 0.5, -0.7):
+                original = self._mesh_world_poses(src, q)
+                rerooted = self._mesh_world_poses(dst, q)
+                for name in original:
+                    np.testing.assert_allclose(
+                        original[name], rerooted[name], atol=1e-9,
+                        err_msg=f'link {name} at q={q}')
+
+    def test_visuals_without_origin_tags(self):
+        # URDF omits <origin> = identity; the relocation must create and
+        # fill it instead of silently skipping the compensation
+        self._assert_fidelity(self._urdf(self._BOX))
+
+    def test_nonzero_visual_offsets_and_inertials(self):
+        # existing offsets must be COMPOSED with the relocation, and
+        # inertial origins compensated the same way
+        self._assert_fidelity(self._urdf(self._BOX_OFFSET + self._INERTIAL))
+
+    def test_off_path_branch(self):
+        self._assert_fidelity(self._urdf(self._BOX, branch=True))
+
+    def test_inertial_com_world_position_preserved(self):
+        import numpy as np
+
+        from skrobot.coordinates.math import xyzrpy2matrix
+        from skrobot.models.urdf import RobotModelFromURDF
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, 'm.urdf')
+            with open(src, 'w') as f:
+                f.write(self._urdf(self._BOX_OFFSET + self._INERTIAL))
+            dst = os.path.join(tmp, 'r.urdf')
+            change_urdf_root_link(src, 'dummy_link1', dst)
+
+            def com_rel(path):
+                robot = RobotModelFromURDF(urdf_file=path)
+                links = {link.name: link for link in robot.link_list}
+                root = ET.parse(path).getroot()
+                base = [link for link in root.findall('link')
+                        if link.get('name') == 'base_link'][0]
+                origin = base.find('inertial').find('origin')
+                com = xyzrpy2matrix(
+                    [float(v) for v in origin.get('xyz').split()],
+                    [float(v) for v in origin.get('rpy', '0 0 0').split()])
+                world = links['base_link'].worldcoords().T() @ com
+                ref = links['dummy_link1'].worldcoords().T()
+                return np.linalg.inv(ref) @ world
+            np.testing.assert_allclose(com_rel(src), com_rel(dst),
+                                       atol=1e-9)


### PR DESCRIPTION
`URDFXMLRootLinkChanger` (the implementation behind `skr change-urdf-root`) silently corrupted geometry when re-rooting a URDF. Re-rooting relocates the frames of on-path links by design (a reversed revolute joint must turn its new child about an axis through that child's origin), but the frame compensation had three gaps:

1. visual/collision origins were skipped entirely when the `<origin>` element was absent;
2. an existing origin offset was overwritten instead of composed (the source of the zero-offset assumption);
3. inertial origins were never adjusted at all.

This change creates-and-composes the origin in all three places, which also makes non-zero offsets fully supported, so the now-unnecessary warning and TODO are removed.

Verification: 4 new fidelity tests assert mesh/inertial world poses are preserved to machine precision across several joint angles (missing origin tag / non-zero offset + inertial / off-path branches / center-of-mass world position). The existing tests pass unchanged (urdf_tests 62 passed; ruff/flake8/typos green).