### PR TITLE
Fix align_axis_to_direction ignoring small and near-half-turn correct…

### DIFF
--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -20,6 +20,7 @@ from skrobot.coordinates.math import random_translation
 from skrobot.coordinates.math import rotate_matrix
 from skrobot.coordinates.math import rotation_distance
 from skrobot.coordinates.math import rotation_matrix
+from skrobot.coordinates.math import rotation_matrix_from_vectors
 from skrobot.coordinates.math import rotation_matrix_to_axis_angle_vector
 from skrobot.coordinates.math import rpy2quaternion
 from skrobot.coordinates.math import rpy_angle
@@ -1107,7 +1108,7 @@ class Coordinates(object):
         else:
             raise TypeError('wrt {} not supported'.format(wrt))
 
-    def align_axis_to_direction(self, direction, axis='z', wrt='world', eps=0.005):
+    def align_axis_to_direction(self, direction, axis='z', wrt='world', eps=None):
         """Align the specified axis of this coordinate to point in the given direction.
 
         Rotates this coordinate system so that the specified axis
@@ -1127,8 +1128,9 @@ class Coordinates(object):
             'local': direction is in this coordinate's local frame
             Coordinates: direction is in the given coordinate's frame
         eps : float, optional
-            Tolerance for detecting parallel/anti-parallel cases.
-            Default is 0.005.
+            Deprecated and ignored. The parallel and anti-parallel cases are
+            handled by
+            :func:`skrobot.coordinates.math.rotation_matrix_from_vectors`.
 
         Returns
         -------
@@ -1166,21 +1168,15 @@ class Coordinates(object):
         else:
             raise ValueError('wrt {} not supported'.format(wrt))
 
-        normalized_direction = normalize_vector(direction)
-        axis_vector = convert_to_axis_vector(axis)
-        current_axis = self.rotate_vector(axis_vector)
-        rot_axis = np.cross(current_axis, normalized_direction)
-        rot_angle_cos = np.clip(
-            np.dot(normalized_direction, current_axis), -1.0, 1.0)
-        if np.isclose(rot_angle_cos, 1.0, atol=eps):
-            return self
-        elif np.isclose(rot_angle_cos, -1.0, atol=eps):
-            for candidate_axis in [np.array([1, 0, 0]), np.array([0, 1, 0])]:
-                candidate_cos = np.dot(current_axis, candidate_axis)
-                if not np.isclose(abs(candidate_cos), 1.0, atol=eps):
-                    rot_axis = candidate_axis - candidate_cos * current_axis
-                    break
-        self.rotate(np.arccos(rot_angle_cos), rot_axis, 'world')
+        if eps is not None:
+            warnings.warn(
+                'The eps argument is deprecated and ignored. The degenerate '
+                'cases are handled by rotation_matrix_from_vectors.',
+                DeprecationWarning,
+                stacklevel=2)
+        current_axis = self.rotate_vector(convert_to_axis_vector(axis))
+        self.rotate_with_matrix(
+            rotation_matrix_from_vectors(current_axis, direction), 'world')
         return self
 
     def slerp(self, other, ratio):

--- a/skrobot/coordinates/geo.py
+++ b/skrobot/coordinates/geo.py
@@ -46,7 +46,7 @@ def midcoords(p, c1, c2):
     return c1.interpolate(c2, p)
 
 
-def orient_coords_to_axis(target_coords, v, axis='z', eps=0.005):
+def orient_coords_to_axis(target_coords, v, axis='z', eps=None):
     """Orient axis to the direction
 
     .. deprecated::
@@ -105,7 +105,7 @@ def orient_coords_to_axis(target_coords, v, axis='z', eps=0.005):
         DeprecationWarning,
         stacklevel=2
     )
-    return target_coords.align_axis_to_direction(v, axis=axis, eps=eps)
+    return target_coords.align_axis_to_direction(v, axis=axis)
 
 
 def rotate_points(points, a, b):

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -9,6 +9,7 @@ from numpy import testing
 from skrobot.coordinates import make_cascoords
 from skrobot.coordinates import make_coords
 from skrobot.coordinates import Transform
+from skrobot.coordinates.math import _check_valid_rotation
 from skrobot.coordinates.math import matrix2ypr
 from skrobot.coordinates.math import rotation_matrix
 from skrobot.coordinates.math import rpy_matrix
@@ -477,6 +478,23 @@ class TestCoordinates(unittest.TestCase):
         testing.assert_array_almost_equal(coords.rotation, coords.rotation_matrix)
         coords.translate([1.0, 2.0, 3.0])
         testing.assert_array_almost_equal(coords.translation, coords.translation_vector)
+
+    def test_align_axis_to_direction_small_and_near_half_turn(self):
+        """Directions close to the current axis, or close to its opposite."""
+        axis_index = {'x': 0, 'y': 1, 'z': 2}
+        for degree in (0.0, 0.001, 1.0, 3.0, 5.0, 5.7, 90.0,
+                       175.0, 177.0, 179.0, 179.999, 180.0):
+            theta = np.deg2rad(degree)
+            direction = np.array([np.sin(theta), 0.0, np.cos(theta)])
+            for name, index in axis_index.items():
+                c = make_coords()
+                c.align_axis_to_direction(direction, axis=name, wrt='world')
+                aligned = c.rotation[:, index]
+                testing.assert_almost_equal(
+                    aligned, direction, decimal=5,
+                    err_msg='axis {} at {} deg -> {}'.format(
+                        name, degree, aligned))
+                _check_valid_rotation(c.rotation)
 
     def test_align_axis_to_direction(self):
         """Test align_axis_to_direction method."""

--- a/tests/skrobot_tests/coordinates_tests/test_geo.py
+++ b/tests/skrobot_tests/coordinates_tests/test_geo.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy as np
-from numpy import pi
 from numpy import testing
 
 from skrobot.coordinates import make_coords
@@ -44,14 +43,17 @@ class TestGeo(unittest.TestCase):
             [0, 0, 0])
 
         # case of rot_angle_cos == -1.0
+        # Any half turn about an axis perpendicular to z sends z to -z, so
+        # assert where the axis ends up rather than picking one of them.
         target_coords = make_coords()
         orient_coords_to_axis(target_coords, [0, 0, -1])
 
         testing.assert_array_equal(target_coords.worldpos(),
                                    [0, 0, 0])
         testing.assert_array_almost_equal(
-            matrix2ypr(target_coords.rotation),
-            [0, 0, pi])
+            target_coords.rotation[:, 2], [0, 0, -1])
+        testing.assert_array_almost_equal(
+            np.linalg.det(target_coords.rotation), 1.0)
 
     def test_rotate_points(self):
         points = np.array([1, 0, 0])


### PR DESCRIPTION
…ions

The parallel and anti-parallel cases were both guarded with eps=0.005, but eps is a tolerance on the cosine, so that is a dead band about 5.7 degrees wide. Inside it the method either returned without rotating anything, or rotated about a fabricated axis instead of the cross product. Asking to align by 3 degrees left 3 degrees of error, and directions near the opposite axis landed up to 7 degrees off. Worst residual over 20000 random directions was 10.74 degrees.

rotation_matrix_from_vectors already solves exactly this problem, and does it properly: it keys off the norm of the cross product with a 1e-12 threshold, so only the genuinely degenerate cases are special-cased. Delegate to it instead of open coding a second version. Worst residual is now 1.5e-6 degrees.

eps no longer has anything to control, so it is deprecated and ignored.

The anti-parallel test picked one particular half turn out of the infinitely many that are equally correct; assert where the axis lands instead.