### PR TITLE
Use a rotation, not a reflection, in rotate_points for opposite vectors

### DIFF
--- a/skrobot/coordinates/geo.py
+++ b/skrobot/coordinates/geo.py
@@ -1,9 +1,6 @@
 import warnings
 
-import numpy as np
-
-from skrobot.coordinates.math import angle_between_vectors
-from skrobot.coordinates.math import normalize_vector
+from skrobot.coordinates.math import rotation_matrix_from_vectors
 
 
 def midcoords(p, c1, c2):
@@ -111,13 +108,8 @@ def orient_coords_to_axis(target_coords, v, axis='z', eps=None):
 def rotate_points(points, a, b):
     """Rotate given points based on a starting and ending vector.
 
-    Axis vector k is calculated from the any two nonzero vectors a and b.
-    Rotated points are calculated from following Rodrigues rotation formula.
-
-    .. math::
-
-        `P_{rot} = P \\cos \\theta +
-        (k \\times P) \\sin \\theta + k (k \\cdot P) (1 - \\cos \\theta)`
+    The points are rotated by the shortest-arc rotation that takes ``a`` onto
+    ``b``.
 
     Parameters
     ----------
@@ -135,13 +127,4 @@ def rotate_points(points, a, b):
     """
     if points.ndim == 1:
         points = points[None, :]
-
-    a = normalize_vector(a)
-    b = normalize_vector(b)
-    k = normalize_vector(np.cross(a, b))
-    theta = angle_between_vectors(a, b, normalize=False)
-
-    points_rot = points * np.cos(theta) \
-        + np.cross(k, points) * np.sin(theta) \
-        + k * np.dot(k, points.T).reshape(-1, 1) * (1 - np.cos(theta))
-    return points_rot
+    return points.dot(rotation_matrix_from_vectors(a, b).T)

--- a/tests/skrobot_tests/coordinates_tests/test_geo.py
+++ b/tests/skrobot_tests/coordinates_tests/test_geo.py
@@ -60,6 +60,31 @@ class TestGeo(unittest.TestCase):
         rot_points = rotate_points(points, [1, 0, 0], [0, 0, 1])
         testing.assert_almost_equal(rot_points, [[0, 0, 1]])
 
+    def test_rotate_points_parallel_and_anti_parallel(self):
+        points = np.array([[1.0, 2.0, 3.0], [0.0, 1.0, 0.0]])
+
+        # a == b: nothing moves.
+        testing.assert_almost_equal(
+            rotate_points(points, [0, 0, 1], [0, 0, 1]), points)
+
+        # a == -b: a half turn, which must keep the norms and be a rotation
+        # rather than a point reflection (that would negate every component).
+        rotated = rotate_points(points, [0, 0, 1], [0, 0, -1])
+        testing.assert_almost_equal(
+            np.linalg.norm(rotated, axis=1), np.linalg.norm(points, axis=1))
+        testing.assert_almost_equal(rotated[:, 2], -points[:, 2])
+        self.assertFalse(np.allclose(rotated, -points),
+                         'anti-parallel case is a reflection, not a rotation')
+
+        # The rotation must be the one that carries a onto b.
+        for a, b in (([0, 0, 1], [0, 0, -1]), ([1, 0, 0], [-1, 0, 0]),
+                     ([1, 1, 1], [-1, -1, -1])):
+            a = np.array(a, dtype=np.float64)
+            a /= np.linalg.norm(a)
+            b = np.array(b, dtype=np.float64)
+            b /= np.linalg.norm(b)
+            testing.assert_almost_equal(rotate_points(a, a, b)[0], b)
+
         points = np.array([[1, 0, 0]])
         rot_points = rotate_points(points, [1, 0, 0], [0, 0, 1])
         testing.assert_almost_equal(rot_points, [[0, 0, 1]])


### PR DESCRIPTION
`rotate_points` built its axis with `normalize_vector(cross(a, b))` and had **no guard for the degenerate directions**. When `a` and `b` are opposite, the cross product is zero, so the axis came out as `[0, 0, 0]` and theta as pi, and the Rodrigues expression collapsed to `points * cos(pi)` = `-points`.

That is a point reflection (det = -1), not a half turn:

```python
rotate_points([1, 2, 3], a=[0, 0, 1], b=[0, 0, -1])
# was:      [-1, -2, -3]   <- mirrored
# expected: [ 1, -2, -3]   <- half turn about X
```

It went unnoticed because the source vector itself lands correctly (`-a` is `b`). Every other point was mirrored instead of rotated.

`rotation_matrix_from_vectors` already handles both degenerate directions and returns a proper rotation, so use it.

### Testing
- Full suite passes.
- The new regression test fails on the unpatched code.