### PR TITLE
Stop look_at_rotation from discarding an up close to the view direction

### DIFF
--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -2903,18 +2903,19 @@ def look_at_rotation(camera_pos, target=None, up=None, return_matrix=True):
     # For OpenCV convention: camera looks along +Z, so R[2, :] = look_dir
     cam_z = look_dir
 
-    # If look direction is parallel to up vector, use alternative up
-    if abs(np.dot(cam_z, up)) > 0.99:
-        up = np.array([0.0, 1.0, 0.0])
-
     # Camera X axis (right) = look_dir × up (for right-hand system)
     cam_x = np.cross(cam_z, up)
     cam_x_norm = np.linalg.norm(cam_x)
-    if cam_x_norm < 1e-8:
-        # Fallback if cross product is zero
-        up = np.array([1.0, 0.0, 0.0])
-        cam_x = np.cross(cam_z, up)
-        cam_x_norm = np.linalg.norm(cam_x)
+    if cam_x_norm < _EPS:
+        # up is parallel to the view direction, so it cannot pin down the
+        # roll. Only then fall back to an up that can: a tolerance on the
+        # angle here would silently discard the caller's up.
+        for fallback_up in (np.array([0.0, 1.0, 0.0]),
+                            np.array([1.0, 0.0, 0.0])):
+            cam_x = np.cross(cam_z, fallback_up)
+            cam_x_norm = np.linalg.norm(cam_x)
+            if cam_x_norm >= _EPS:
+                break
     cam_x = cam_x / cam_x_norm
 
     # Camera Y axis (down in OpenCV) = cam_z × cam_x

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -15,6 +15,7 @@ from skrobot.coordinates.math import counter_clockwise_angle_between_vectors
 from skrobot.coordinates.math import cross_product
 from skrobot.coordinates.math import interpolate_rotation_matrices
 from skrobot.coordinates.math import invert_yaw_pitch_roll
+from skrobot.coordinates.math import look_at_rotation
 from skrobot.coordinates.math import matrix2quaternion
 from skrobot.coordinates.math import matrix2rpy
 from skrobot.coordinates.math import matrix2xyzrpy
@@ -967,6 +968,32 @@ class TestMath(unittest.TestCase):
         rot = rpy2matrix(roll, pitch, yaw)
         recovered_rpy = matrix2rpy(rot)
         testing.assert_almost_equal(recovered_rpy, np.array([roll, pitch, yaw]))
+
+    def test_look_at_rotation(self):
+        # The camera looks along +Z (OpenCV convention).
+        r = look_at_rotation(np.zeros(3), target=[0, 0, 1], up=[0, -1, 0])
+        _check_valid_rotation(r)
+        testing.assert_almost_equal(r[2], [0, 0, 1])
+
+        # A given up must be honoured however close it gets to the view
+        # direction; only an exactly parallel one leaves the roll undefined.
+        up = np.array([0.0, 0.0, 1.0])
+        for degree in (0.5, 3.0, 8.0, 8.2, 30.0, 90.0):
+            theta = np.deg2rad(degree)
+            target = np.array([np.sin(theta), 0.0, np.cos(theta)])
+            r = look_at_rotation(np.zeros(3), target=target, up=up)
+            _check_valid_rotation(r)
+            testing.assert_almost_equal(r[2], target)
+            # cam_x is built from cam_z x up, so it stays perpendicular to up.
+            testing.assert_almost_equal(
+                np.dot(r[0], up), 0.0,
+                err_msg='up was discarded at {} deg'.format(degree))
+
+        # up parallel to the view direction: fall back, but stay a rotation.
+        for up in ([0, 0, 1], [0, 0, -1]):
+            r = look_at_rotation(np.zeros(3), target=[0, 0, 1], up=up)
+            _check_valid_rotation(r)
+            testing.assert_almost_equal(r[2], [0, 0, 1])
 
     def test_rotation_matrix_from_vectors(self):
         # random directions: R maps a onto b exactly


### PR DESCRIPTION
`up` only fails to pin down the camera roll when it is parallel to the view direction, but the check was `abs(dot(cam_z, up)) > 0.99` — a tolerance on the **cosine**, so anything within **8.1 degrees** was treated as parallel. Inside that band the caller's `up` was silently swapped for `[0, 1, 0]` and the roll jumped at the boundary (measured: honoured at 8.2 deg, discarded at 8.1 deg).

Key the fallback off the cross product norm instead, so it only fires when the cross product really is zero. three.js `Matrix4.lookAt` does the same, and only for an exactly zero length.

### Testing
- The function had no tests; one is added covering the band, the parallel fallback and the returned basis.
- The new test fails on the unpatched code.
- 20000 random (direction, up) pairs all give an orthonormal `R` with `det = +1` and `R[2]` equal to the view direction.