### PR TITLE
Reuse rotation_matrix_from_vectors for the remaining Z-to-axis rotations

### DIFF
--- a/skrobot/collision/robot_collision.py
+++ b/skrobot/collision/robot_collision.py
@@ -20,6 +20,7 @@ from skrobot.collision.distance import collision_distance
 from skrobot.collision.geometry import Capsule
 from skrobot.collision.geometry import HalfSpace
 from skrobot.collision.geometry import Sphere
+from skrobot.coordinates.math import rotation_matrix_from_vectors
 
 
 class LinkCollisionGeometry:
@@ -739,22 +740,8 @@ class RobotCollisionChecker:
                 # Compute rotation to align Z-axis with capsule axis
                 rot_matrix = np.eye(3)
                 if height > 1e-6:
-                    axis_local_normalized = axis_local / height
-                    z_axis = np.array([0.0, 0.0, 1.0])
-                    # Rotation from Z to capsule axis
-                    v = np.cross(z_axis, axis_local_normalized)
-                    c = np.dot(z_axis, axis_local_normalized)
-                    if np.linalg.norm(v) > 1e-6:
-                        # Rodrigues' rotation formula
-                        vx = np.array([
-                            [0, -v[2], v[1]],
-                            [v[2], 0, -v[0]],
-                            [-v[1], v[0], 0]
-                        ])
-                        rot_matrix = np.eye(3) + vx + vx @ vx * (1 / (1 + c))
-                    elif c < 0:
-                        # 180 degree rotation around X
-                        rot_matrix = np.diag([1, -1, -1])
+                    rot_matrix = rotation_matrix_from_vectors(
+                        [0.0, 0.0, 1.0], axis_local)
 
                 # Create coords at capsule center with proper rotation
                 link_pos = link.copy_worldcoords()

--- a/skrobot/utils/primitive_fitting.py
+++ b/skrobot/utils/primitive_fitting.py
@@ -5,6 +5,7 @@ from logging import getLogger
 import numpy as np
 
 from skrobot._lazy_imports import _lazy_trimesh
+from skrobot.coordinates.math import rotation_matrix_from_vectors
 
 
 logger = getLogger(__name__)
@@ -287,21 +288,9 @@ def create_primitive_mesh(primitive_params):
 
         mesh = trimesh.creation.cylinder(radius=radius, height=height)
 
-        z_axis = np.array([0, 0, 1])
-        axis = axis / np.linalg.norm(axis)
-
-        if not np.allclose(axis, z_axis):
-            from skrobot.coordinates.math import rotation_matrix
-            if np.allclose(axis, -z_axis):
-                rot_matrix = rotation_matrix(np.pi, [1, 0, 0])
-            else:
-                rotation_axis = np.cross(z_axis, axis)
-                angle = np.arccos(np.clip(np.dot(z_axis, axis), -1.0, 1.0))
-                rot_matrix = rotation_matrix(angle, rotation_axis)
-
-            transform = np.eye(4)
-            transform[:3, :3] = rot_matrix
-            mesh.apply_transform(transform)
+        transform = np.eye(4)
+        transform[:3, :3] = rotation_matrix_from_vectors([0, 0, 1], axis)
+        mesh.apply_transform(transform)
 
         mesh.apply_translation(center)
         return mesh


### PR DESCRIPTION
Refactor only, no behavior change intended.

`skrobot/collision/robot_collision.py` and `skrobot/utils/primitive_fitting.py` each open coded the rotation taking +Z onto a given axis, with their own degenerate-direction handling. Neither is wrong today, but this is the same duplicated maths that had already drifted into a 5.7 degree dead band in `align_axis_to_direction` (#789) and into reflections in the viewer (#790) and in `rotate_points` (#791). Call the shared implementation instead.

The capsule form also divided by `1 + cos`, which loses precision as the axis approaches -Z; `rotation_matrix_from_vectors` keys off the cross product norm and stays well conditioned there.

### Testing
Full suite passes.