### PR TITLE
Reuse skew_symmetric_matrix instead of writing the matrix out again

### DIFF
--- a/skrobot/kinematics/differentiable.py
+++ b/skrobot/kinematics/differentiable.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from skrobot.backend import rodrigues_rotation as _rodrigues_rotation
 from skrobot.coordinates.math import normalize_axis_mask
+from skrobot.coordinates.math import skew_symmetric_matrix
 
 
 # =============================================================================
@@ -838,11 +839,7 @@ def compute_jacobian_analytical_batch(joint_angles_batch, fk_params):
             # Revolute joint: rotate around axis
             # Rodrigues formula: R = I + sin(θ)K + (1-cos(θ))K²
             # where K is skew-symmetric matrix of axis
-            K = np.array([
-                [0, -axis[2], axis[1]],
-                [axis[2], 0, -axis[0]],
-                [-axis[1], axis[0], 0]
-            ])
+            K = skew_symmetric_matrix(axis)
             K2 = K @ K
 
             sin_theta = np.sin(delta)[:, None, None]  # (batch_size, 1, 1)
@@ -2404,11 +2401,7 @@ def _create_jax_multi_ee_solver(fk_params_list, union_info):
         for i in range(n_joints):
             axis = np.array(fk_params['joint_axes'][i])
             axis_norm = axis / (np.linalg.norm(axis) + 1e-10)
-            K = np.array([
-                [0, -axis_norm[2], axis_norm[1]],
-                [axis_norm[2], 0, -axis_norm[0]],
-                [-axis_norm[1], axis_norm[0], 0]
-            ])
+            K = skew_symmetric_matrix(axis_norm)
             joint_K.append(jnp.array(K))
             joint_K2.append(jnp.array(K @ K))
 
@@ -3605,11 +3598,7 @@ def _create_jax_jacobian_solver(fk_params, backend):
         for i in range(n_joints):
             axis = np.array(fk_params['joint_axes'][i])
             axis_norm = axis / (np.linalg.norm(axis) + 1e-10)
-            K = np.array([
-                [0, -axis_norm[2], axis_norm[1]],
-                [axis_norm[2], 0, -axis_norm[0]],
-                [-axis_norm[1], axis_norm[0], 0]
-            ])
+            K = skew_symmetric_matrix(axis_norm)
             _joint_K.append(jnp.array(K))
             _joint_K2.append(jnp.array(K @ K))
 
@@ -4537,11 +4526,7 @@ def _axis_angle_to_matrix_batched(axis, angles):
     axis = axis / (np.linalg.norm(axis) + 1e-10)
 
     # Skew-symmetric matrix K
-    K = np.array([
-        [0, -axis[2], axis[1]],
-        [axis[2], 0, -axis[0]],
-        [-axis[1], axis[0], 0]
-    ])
+    K = skew_symmetric_matrix(axis)
 
     # K @ K precomputed
     K2 = K @ K

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -29,6 +29,7 @@ from skrobot.coordinates.math import normalize_mask
 from skrobot.coordinates.math import quaternion2matrix
 from skrobot.coordinates.math import rpy2quaternion
 from skrobot.coordinates.math import select_by_mask
+from skrobot.coordinates.math import skew_symmetric_matrix
 from skrobot.model.joint import calc_target_joint_dimension
 from skrobot.model.joint import calc_target_joint_dimension_from_link_list
 from skrobot.model.joint import FixedJoint
@@ -4476,9 +4477,7 @@ class RobotModel(CascadedLink):
 
                 # Parallel axis theorem
                 r = com_world - total_centroid
-                r_cross = np.array([[0, -r[2], r[1]],
-                                   [r[2], 0, -r[0]],
-                                   [-r[1], r[0], 0]])
+                r_cross = skew_symmetric_matrix(r)
                 total_inertia += link_inertia_world - link.mass * r_cross.dot(r_cross)
 
         return {


### PR DESCRIPTION
`skew_symmetric_matrix` already exists in `coordinates/math.py`, but it had **two** internal callers while the same 3x3 matrix was spelled out by hand in **seven** places.

That is how the vector-alignment maths drifted into a 5.7 degree dead band (#789) and into reflections (#790, #791): the shared helper was there, nobody called it.

This replaces the five numpy ones:

- `skrobot/model/robot_model.py` (`r_cross`)
- `skrobot/kinematics/differentiable.py` x4

The two remaining copies build `jnp` arrays for jax and cannot use the numpy helper, so they are left alone.

Only the matrix construction changes; the callers keep their own `axis / (norm + 1e-10)` normalization.

### Deliberately not included

`rodrigues()` is hand-rolled in four more places (`I + sin*K + (1-cos)*K@K`), but reusing it there would regress: `rodrigues([0, 0, 0], t)` returns NaN, whereas the current code yields identity for a zero axis, which a zero-axis joint in a URDF would hit.

### Testing

- Full suite passes (440).
- `skew_symmetric_matrix(a)` verified identical to the hand-written matrix over 5000 random axes, including dtype and shape for float, int and list inputs.