### PR TITLE
Fix rotate_vector silently returning garbage for a batch of vectors

### DIFF
--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -737,12 +737,12 @@ class Coordinates(object):
         Parameters
         ----------
         v : numpy.ndarray
-            vector shape of (3,)
+            vector shape of (3,) or (N, 3)
 
         Returns
         -------
-        np.matmul(self._rotation, v) : numpy.ndarray
-            rotated vector
+        rotated_vector : numpy.ndarray
+            rotated vector, of the same shape as ``v``
 
         Examples
         --------
@@ -752,6 +752,9 @@ class Coordinates(object):
         >>> c.rotate_vector([1, 2, 3])
         array([-1., -2.,  3.])
         """
+        v = np.array(v, dtype=np.float64)
+        if v.ndim == 2:
+            return np.matmul(self._rotation, v.T).T
         return np.matmul(self._rotation, v)
 
     def inverse_rotate_vector(self, v):

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -145,6 +145,24 @@ class TestCoordinates(unittest.TestCase):
         expected_pos = ref_coord.transform_vector([2, 2, 2])
         testing.assert_array_equal(coord.translation, expected_pos)
 
+    def test_rotate_vector_batch_matches_single(self):
+        # (N, 3) went through np.matmul(R, v) unbranched, which does not raise
+        # for N == 3 -- it silently computed something else.
+        c = make_coords(pos=[1, 2, 3], rot=rotation_matrix(0.5, [0.3, -0.4, 0.5]))
+        points = np.array([[0.5, -1.5, 2.5], [0.0, 0.0, 0.0], [-3.0, 1.0, 0.25]])
+
+        rotated = c.rotate_vector(points)
+        self.assertEqual(rotated.shape, points.shape)
+        # A zero vector stays zero under any rotation.
+        testing.assert_almost_equal(rotated[1], [0, 0, 0])
+        # Every row must equal the single-vector call.
+        for i, point in enumerate(points):
+            testing.assert_almost_equal(rotated[i], c.rotate_vector(point))
+        testing.assert_almost_equal(rotated, points.dot(c.rotation.T))
+        # Transform exposes the same API and was already correct.
+        testing.assert_almost_equal(
+            rotated, c.get_transform().rotate_vector(points))
+
     def test_transform(self):
         coord = make_coords()
         coord.transform(make_coords(pos=[1, 2, 3]))


### PR DESCRIPTION
`Coordinates.rotate_vector` was a bare `np.matmul(self._rotation, v)`. That is right for a single `(3,)` vector, but for an `(N, 3)` batch numpy computes `(3, 3) @ (N, 3)`, which does not even raise when `N == 3` — it just returns something else:

```python
c.rotate_vector([[1, 2, 3], [0, 0, 0]])[1]   # -> [0.91, -0.72, 0.71]
```

A zero vector stays zero under any rotation, so that answer is impossible. It also disagreed with scipy's `Rotation.apply`.

Every sibling already handles both shapes:

| API | batch handling |
|---|---|
| `Coordinates.transform_vector` | branches on `ndim` ✅ |
| `Coordinates.inverse_rotate_vector` | `matmul(v, R)`, works either way ✅ |
| `Transform.rotate_vector` | correct ✅ |
| **`Coordinates.rotate_vector`** | **no branch** ❌ |

Only this one was out of step, so give it the same `ndim` branch `transform_vector` uses.

The existing test only fed a batch to `Transform.rotate_vector` — the implementation that was already correct — and asserted that no exception was raised rather than checking a value.

### Testing

- Full suite passes (456).
- The new regression test fails on the unpatched code.
- 2000 random (coords, 5x3 points) cases now match `scipy.spatial.transform.Rotation.apply` exactly, agree with the single-vector call row by row, and agree with `Transform.rotate_vector`.