### PR TITLE
Deprecate Coordinates.quaternion in favour of the explicit spellings

### DIFF
--- a/examples/trajectory_interpolation_demo.py
+++ b/examples/trajectory_interpolation_demo.py
@@ -83,8 +83,8 @@ def main():
     print("Rotation type: {}".format('Simple' if args.simple_rotation else 'Complex'))
     print("Start position: {}".format(start_coords.translation))
     print("End position: {}".format(end_coords.translation))
-    print("Start quaternion: {}".format(start_coords.quaternion))
-    print("End quaternion: {}".format(end_coords.quaternion))
+    print("Start quaternion: {}".format(start_coords.quaternion_wxyz))
+    print("End quaternion: {}".format(end_coords.quaternion_wxyz))
 
     start_frame_objects = create_coordinate_frame(start_coords, "start", 0.15)
     end_frame_objects = create_coordinate_frame(end_coords, "end", 0.15)

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -669,6 +669,11 @@ class Coordinates(object):
     def quaternion(self):
         """Property of quaternion in [w, x, y, z] format
 
+        .. deprecated::
+            The name does not say which order it returns. Use
+            :attr:`quaternion_wxyz` for [w, x, y, z] or
+            :attr:`quaternion_xyzw` for [x, y, z, w] instead.
+
         Returns
         -------
         q : numpy.ndarray
@@ -679,22 +684,43 @@ class Coordinates(object):
         >>> from numpy import pi
         >>> from skrobot.coordinates import make_coords
         >>> c = make_coords()
-        >>> c.quaternion
+        >>> c.quaternion_wxyz
         array([1., 0., 0., 0.])
         >>> c.rotate(pi / 3, 'y').rotate(pi / 5, 'z')
-        >>> c.quaternion
+        >>> c.quaternion_wxyz
         array([0.8236391 , 0.1545085 , 0.47552826, 0.26761657])
         """
-        return matrix2quaternion(self._rotation)
+        warnings.warn(
+            "quaternion is deprecated because the name does not say which "
+            "order it returns. Use quaternion_wxyz for [w, x, y, z] or "
+            "quaternion_xyzw for [x, y, z, w] instead.",
+            DeprecationWarning,
+            stacklevel=2)
+        return self.quaternion_wxyz
 
     @property
     def quaternion_wxyz(self):
         """Property of quaternion in [w, x, y, z] format
 
+        This is the order skrobot uses everywhere else, so it is what
+        :attr:`quaternion` returns too. See :attr:`quaternion_xyzw` for the
+        other order, which ROS and pybullet use.
+
         Returns
         -------
         q : numpy.ndarray
             [w, x, y, z] quaternion
+
+        Examples
+        --------
+        >>> from numpy import pi
+        >>> from skrobot.coordinates import make_coords
+        >>> c = make_coords()
+        >>> c.quaternion_wxyz
+        array([1., 0., 0., 0.])
+        >>> c.rotate(pi / 3, 'y').rotate(pi / 5, 'z')
+        >>> c.quaternion_wxyz
+        array([0.8236391 , 0.1545085 , 0.47552826, 0.26761657])
         """
         return matrix2quaternion(self._rotation)
 
@@ -2230,8 +2256,8 @@ def slerp_coordinates(c1, c2, t):
     interpolated_pos = pos1 + t * (pos2 - pos1)
 
     # True spherical linear interpolation for rotation using quaternions
-    q1 = c1.quaternion
-    q2 = c2.quaternion
+    q1 = c1.quaternion_wxyz
+    q2 = c2.quaternion_wxyz
 
     # Ensure we take the shorter path for rotation
     if np.dot(q1, q2) < 0:
@@ -2294,8 +2320,8 @@ def lerp_coordinates(c1, c2, t):
     interpolated_pos = pos1 + t * (pos2 - pos1)
 
     # Linear interpolation for rotation using quaternions
-    q1 = c1.quaternion
-    q2 = c2.quaternion
+    q1 = c1.quaternion_wxyz
+    q2 = c2.quaternion_wxyz
 
     # Ensure we take the shorter path
     if np.dot(q1, q2) < 0:

--- a/tests/skrobot_tests/coordinates_tests/test_base.py
+++ b/tests/skrobot_tests/coordinates_tests/test_base.py
@@ -153,6 +153,27 @@ class TestCoordinates(unittest.TestCase):
         testing.assert_almost_equal(coord.rotation,
                                     [[-1, 0, 0], [0, -1, 0], [0, 0, 1]])
 
+    def test_quaternion_is_deprecated_alias_of_wxyz(self):
+        c = make_coords().rotate(pi / 3, 'y').rotate(pi / 5, 'z')
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            ambiguous = c.quaternion
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning) for w in caught))
+        # Same value as before, so callers keep working.
+        testing.assert_almost_equal(ambiguous, c.quaternion_wxyz)
+
+        # The explicit spellings stay quiet and disagree with each other,
+        # which is the whole reason the bare name is ambiguous.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            wxyz = c.quaternion_wxyz
+            xyzw = c.quaternion_xyzw
+        self.assertFalse(
+            any(issubclass(w.category, DeprecationWarning) for w in caught))
+        testing.assert_almost_equal(xyzw, wxyz2xyzw(wxyz))
+        self.assertFalse(np.allclose(wxyz, xyzw))
+
     def test_init_rotation_forms(self):
         # rot accepts a 3x3 matrix, a quaternion or rpy angles, and pos can
         # carry a whole 4x4 matrix.
@@ -305,7 +326,7 @@ class TestCoordinates(unittest.TestCase):
         testing.assert_almost_equal(
             result.translation, (1, 2, 3))
         testing.assert_almost_equal(
-            result.quaternion, (0, 0, 1, 0))
+            result.quaternion_wxyz, (0, 0, 1, 0))
 
     def test_translate(self):
         c = make_coords()
@@ -405,13 +426,13 @@ class TestCoordinates(unittest.TestCase):
             coord_a.transformation(coord_b).worldpos(),
             [1, 0, -1])
         testing.assert_almost_equal(
-            coord_a.transformation(coord_b).quaternion,
+            coord_a.transformation(coord_b).quaternion_wxyz,
             [1, 0, 0, 0])
         testing.assert_almost_equal(
             coord_b.transformation(coord_a).worldpos(),
             [-1, 0, 1])
         testing.assert_almost_equal(
-            coord_b.transformation(coord_a).quaternion,
+            coord_b.transformation(coord_a).quaternion_wxyz,
             [1, 0, 0, 0])
 
         c = make_coords(rot=[deg2rad(10), 0, 0])
@@ -433,7 +454,7 @@ class TestCoordinates(unittest.TestCase):
             coord_b.inverse_transformation().worldpos(),
             [-0.41549991, -0.12132025, 0.83588229])
         testing.assert_almost_equal(
-            coord_b.inverse_transformation().quaternion,
+            coord_b.inverse_transformation().quaternion_wxyz,
             [0.20692513, 0.50841015, 0.82812527, 0.1136206])
 
         # check inverse of transformation(worldcoords)
@@ -454,10 +475,10 @@ class TestCoordinates(unittest.TestCase):
     def test_quaternion(self):
         c = make_coords()
         testing.assert_almost_equal(
-            c.quaternion, [1, 0, 0, 0])
+            c.quaternion_wxyz, [1, 0, 0, 0])
         c.rotate(pi / 3, 'y').rotate(pi / 5, 'z')
         testing.assert_almost_equal(
-            c.quaternion,
+            c.quaternion_wxyz,
             [0.8236391, 0.1545085, 0.47552826, 0.26761657])
 
     def test_difference_position(self):

--- a/tests/skrobot_tests/interfaces_tests/ros/test_tf_utils.py
+++ b/tests/skrobot_tests/interfaces_tests/ros/test_tf_utils.py
@@ -49,21 +49,21 @@ class TestTFUtils(unittest.TestCase):
         pose = geometry_msgs.msg.Transform()
         c = tf_pose_to_coords(pose)
         testing.assert_equal(c.translation, (0, 0, 0))
-        testing.assert_equal(c.quaternion, (1, 0, 0, 0))
+        testing.assert_equal(c.quaternion_wxyz, (1, 0, 0, 0))
 
         pose_stamped = geometry_msgs.msg.TransformStamped()
         c = tf_pose_to_coords(pose_stamped)
         testing.assert_equal(c.translation, (0, 0, 0))
-        testing.assert_equal(c.quaternion, (1, 0, 0, 0))
+        testing.assert_equal(c.quaternion_wxyz, (1, 0, 0, 0))
 
     @unittest.skipUnless(_ros_available, 'ROS is not available.')
     def test_geometry_pose_to_coords(self):
         pose = geometry_msgs.msg.Pose()
         c = geometry_pose_to_coords(pose)
         testing.assert_equal(c.translation, (0, 0, 0))
-        testing.assert_equal(c.quaternion, (1, 0, 0, 0))
+        testing.assert_equal(c.quaternion_wxyz, (1, 0, 0, 0))
 
         pose_stamped = geometry_msgs.msg.Pose()
         c = geometry_pose_to_coords(pose_stamped)
         testing.assert_equal(c.translation, (0, 0, 0))
-        testing.assert_equal(c.quaternion, (1, 0, 0, 0))
+        testing.assert_equal(c.quaternion_wxyz, (1, 0, 0, 0))


### PR DESCRIPTION
`quaternion` and `quaternion_wxyz` had byte-identical bodies:

```python
@property
def quaternion(self):
    """Property of quaternion in [w, x, y, z] format"""
    return matrix2quaternion(self._rotation)

@property
def quaternion_wxyz(self):
    """Property of quaternion in [w, x, y, z] format"""
    return matrix2quaternion(self._rotation)
```

The bare name does not say which order it returns, and that is a real hazard here: skrobot is `wxyz` throughout while ROS and pybullet are `xyzw`, and the library ships `wxyz2xyzw` / `xyzw2wxyz` for exactly that reason. Handing one to code expecting the other does not raise — it just rotates differently.

Keep the property and its value, but warn and point at `quaternion_wxyz` or `quaternion_xyzw`.

**Deleting it is not an option**: callers outside this repo read it, e.g. `qw, qx, qy, qz = link.copy_worldcoords().quaternion` in [iory/urdfeus](https://github.com/iory/urdfeus), and `link_coords.quaternion` in [iory/formamotus](https://github.com/iory/formamotus).

### Also

- `lerp_coordinates` and `slerp_coordinates` were reading `.quaternion`; switched to `quaternion_wxyz` first, so the library does not warn at itself.
- Tests and the example migrated.
- `quaternion_wxyz`'s docstring now says which convention is which — that is the question a reader arrives with.

The deprecation follows the pattern already in this file (`rpy_angle`, `orient_coords_to_axis`, `assoc(c=...)`).

### Testing

- Full suite passes (470). The value is unchanged, so existing callers keep working; they only gain a warning.
- New test asserts the warning fires, that the value still equals `quaternion_wxyz`, that the explicit spellings stay quiet, and that `wxyz` and `xyzw` really do differ — which is the whole reason the bare name is ambiguous.