### PR TITLE
Say which order the remaining quaternion docstrings mean

### DIFF
--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -2281,9 +2281,9 @@ def quaternion_slerp(q0, q1, fraction, spin=0, shortestpath=True):
     Parameters
     ----------
     q0 : list or numpy.ndarray
-        start quaternion
+        start quaternion in [w, x, y, z] order
     q1 : list or numpy.ndarray
-        end quaternion
+        end quaternion in [w, x, y, z] order
     fraction : float
         ratio
     spin : int
@@ -2294,7 +2294,7 @@ def quaternion_slerp(q0, q1, fraction, spin=0, shortestpath=True):
     Returns
     -------
     quaternion : numpy.ndarray
-        spherical linear interpolated quaternion
+        spherical linear interpolated quaternion in [w, x, y, z] order
 
     Examples
     --------
@@ -2515,7 +2515,7 @@ def rotation_vector_to_quaternion(rvec):
     Returns
     -------
     q : numpy.ndarray
-        quaternion
+        quaternion in [w, x, y, z] order
     """
     rvec = np.array(rvec).reshape(-1)
     theta = np.linalg.norm(rvec)


### PR DESCRIPTION
Docs only.

Of the seventeen quaternion functions in `math.py`, fifteen already spell out `[w, x, y, z]`. `quaternion_slerp` and `rotation_vector_to_quaternion` just said "quaternion", leaving the reader to guess — and the guess is a coin flip that does not raise, because skrobot is scalar-first while ROS and pybullet are scalar-last:

```python
q_ros = [0.0, 0.0, 0.3826834, 0.9238795]   # xyzw, 45 deg about z
quaternion2matrix(q_ros) @ [1, 0, 0]       # -> [-1, 0, 0]   no error, wrong rotation
                                           #    [0.707, 0.707, 0] is correct
```

Both are scalar-first; confirmed against the implementations rather than assumed.