### PR TITLE
Point the two rotate_vector functions at each other

### DIFF
--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -760,6 +760,11 @@ class Coordinates(object):
     def rotate_vector(self, v):
         """Rotate 3-dimensional vector using rotation of this coordinate
 
+        The rotation applied is this coordinate's own. To rotate a vector
+        around an arbitrary axis by an angle instead, use
+        :func:`skrobot.coordinates.math.rotate_vector`, which shares the name
+        but takes an axis and an angle.
+
         Parameters
         ----------
         v : numpy.ndarray

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -892,16 +892,20 @@ def rotation_matrix(theta, axis, skip_normalization=False):
 
 
 def rotate_vector(vec, theta, axis):
-    """Rotate vector.
+    """Rotate vector around an axis by an angle.
 
     Rotate vec with respect to axis.
+
+    This takes an axis and an angle. It is not the same operation as
+    :meth:`skrobot.coordinates.Coordinates.rotate_vector`, which shares the
+    name but rotates a vector by the coordinate's own rotation.
 
     Parameters
     ----------
     vec : list or numpy.ndarray
         target vector
     theta : float
-        rotation angle
+        rotation angle in radian
     axis : list or numpy.ndarray or str
         axis of rotation.
 


### PR DESCRIPTION
Docs only.

```python
math.rotate_vector(vec, theta, axis)   # rotates around an axis by an angle
Coordinates.rotate_vector(v)           # applies the coordinate's own rotation
```

Same name, different operations. Reaching for the wrong one is a real first move — the name is the obvious candidate either way — so each docstring now names the other.

Mixing them up **raises** rather than returning a wrong answer:

```python
math.rotate_vector([1, 0, 0], q_wxyz, 'z')   # ValueError
math.rotate_vector([1, 0, 0], 'z', pi / 2)   # ValueError: Invalid type for axis
math.rotate_vector([1, 0, 0], q_wxyz)        # TypeError: missing 1 required positional argument
```

So this is a signpost, not a fix — renaming would break `interfaces/ros/move_base.py` and any caller outside the repo for no correctness gain.