### PR TITLE
Deprecate rotate_vector and rotate_matrix for names that say axis-angle

### DIFF
--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -17,7 +17,7 @@ from skrobot.coordinates.math import normalize_vector
 from skrobot.coordinates.math import quaternion2matrix
 from skrobot.coordinates.math import random_rotation
 from skrobot.coordinates.math import random_translation
-from skrobot.coordinates.math import rotate_matrix
+from skrobot.coordinates.math import rotate_matrix_by_axis_angle
 from skrobot.coordinates.math import rotation_distance
 from skrobot.coordinates.math import rotation_matrix
 from skrobot.coordinates.math import rotation_matrix_from_vectors
@@ -1008,7 +1008,7 @@ class Coordinates(object):
         if rotation_mirror is not None:
             rot = coords.worldrot()
             if not need_mirror_for_nearest_axis(self, coords, rotation_mirror):
-                rot = rotate_matrix(rot, np.pi, rotation_mirror)
+                rot = rotate_matrix_by_axis_angle(rot, np.pi, rotation_mirror)
             dif_rot = rotation_matrix_to_axis_angle_vector(
                 np.matmul(self.worldrot().T, rot))
             dif_rot[mask_vec == 0] = 0.0
@@ -1100,11 +1100,11 @@ class Coordinates(object):
         elif axis is None or axis is False:
             self.rotate_with_matrix(theta, wrt)
         elif wrt == 'local' or wrt == self:
-            self._rotation = rotate_matrix(
+            self._rotation = rotate_matrix_by_axis_angle(
                 self._rotation, theta, axis,
                 skip_normalization=skip_normalization)
         elif wrt == 'parent' or wrt == 'world':
-            self._rotation = rotate_matrix(
+            self._rotation = rotate_matrix_by_axis_angle(
                 self._rotation, theta,
                 axis, True,
                 skip_normalization=skip_normalization)
@@ -2003,13 +2003,15 @@ class CascadedCoords(Coordinates):
             return self.rotate_with_matrix(theta, wrt)
 
         if wrt == 'local' or wrt == self:
-            rotation = rotate_matrix(self._rotation, theta, axis,
-                                     skip_normalization=skip_normalization)
+            rotation = rotate_matrix_by_axis_angle(
+                self._rotation, theta, axis,
+                skip_normalization=skip_normalization)
             return self.newcoords(rotation, self._translation,
                                   check_validity=False, relative_coords='local')
         elif wrt == 'parent' or wrt == self.parent:
-            rotation = rotate_matrix(self._rotation, theta, axis,
-                                     skip_normalization=skip_normalization)
+            rotation = rotate_matrix_by_axis_angle(
+                self._rotation, theta, axis,
+                skip_normalization=skip_normalization)
             return self.newcoords(rotation, self._translation,
                                   check_validity=False, relative_coords='local')
         else:

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -891,17 +891,15 @@ def rotation_matrix(theta, axis, skip_normalization=False):
     return out
 
 
-def rotate_vector(vec, theta, axis):
-    """Rotate vector.
-
-    Rotate vec with respect to axis.
+def rotate_vector_by_axis_angle(vec, theta, axis):
+    """Rotate a vector around an axis by an angle.
 
     Parameters
     ----------
     vec : list or numpy.ndarray
         target vector
     theta : float
-        rotation angle
+        rotation angle in radian
     axis : list or numpy.ndarray or str
         axis of rotation.
 
@@ -910,15 +908,21 @@ def rotate_vector(vec, theta, axis):
     rotated_vec : numpy.ndarray
         rotated vector.
 
+    See Also
+    --------
+    skrobot.coordinates.Coordinates.rotate_vector :
+        rotate a vector by a coordinate's own rotation, rather than by an
+        axis and an angle.
+
     Examples
     --------
     >>> from numpy import pi
-    >>> from skrobot.coordinates.math import rotate_vector
-    >>> rotate_vector([1, 0, 0], pi / 6.0, [1, 0, 0])
+    >>> from skrobot.coordinates.math import rotate_vector_by_axis_angle
+    >>> rotate_vector_by_axis_angle([1, 0, 0], pi / 6.0, [1, 0, 0])
     array([1., 0., 0.])
-    >>> rotate_vector([1, 0, 0], pi / 6.0, [0, 1, 0])
+    >>> rotate_vector_by_axis_angle([1, 0, 0], pi / 6.0, [0, 1, 0])
     array([ 0.8660254,  0.       , -0.5      ])
-    >>> rotate_vector([1, 0, 0], pi / 6.0, [0, 0, 1])
+    >>> rotate_vector_by_axis_angle([1, 0, 0], pi / 6.0, [0, 0, 1])
     array([0.8660254, 0.5      , 0.       ])
     """
     rot = rotation_matrix(theta, axis)
@@ -926,7 +930,63 @@ def rotate_vector(vec, theta, axis):
     return rotated_vec
 
 
-def rotate_matrix(matrix, theta, axis, world=None, skip_normalization=False):
+def rotate_vector(vec, theta, axis):
+    """Rotate a vector around an axis by an angle.
+
+    .. deprecated::
+        The name reads like
+        :meth:`skrobot.coordinates.Coordinates.rotate_vector`, which rotates
+        by a coordinate's own rotation instead. Use
+        :func:`rotate_vector_by_axis_angle`.
+
+    Parameters
+    ----------
+    vec : list or numpy.ndarray
+        target vector
+    theta : float
+        rotation angle in radian
+    axis : list or numpy.ndarray or str
+        axis of rotation.
+
+    Returns
+    -------
+    rotated_vec : numpy.ndarray
+        rotated vector.
+    """
+    warnings.warn(
+        'rotate_vector is deprecated because the name reads like '
+        "Coordinates.rotate_vector, which rotates by a coordinate's own "
+        'rotation rather than by an axis and an angle. Use '
+        'rotate_vector_by_axis_angle instead.',
+        DeprecationWarning,
+        stacklevel=2)
+    return rotate_vector_by_axis_angle(vec, theta, axis)
+
+
+def rotate_matrix_by_axis_angle(matrix, theta, axis, world=None,
+                                skip_normalization=False):
+    """Rotate a rotation matrix around an axis by an angle.
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray
+        3x3 rotation matrix to rotate
+    theta : float
+        rotation angle in radian
+    axis : list or numpy.ndarray or str
+        axis of rotation.
+    world : bool or None
+        if None or False, rotate about ``matrix``'s own axes, i.e. multiply
+        the new rotation from the right. Otherwise rotate about the world
+        axes, i.e. multiply from the left.
+    skip_normalization : bool
+        if True, skip normalization of ``axis``.
+
+    Returns
+    -------
+    rotated_matrix : numpy.ndarray
+        3x3 rotation matrix
+    """
     if world is False or world is None:
         return np.dot(
             matrix,
@@ -935,6 +995,42 @@ def rotate_matrix(matrix, theta, axis, world=None, skip_normalization=False):
     return np.dot(
         rotation_matrix(theta, axis, skip_normalization=skip_normalization),
         matrix)
+
+
+def rotate_matrix(matrix, theta, axis, world=None, skip_normalization=False):
+    """Rotate a rotation matrix around an axis by an angle.
+
+    .. deprecated::
+        Renamed for symmetry with :func:`rotate_vector_by_axis_angle`. Use
+        :func:`rotate_matrix_by_axis_angle`.
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray
+        3x3 rotation matrix to rotate
+    theta : float
+        rotation angle in radian
+    axis : list or numpy.ndarray or str
+        axis of rotation.
+    world : bool or None
+        if None or False, rotate about ``matrix``'s own axes. Otherwise
+        rotate about the world axes.
+    skip_normalization : bool
+        if True, skip normalization of ``axis``.
+
+    Returns
+    -------
+    rotated_matrix : numpy.ndarray
+        3x3 rotation matrix
+    """
+    warnings.warn(
+        'rotate_matrix is deprecated. Use rotate_matrix_by_axis_angle '
+        'instead.',
+        DeprecationWarning,
+        stacklevel=2)
+    return rotate_matrix_by_axis_angle(
+        matrix, theta, axis, world=world,
+        skip_normalization=skip_normalization)
 
 
 def rpy_matrix(az, ay, ax):
@@ -972,8 +1068,8 @@ def rpy_matrix(az, ay, ax):
            [-8.66025404e-01,  2.50000000e-01,  4.33012702e-01]])
     """
     r = rotation_matrix(ax, 'x')
-    r = rotate_matrix(r, ay, 'y', world=True)
-    r = rotate_matrix(r, az, 'z', world=True)
+    r = rotate_matrix_by_axis_angle(r, ay, 'y', world=True)
+    r = rotate_matrix_by_axis_angle(r, az, 'z', world=True)
     return r
 
 

--- a/skrobot/interfaces/ros/move_base.py
+++ b/skrobot/interfaces/ros/move_base.py
@@ -12,7 +12,7 @@ import std_srvs.srv
 import trajectory_msgs.msg
 
 from skrobot.coordinates import Coordinates
-from skrobot.coordinates.math import rotate_vector
+from skrobot.coordinates.math import rotate_vector_by_axis_angle
 from skrobot.coordinates.math import rotation_distance
 from skrobot.interfaces.ros.base import ROSRobotInterfaceBase
 from skrobot.interfaces.ros.tf_utils import coords_to_geometry_pose
@@ -369,7 +369,7 @@ class ROSRobotMoveBaseInterface(ROSRobotInterfaceBase):
             odom_angle = odom.rpy_angle()[0][0]
             diff_position = goal_position - (
                 odom_pos + np.array((0, 0, odom_angle)))
-            v = rotate_vector(
+            v = rotate_vector_by_axis_angle(
                 np.array((diff_position[0], diff_position[1], 0.0)),
                 -odom_angle, 'z') - np.array((0, 0, odom_angle))
             x = v[0]

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -1,6 +1,7 @@
 import math
 import sys
 import unittest
+import warnings
 
 import numpy as np
 from numpy import pi
@@ -39,7 +40,9 @@ from skrobot.coordinates.math import random_rotation
 from skrobot.coordinates.math import random_translation
 from skrobot.coordinates.math import rodrigues
 from skrobot.coordinates.math import rotate_matrix
+from skrobot.coordinates.math import rotate_matrix_by_axis_angle
 from skrobot.coordinates.math import rotate_vector
+from skrobot.coordinates.math import rotate_vector_by_axis_angle
 from skrobot.coordinates.math import rotation_angle
 from skrobot.coordinates.math import rotation_distance
 from skrobot.coordinates.math import rotation_matrix
@@ -108,7 +111,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(ret, 6)
 
     def test_midrot(self):
-        m1 = rotate_matrix(rotate_matrix(rotate_matrix(
+        m1 = rotate_matrix_by_axis_angle(rotate_matrix_by_axis_angle(rotate_matrix_by_axis_angle(
             np.eye(3), 0.2, 'x'), 0.4, 'y'), 0.6, 'z')
         testing.assert_almost_equal(
             interpolate_rotation_matrices(0.5, m1, np.eye(3)),
@@ -184,6 +187,49 @@ class TestMath(unittest.TestCase):
                       [0.0, 0.0, 1.0]]),
             decimal=5)
 
+    def test_deprecated_rotate_helpers(self):
+        # The old names still work and still return the same values; they only
+        # gained a warning pointing at the unambiguous spelling.
+        vec = np.array([1.0, 0.0, 0.0])
+        matrix = rotation_matrix(0.3, 'x')
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            rotated_vec = rotate_vector(vec, 0.5, 'z')
+            rotated_matrix = rotate_matrix(matrix, 0.5, 'z')
+            world = rotate_matrix(matrix, 0.5, 'z', world=True)
+        deprecations = [w for w in caught
+                        if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(len(deprecations), 3)
+
+        testing.assert_almost_equal(
+            rotated_vec, rotate_vector_by_axis_angle(vec, 0.5, 'z'))
+        testing.assert_almost_equal(
+            rotated_matrix, rotate_matrix_by_axis_angle(matrix, 0.5, 'z'))
+        testing.assert_almost_equal(
+            world, rotate_matrix_by_axis_angle(matrix, 0.5, 'z', world=True))
+
+        # The new names stay quiet.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            rotate_vector_by_axis_angle(vec, 0.5, 'z')
+            rotate_matrix_by_axis_angle(matrix, 0.5, 'z')
+        self.assertFalse([w for w in caught
+                          if issubclass(w.category, DeprecationWarning)])
+
+    def test_rotate_matrix_by_axis_angle_world_flag(self):
+        # world picks which side the new rotation multiplies on.
+        matrix = rotation_matrix(0.3, 'x')
+        turn = rotation_matrix(0.5, 'z')
+        testing.assert_almost_equal(
+            rotate_matrix_by_axis_angle(matrix, 0.5, 'z'), matrix.dot(turn))
+        testing.assert_almost_equal(
+            rotate_matrix_by_axis_angle(matrix, 0.5, 'z', world=False),
+            matrix.dot(turn))
+        testing.assert_almost_equal(
+            rotate_matrix_by_axis_angle(matrix, 0.5, 'z', world=True),
+            turn.dot(matrix))
+
     def test_rodrigues(self):
         mat = rpy_matrix(pi / 6, pi / 5, pi / 3)
         theta, axis = rotation_angle(mat)
@@ -227,13 +273,13 @@ class TestMath(unittest.TestCase):
 
     def test_rotate_vector(self):
         testing.assert_array_almost_equal(
-            rotate_vector([1, 0, 0], pi / 6.0, [1, 0, 0]),
+            rotate_vector_by_axis_angle([1, 0, 0], pi / 6.0, [1, 0, 0]),
             (1, 0, 0))
         testing.assert_array_almost_equal(
-            rotate_vector([1, 0, 0], pi / 6.0, [0, 1, 0]),
+            rotate_vector_by_axis_angle([1, 0, 0], pi / 6.0, [0, 1, 0]),
             (0.8660254, 0, -0.5))
         testing.assert_array_almost_equal(
-            rotate_vector([1, 0, 0], pi / 6.0, [0, 0, 1]),
+            rotate_vector_by_axis_angle([1, 0, 0], pi / 6.0, [0, 0, 1]),
             (0.8660254, 0.5, 0))
 
     def test_rotation_angle(self):
@@ -274,7 +320,7 @@ class TestMath(unittest.TestCase):
             [12, 0, -4])
 
     def test_matrix_exponent(self):
-        m1 = rotate_matrix(rotate_matrix(rotate_matrix(
+        m1 = rotate_matrix_by_axis_angle(rotate_matrix_by_axis_angle(rotate_matrix_by_axis_angle(
             np.eye(3), 0.2, 'x'), 0.4, 'y'), 0.6, 'z')
         testing.assert_almost_equal(
             axis_angle_vector_to_rotation_matrix(rotation_matrix_to_axis_angle_vector(m1)), m1,
@@ -311,9 +357,9 @@ class TestMath(unittest.TestCase):
                       [-0.1656854, -0.9656854, 0.2000000]]))
         testing.assert_almost_equal(
             quaternion2matrix([0.925754, 0.151891, 0.159933, 0.307131]),
-            rotate_matrix(
-                rotate_matrix(
-                    rotate_matrix(
+            rotate_matrix_by_axis_angle(
+                rotate_matrix_by_axis_angle(
+                    rotate_matrix_by_axis_angle(
                         np.eye(3), 0.2, 'x'), 0.4, 'y'), 0.6, 'z'),
             decimal=5)
 
@@ -330,9 +376,9 @@ class TestMath(unittest.TestCase):
         testing.assert_almost_equal(matrix2quaternion(np.eye(3)),
                                     np.array([1, 0, 0, 0]))
 
-        m = rotate_matrix(
-            rotate_matrix(
-                rotate_matrix(
+        m = rotate_matrix_by_axis_angle(
+            rotate_matrix_by_axis_angle(
+                rotate_matrix_by_axis_angle(
                     np.eye(3), 0.2, 'x'), 0.4, 'y'), 0.6, 'z')
 
         testing.assert_almost_equal(
@@ -413,9 +459,9 @@ class TestMath(unittest.TestCase):
         # trace/diagonal; exercise each with a matrix that lands in it.
         cases = [
             (np.eye(3), [1, 0, 0, 0]),                       # tr > 0
-            (rotate_matrix(np.eye(3), pi, 'x'), [0, 1, 0, 0]),  # m00 largest
-            (rotate_matrix(np.eye(3), pi, 'y'), [0, 0, 1, 0]),  # m11 largest
-            (rotate_matrix(np.eye(3), pi, 'z'), [0, 0, 0, 1]),  # else (m22)
+            (rotate_matrix_by_axis_angle(np.eye(3), pi, 'x'), [0, 1, 0, 0]),  # m00 largest
+            (rotate_matrix_by_axis_angle(np.eye(3), pi, 'y'), [0, 0, 1, 0]),  # m11 largest
+            (rotate_matrix_by_axis_angle(np.eye(3), pi, 'z'), [0, 0, 0, 1]),  # else (m22)
         ]
         for m, q in cases:
             testing.assert_almost_equal(matrix2quaternion(m), q)
@@ -434,10 +480,10 @@ class TestMath(unittest.TestCase):
         # Batched (N, 3, 3) input uses a separate vectorized code path.
         mats = np.array([
             np.eye(3),
-            rotate_matrix(np.eye(3), pi, 'x'),
-            rotate_matrix(np.eye(3), pi, 'y'),
-            rotate_matrix(np.eye(3), pi, 'z'),
-            rotate_matrix(rotate_matrix(rotate_matrix(
+            rotate_matrix_by_axis_angle(np.eye(3), pi, 'x'),
+            rotate_matrix_by_axis_angle(np.eye(3), pi, 'y'),
+            rotate_matrix_by_axis_angle(np.eye(3), pi, 'z'),
+            rotate_matrix_by_axis_angle(rotate_matrix_by_axis_angle(rotate_matrix_by_axis_angle(
                 np.eye(3), 0.2, 'x'), 0.4, 'y'), 0.6, 'z'),
         ])
         quats = matrix2quaternion(mats)


### PR DESCRIPTION
```python
math.rotate_vector(vec, theta, axis)   # rotates by an axis and an angle
Coordinates.rotate_vector(v)           # rotates by the coordinate's own rotation
```

Same name, different operations, and the name is the obvious first guess either way. An LLM agent asked to rotate a vector reached for `math.rotate_vector` first and only backed out after reading the signature:

> `rotate_vector` looked like the obvious candidate by name, but its signature is `(vec, theta, axis)` — it's an axis-angle helper, not a quaternion one.

Add `rotate_vector_by_axis_angle` and deprecate the old spelling.

`rotate_matrix` gets the same treatment. The two are a pair — one turns a vector, the other a matrix, both by an axis and an angle — so deprecating only one would leave the pair mismatched.

### Scope

Mixing the two `rotate_vector`s up **raises** rather than returning a wrong answer:

```python
math.rotate_vector([1, 0, 0], q_wxyz, 'z')   # ValueError
math.rotate_vector([1, 0, 0], q_wxyz)        # TypeError: missing 1 required positional argument
```

So this is about the first move, not about correctness. The old names keep working and keep returning the same values; they only gained a warning.

### Also

- Internal callers (`base.py`, `interfaces/ros/move_base.py`, `rpy_matrix`) move to the new names first, so the library does not warn at itself.
- `rotate_matrix` had **no docstring at all**. The new one writes down what `world` picks: `None`/`False` gives `matrix @ R`, truthy gives `R @ matrix`.
- External usage of either name is zero (GitHub code search).

### Testing

- Full suite passes (472).
- New tests assert the warnings fire, that the old names still return exactly what the new ones do (including `world=True` and `skip_normalization`), and that the new names stay quiet.