### PR TITLE
Support closed-loop assemblies with an in-process loop-closure solver

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -240,7 +240,11 @@ def _import_object_from_name(module_name, fullname):
     if obj is None:
         return None
     for comp in fullname.split('.'):
-        obj = getattr(obj, comp)
+        # tolerate names that are not class attributes, e.g. dataclass
+        # fields without defaults -- no source link for those
+        obj = getattr(obj, comp, None)
+        if obj is None:
+            return None
     return obj
 
 
@@ -294,8 +298,9 @@ def _get_sourcefile_and_linenumber(obj):
     # Get the source file name and line number at which obj is defined.
     try:
         filename = inspect.getsourcefile(obj)
-    except TypeError:
-        # obj is not a module, class, function, ..etc.
+    except (TypeError, OSError):
+        # obj is not a module, class, function, ..etc., or its source
+        # cannot be located
         return None, None
 
     # inspect can return None for cython objects
@@ -303,7 +308,10 @@ def _get_sourcefile_and_linenumber(obj):
         return None, None
 
     # Get the source line number
-    _, linenum = inspect.getsourcelines(obj)
+    try:
+        _, linenum = inspect.getsourcelines(obj)
+    except (TypeError, OSError):
+        return None, None
 
     return filename, linenum
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -14,6 +14,7 @@ API Reference
    interfaces
    sdfs
    planner
+   module_assembly
    viewers
    robot_model_tips
    how_to_create_urdf_from_cad.rst

--- a/docs/source/reference/module_assembly.rst
+++ b/docs/source/reference/module_assembly.rst
@@ -1,15 +1,15 @@
 Module Assembly
 ===============
 
-``skrobot.urdf.module_assembly`` composes robots out of reusable URDF
-modules: parse each part once into a :class:`~skrobot.urdf.RobotModule`
+``skrobot.assembly.module_assembly`` composes robots out of reusable URDF
+modules: parse each part once into a :class:`~skrobot.assembly.RobotModule`
 (its links become connection ports, each a full SE(3) frame), place
-instances in a :class:`~skrobot.urdf.RobotAssembly`, connect ports, and
+instances in a :class:`~skrobot.assembly.RobotAssembly`, connect ports, and
 build a combined URDF or a live :class:`~skrobot.model.RobotModel`.
 
 .. code-block:: python
 
-   from skrobot.urdf import RobotAssembly, RobotModule
+   from skrobot.assembly import RobotAssembly, RobotModule
 
    arm = RobotModule.from_urdf('arm', 'arm_module.urdf')
    gripper = RobotModule.from_urdf('gripper', 'gripper_module.urdf')
@@ -61,8 +61,8 @@ Classes
    :toctree: generated/
    :nosignatures:
 
-   skrobot.urdf.Port
-   skrobot.urdf.RobotModule
-   skrobot.urdf.Connection
-   skrobot.urdf.RobotAssembly
+   skrobot.assembly.Port
+   skrobot.assembly.RobotModule
+   skrobot.assembly.Connection
+   skrobot.assembly.RobotAssembly
    skrobot.kinematics.LoopClosureSolver

--- a/docs/source/reference/module_assembly.rst
+++ b/docs/source/reference/module_assembly.rst
@@ -1,0 +1,68 @@
+Module Assembly
+===============
+
+``skrobot.urdf.module_assembly`` composes robots out of reusable URDF
+modules: parse each part once into a :class:`~skrobot.urdf.RobotModule`
+(its links become connection ports, each a full SE(3) frame), place
+instances in a :class:`~skrobot.urdf.RobotAssembly`, connect ports, and
+build a combined URDF or a live :class:`~skrobot.model.RobotModel`.
+
+.. code-block:: python
+
+   from skrobot.urdf import RobotAssembly, RobotModule
+
+   arm = RobotModule.from_urdf('arm', 'arm_module.urdf')
+   gripper = RobotModule.from_urdf('gripper', 'gripper_module.urdf')
+
+   assembly = RobotAssembly('my_robot')
+   assembly.add_module_instance('arm1', arm)
+   assembly.add_module_instance('hand', gripper)
+   # mate=True seats the child port onto the parent port
+   # (keyed connector: origins coincide, Z opposed, X aligned)
+   assembly.connect('arm1', 'flange', 'hand', 'base_link', mate=True)
+   assembly.set_root('arm1', 'base_link')
+   urdf_path = assembly.build()
+   robot = assembly.build_robot_model()
+
+Connections are fixed joints by default; pass
+``joint_type='revolute'`` (or ``'continuous'`` / ``'prismatic'``) to
+turn the connected port pair itself into an articulation, so linkages
+can be assembled from bare links with no module-internal joints.
+
+Closed loops
+------------
+
+A URDF is a tree, so a closed linkage (four-bar, parallel mechanism)
+declares its cut edge with ``connect(..., loop=True)``: the two ports
+must coincide at the zero pose and their common Z axis is the passive
+hinge.  ``build()`` writes a ``loop_closures.yaml`` sidecar (the
+runtime-IK relay contract) next to the output URDF, injects exact
+``<mimic>`` tags when the loop is a parallelogram four-bar (verified
+numerically before writing), and keeps the config on
+``assembly.loop_closures``.  A general loop is closed in-process with
+:class:`~skrobot.kinematics.LoopClosureSolver`:
+
+.. code-block:: python
+
+   from skrobot.kinematics import LoopClosureSolver
+
+   robot = assembly.build_robot_model()
+   solver = LoopClosureSolver(robot, assembly.loop_closures)
+   robot.crank_joint.joint_angle(0.4)
+   solver.solve()  # dependent joints updated so the loop closes
+
+See ``examples/module_assembly_four_bar.py`` for a complete
+closed-loop assembly built from bare links.
+
+Classes
+-------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   skrobot.urdf.Port
+   skrobot.urdf.RobotModule
+   skrobot.urdf.Connection
+   skrobot.urdf.RobotAssembly
+   skrobot.kinematics.LoopClosureSolver

--- a/examples/module_assembly_four_bar.py
+++ b/examples/module_assembly_four_bar.py
@@ -25,9 +25,9 @@ import time
 
 import numpy as np
 
+from skrobot.assembly import RobotAssembly
+from skrobot.assembly import RobotModule
 from skrobot.kinematics import LoopClosureSolver
-from skrobot.urdf import RobotAssembly
-from skrobot.urdf import RobotModule
 
 
 _GROUND_URDF = """<?xml version="1.0"?>
@@ -79,7 +79,7 @@ def write_bar(directory, name, length, along):
 
     Returns
     -------
-    skrobot.urdf.RobotModule
+    skrobot.assembly.RobotModule
         The parsed module.
     """
     if along == 'x':
@@ -116,7 +116,7 @@ def assemble_four_bar(directory, crank2_length, g2_xyz):
 
     Returns
     -------
-    skrobot.urdf.RobotAssembly
+    skrobot.assembly.RobotAssembly
         The assembled linkage.
     """
     ground_path = os.path.join(directory, 'ground.urdf')

--- a/examples/module_assembly_four_bar.py
+++ b/examples/module_assembly_four_bar.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+"""Assemble a closed-loop four-bar linkage from bare link modules.
+
+Builds a four-bar from four bare bar modules (no movable internal
+joints): the hinges are movable CONNECTIONS
+(``connect(joint_type='revolute')``) and the loop is closed with a cut
+edge (``connect(loop=True)``).  Two variants are shown:
+
+* a parallelogram -- ``build()`` certifies the geometry and writes
+  exact ``<mimic>`` tags, so the loop stays closed in any URDF viewer;
+* a general four-bar -- the coupling is nonlinear, so the loop is
+  closed at runtime with ``skrobot.kinematics.LoopClosureSolver``
+  (the ``loop_closures.yaml`` sidecar carries the same constraint for
+  ROS-side consumers).
+
+Usage:
+    python examples/module_assembly_four_bar.py
+    python examples/module_assembly_four_bar.py --viewer
+"""
+
+import argparse
+import os
+import tempfile
+import time
+
+import numpy as np
+
+from skrobot.kinematics import LoopClosureSolver
+from skrobot.urdf import RobotAssembly
+from skrobot.urdf import RobotModule
+
+
+_GROUND_URDF = """<?xml version="1.0"?>
+<robot name="ground">
+  <link name="base_link"/>
+  <link name="g1"/>
+  <link name="g2"/>
+  <joint name="fg1" type="fixed">
+    <parent link="base_link"/><child link="g1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+  <joint name="fg2" type="fixed">
+    <parent link="base_link"/><child link="g2"/>
+    <origin xyz="{g2_xyz}" rpy="0 0 0"/>
+  </joint>
+</robot>
+"""
+
+_BAR_URDF = """<?xml version="1.0"?>
+<robot name="bar">
+  <link name="base_link">
+    <visual>
+      <origin xyz="{half_xyz}" rpy="0 0 0"/>
+      <geometry><box size="{box_size}"/></geometry>
+    </visual>
+  </link>
+  <link name="tip"/>
+  <joint name="ext" type="fixed">
+    <parent link="base_link"/><child link="tip"/>
+    <origin xyz="{tip_xyz}" rpy="0 0 0"/>
+  </joint>
+</robot>
+"""
+
+
+def write_bar(directory, name, length, along):
+    """Write a single-link bar module and parse it.
+
+    Parameters
+    ----------
+    directory : str
+        Where to write the URDF file.
+    name : str
+        Module name (also the file stem).
+    length : float
+        Bar length in metres.
+    along : str
+        ``'x'`` or ``'y'``: the axis the bar extends along.
+
+    Returns
+    -------
+    skrobot.urdf.RobotModule
+        The parsed module.
+    """
+    if along == 'x':
+        tip = (length, 0.0, 0.0)
+        box = (length, 0.01, 0.01)
+    else:
+        tip = (0.0, length, 0.0)
+        box = (0.01, length, 0.01)
+    half = tuple(v / 2.0 for v in tip)
+    path = os.path.join(directory, name + '.urdf')
+    with open(path, 'w') as f:
+        f.write(_BAR_URDF.format(
+            tip_xyz=' '.join(str(v) for v in tip),
+            half_xyz=' '.join(str(v) for v in half),
+            box_size=' '.join(str(v) for v in box)))
+    return RobotModule.from_urdf(name, path)
+
+
+def assemble_four_bar(directory, crank2_length, g2_xyz):
+    """Assemble ground + two cranks + coupler, loop-closed at the tips.
+
+    With ``crank2_length=0.1`` and ``g2_xyz='0.2 0 0'`` the hinge
+    quadrilateral is a parallelogram; other values give a general
+    four-bar (as long as the zero pose still closes).
+
+    Parameters
+    ----------
+    directory : str
+        Where the module URDFs are written.
+    crank2_length : float
+        Length of the second crank in metres.
+    g2_xyz : str
+        Ground pivot of the second crank ("x y z").
+
+    Returns
+    -------
+    skrobot.urdf.RobotAssembly
+        The assembled linkage.
+    """
+    ground_path = os.path.join(directory, 'ground.urdf')
+    with open(ground_path, 'w') as f:
+        f.write(_GROUND_URDF.format(g2_xyz=g2_xyz))
+    ground = RobotModule.from_urdf('ground', ground_path)
+    crank1 = write_bar(directory, 'crank1', 0.1, 'y')
+    crank2 = write_bar(directory, 'crank2', crank2_length, 'y')
+    coupler = write_bar(directory, 'coupler', 0.2, 'x')
+
+    assembly = RobotAssembly('fourbar')
+    assembly.add_module_instance('g', ground)
+    assembly.add_module_instance('c1', crank1)
+    assembly.add_module_instance('c2', crank2)
+    assembly.add_module_instance('cp', coupler)
+    hinge = {'joint_type': 'revolute', 'lower': -3.0, 'upper': 3.0}
+    assembly.connect('g', 'g1', 'c1', 'base_link', **hinge)
+    assembly.connect('g', 'g2', 'c2', 'base_link', **hinge)
+    assembly.connect('c1', 'tip', 'cp', 'base_link', **hinge)
+    # the cut edge: never a URDF joint, exported as a closure constraint
+    assembly.connect('cp', 'tip', 'c2', 'tip', loop=True)
+    assembly.set_root('g', 'base_link')
+    return assembly
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Closed-loop module assembly demo')
+    parser.add_argument('--viewer', action='store_true',
+                        help='animate the general four-bar in a viewer')
+    parser.add_argument('--no-interactive', action='store_true',
+                        help='run in non-interactive mode (CI testing)')
+    args = parser.parse_args()
+    if args.no_interactive:
+        args.viewer = False
+
+    tmp = tempfile.mkdtemp(prefix='fourbar_demo_')
+
+    print('=== parallelogram: exact <mimic>, no solver needed ===')
+    parallelogram = assemble_four_bar(tmp, 0.1, '0.2 0 0')
+    urdf_path = parallelogram.build(
+        output_path=os.path.join(tmp, 'parallelogram.urdf'))
+    print(f'built: {urdf_path}')
+    print(f'sidecar: {os.path.join(tmp, "loop_closures.yaml")}')
+    print(f'closure config: {parallelogram.loop_closures}')
+
+    print()
+    print('=== general four-bar: closed by LoopClosureSolver ===')
+    general = assemble_four_bar(tmp, 0.05, '0.2 0.05 0')
+    robot = general.build_robot_model()
+    solver = LoopClosureSolver(robot, general.loop_closures)
+    driver = robot.g_g1_to_c1_base_link_joint
+    for angle in np.linspace(0.0, 0.45, 4):
+        driver.joint_angle(angle)
+        error = solver.solve()
+        follower = robot.g_g2_to_c2_base_link_joint.joint_angle()
+        print(f'crank {angle:+.3f} rad -> rocker {follower:+.3f} rad '
+              f'(closure error {error:.2e} m)')
+
+    if args.viewer:
+        from skrobot.viewers import TrimeshSceneViewer
+        viewer = TrimeshSceneViewer()
+        viewer.add(robot)
+        viewer.show()
+        for angle in np.tile(np.concatenate([
+                np.linspace(0.0, 0.45, 30),
+                np.linspace(0.45, 0.0, 30)]), 10):
+            driver.joint_angle(angle)
+            solver.solve()
+            viewer.redraw()
+            time.sleep(0.03)
+
+
+if __name__ == '__main__':
+    main()

--- a/skrobot/assembly/module_assembly.py
+++ b/skrobot/assembly/module_assembly.py
@@ -355,6 +355,13 @@ class Connection:
         loop connection never becomes a joint in the built URDF; instead
         it is exported as a runtime-IK closure constraint (the two port
         frames must stay coincident on their common hinge axis).
+    dependent : Tuple[str, ...], optional
+        For a loop closure: the final (prefixed) joint names this closure
+        SOLVES.  The remaining movable joints on the loop ring stay
+        independent (driven).  ``None`` (default) picks the split
+        automatically: the movable joint nearest the root drives, the
+        rest are solved.  A 1-DOF planar loop solves 2 joints; a 2-DOF
+        loop (e.g. a five-bar) needs this made explicit.
     """
 
     module_a: str
@@ -368,6 +375,7 @@ class Connection:
     pitch: float = 0.0
     yaw: float = 0.0
     loop: bool = False
+    dependent: Optional[Tuple[str, ...]] = None
     # How the CHILD-side node attaches when the tree is built.  The
     # connection is undirected: whichever endpoint ends up the child once
     # the tree is rooted attaches via ITS declared port.
@@ -526,6 +534,7 @@ class RobotAssembly:
         mate: bool = False,
         attach: str = "root",
         loop: bool = False,
+        dependent: Optional[Tuple[str, ...]] = None,
     ) -> None:
         """
         Create a connection between two module ports.
@@ -582,6 +591,14 @@ class RobotAssembly:
             for a parallelogram four-bar, writes exact ``<mimic>`` tags.
             A loop connection carries no transform, so the offset, ``mate``
             and ``attach`` arguments cannot be combined with it.
+        dependent : Tuple[str, ...], optional
+            Only with ``loop=True``: the final (prefixed, e.g.
+            ``'arm1_elbow'``) joint names this closure solves; the other
+            movable joints on the loop ring stay driven.  Validated at
+            build time against the actual ring.  Default: the ring joint
+            nearest the root drives, the rest are solved -- right for a
+            1-DOF loop, but a multi-DOF loop (five-bar and up) needs the
+            solved joints named explicitly.
         """
         # Validate module instances exist
         if module_a not in self.instances:
@@ -621,6 +638,17 @@ class RobotAssembly:
                     'where the two ports coincide at the zero pose, so '
                     'xyz/rpy offsets, mate and attach cannot be combined '
                     'with loop=True')
+            if dependent is not None:
+                dependent = tuple(dependent)
+                if not dependent:
+                    raise ValueError(
+                        'dependent must name at least one joint the '
+                        'closure solves (or be None for the automatic '
+                        'split)')
+        elif dependent is not None:
+            raise ValueError(
+                'dependent only applies to a loop closure (loop=True): it '
+                'names the joints solved to keep the loop closed')
         if mate:
             if any(abs(v) > 1e-12 for v in (x, y, z, roll, pitch)):
                 raise ValueError(
@@ -649,7 +677,7 @@ class RobotAssembly:
         self.connections.append(
             Connection(module_a, port_a, module_b, port_b, x=x, y=y, z=z,
                        roll=roll, pitch=pitch, yaw=yaw, attach=attach,
-                       loop=loop)
+                       loop=loop, dependent=dependent)
         )
 
     @staticmethod
@@ -1185,24 +1213,8 @@ class RobotAssembly:
                     f"loop closure {label}: no movable joint on the loop "
                     "ring -- the closure would weld a rigid ring, which a "
                     "kinematic tree already represents without it")
-            # a joint that already mimics another, or that an earlier
-            # closure marked dependent, is solved -- it cannot drive
-            drivable = [j for j in ring if j.find("mimic") is None
-                        and j.get("name") not in dependent]
-            if not drivable:
-                raise ValueError(
-                    f"loop closure {label}: every movable joint on the "
-                    "loop ring is already solved (mimic or another "
-                    "closure's dependent), so nothing can drive the loop")
-            driver = min(
-                drivable,
-                key=lambda j: (len(links_up(j.find("child").get("link"))),
-                               j.get("name")))
-            drivers.add(driver.get("name"))
-            # never re-mark another closure's driver as dependent: a joint
-            # must end up on exactly one side of the split
-            deps = [j for j in ring if j is not driver
-                    and j.get("name") not in drivers]
+            driver_name, fixed, deps = self._split_loop_ring(
+                robot, conn, label, ring, links_up, dependent, drivers)
             dependent.update(j.get("name") for j in deps)
             point = t_a[:3, 3]
             closures.append({
@@ -1211,7 +1223,7 @@ class RobotAssembly:
                 "axis": [round(float(v), 8) for v in axis_a],
             })
             self._try_parallelogram_mimic(
-                robot, fk, ring, driver, deps, point, axis_a,
+                robot, fk, ring, driver_name, fixed, deps, point, axis_a,
                 link_a, link_b)
         return {
             "closures": closures,
@@ -1219,8 +1231,125 @@ class RobotAssembly:
             "independent": sorted(set(all_movable) - dependent),
         }
 
-    def _try_parallelogram_mimic(self, robot, fk, ring, driver, deps,
-                                 cut_point, cut_axis, link_a, link_b):
+    @staticmethod
+    def _resolve_mimic_chain(robot):
+        """Resolve every ``<mimic>`` tag to its transitive root driver.
+
+        Returns
+        -------
+        Dict[str, Tuple[str, float, float]]
+            Mapping from a mimicking joint name to ``(root_driver,
+            multiplier, offset)`` such that ``q_joint = multiplier *
+            q_root + offset``.  Joints on a mimic cycle are omitted.
+        """
+        specs = {}
+        for j in robot.findall("joint"):
+            mimic = j.find("mimic")
+            if mimic is not None and mimic.get("joint"):
+                specs[j.get("name")] = (
+                    mimic.get("joint"),
+                    float(mimic.get("multiplier", 1.0)),
+                    float(mimic.get("offset", 0.0)))
+        resolved = {}
+        for name in specs:
+            multiplier, offset = 1.0, 0.0
+            current = name
+            seen = set()
+            while current in specs:
+                if current in seen:
+                    break  # mimic cycle: unresolvable
+                seen.add(current)
+                target, m, o = specs[current]
+                offset += multiplier * o
+                multiplier *= m
+                current = target
+            else:
+                resolved[name] = (current, multiplier, offset)
+        return resolved
+
+    def _split_loop_ring(self, robot, conn, label, ring, links_up,
+                         dependent, drivers):
+        """Split one closure's ring joints into driven vs solved.
+
+        Three strategies, in priority order: the connection's explicit
+        ``dependent`` list; following an existing ``<mimic>`` on the ring
+        to its transitive root (so a chained loop never leaks a
+        kinematically coupled joint into ``independent``); else the
+        nearest-root heuristic (right for a 1-DOF loop).
+
+        Returns
+        -------
+        Tuple[Optional[str], Dict[str, float], List]
+            ``(driver_name, fixed, deps)``: the single driving joint the
+            parallelogram certification runs against (None when there is
+            no unique drivable one -- possibly a joint OUTSIDE the ring
+            for a chained loop), ``fixed`` mapping ring joints that
+            already mimic the driver to their known multiplier, and the
+            ring joint elements this closure marks dependent.
+        """
+        ring_names = [j.get("name") for j in ring]
+        if conn.dependent is not None:
+            missing = [n for n in conn.dependent if n not in ring_names]
+            if missing:
+                raise ValueError(
+                    f"loop closure {label}: dependent joint(s) {missing} "
+                    f"are not movable joints on the loop ring "
+                    f"{ring_names}")
+            conflict = sorted(set(conn.dependent) & drivers)
+            if conflict:
+                raise ValueError(
+                    f"loop closure {label}: {conflict} already drive "
+                    "another closure and cannot be re-marked dependent")
+            deps = [j for j in ring if j.get("name") in conn.dependent]
+            rest = [j for j in ring if j.get("name") not in conn.dependent]
+            drivers.update(j.get("name") for j in rest
+                           if j.get("name") not in dependent)
+            # certify only against a joint that really is independent
+            driver_name = rest[0].get("name") \
+                if len(rest) == 1 and rest[0].find("mimic") is None \
+                and rest[0].get("name") not in dependent \
+                else None
+            return driver_name, {}, deps
+
+        chain = self._resolve_mimic_chain(robot)
+        mimicking = [j for j in ring if j.get("name") in chain]
+        if mimicking:
+            roots = {chain[j.get("name")][0] for j in mimicking}
+            deps = [j for j in ring if j.get("name") not in roots
+                    and j.get("name") not in drivers]
+            # a root an earlier closure already solves is no driver: leave
+            # it dependent and let the relay solve this ring numerically
+            drivers.update(roots - dependent)
+            exact = len(roots) == 1 and not (roots & dependent) and all(
+                abs(chain[j.get("name")][2]) < 1e-12 for j in mimicking)
+            if not exact:
+                return None, {}, deps
+            fixed = {j.get("name"): chain[j.get("name")][1]
+                     for j in mimicking}
+            return next(iter(roots)), fixed, deps
+
+        # a joint an earlier closure marked dependent is solved --
+        # it cannot drive
+        drivable = [j for j in ring if j.get("name") not in dependent]
+        if not drivable:
+            raise ValueError(
+                f"loop closure {label}: every movable joint on the loop "
+                "ring is already solved by another closure, so nothing "
+                "can drive the loop")
+        driver = min(
+            drivable,
+            key=lambda j: (len(links_up(j.find("child").get("link"))),
+                           j.get("name")))
+        drivers.add(driver.get("name"))
+        # never re-mark another closure's driver as dependent: a joint
+        # must end up on exactly one side of the split
+        deps = [j for j in ring if j is not driver
+                and j.get("name") not in drivers]
+        return driver.get("name"), {}, deps
+
+    def _try_parallelogram_mimic(self, robot, fk, ring, driver_name,
+                                 fixed, deps, cut_point, cut_axis,
+                                 link_a, link_b):
         """Write exact ``<mimic>`` tags when the loop is a parallelogram.
 
         A four-bar whose hinge quadrilateral is a parallelogram (all four
@@ -1231,13 +1360,28 @@ class RobotAssembly:
         kinematics before anything is written: the cut-hinge witness
         points must still coincide at sampled nonzero driver angles.
         Silently does nothing when the ring is not such a loop.
+
+        For a chained loop, ``driver_name`` may be a joint OUTSIDE the
+        ring (the transitive root of an existing mimic) and ``fixed``
+        carries the known multipliers of the ring joints that already
+        follow it; only the remaining free dependents get new tags.
         """
-        if len(ring) != 3 or len(deps) != 2:
+        if driver_name is None or len(ring) != 3:
+            return
+        free = [j for j in deps if j.get("name") not in fixed]
+        if not free or len(free) > 2:
+            return
+        # every ring joint must have a determined value during the FK
+        # certification: the driver itself, a known follower, or a free
+        # candidate
+        covered = set(fixed) | {j.get("name") for j in free} | {driver_name}
+        if any(j.get("name") not in covered for j in ring):
             return
         if any(j.get("type") not in ("revolute", "continuous")
                for j in ring):
             return
-        if any(j.find("mimic") is not None for j in ring):
+        if any(j.find("mimic") is not None and j.get("name") not in fixed
+               for j in ring):
             return
         normal = cut_axis / np.linalg.norm(cut_axis)
         world_axes = []
@@ -1261,36 +1405,38 @@ class RobotAssembly:
                                 - (planar[2] - planar[3]))) > 1e-6:
             return
 
-        driver_name = driver.get("name")
         witness_local = []
         for w in (cut_point, cut_point + 0.03 * normal):
             w_h = np.append(w, 1.0)
             witness_local.append((np.linalg.solve(fk[link_a], w_h),
                                   np.linalg.solve(fk[link_b], w_h)))
-        for m0 in (1.0, -1.0):
-            for m1 in (1.0, -1.0):
-                multipliers = (m0, m1)
-                closed = True
-                for q in (0.3, -0.45):
-                    joint_values = {driver_name: q}
-                    for dep, m in zip(deps, multipliers):
-                        joint_values[dep.get("name")] = m * q
-                    fk_q = self._link_transforms(robot, joint_values)
-                    for local_a, local_b in witness_local:
-                        gap = np.linalg.norm(fk_q[link_a] @ local_a
-                                             - fk_q[link_b] @ local_b)
-                        if gap > 1e-9:
-                            closed = False
-                            break
-                    if not closed:
+        combos = [()]
+        for _ in free:
+            combos = [c + (m,) for c in combos for m in (1.0, -1.0)]
+        for multipliers in combos:
+            closed = True
+            for q in (0.3, -0.45):
+                joint_values = {driver_name: q}
+                joint_values.update(
+                    (name, m * q) for name, m in fixed.items())
+                for dep, m in zip(free, multipliers):
+                    joint_values[dep.get("name")] = m * q
+                fk_q = self._link_transforms(robot, joint_values)
+                for local_a, local_b in witness_local:
+                    gap = np.linalg.norm(fk_q[link_a] @ local_a
+                                         - fk_q[link_b] @ local_b)
+                    if gap > 1e-9:
+                        closed = False
                         break
-                if closed:
-                    for dep, m in zip(deps, multipliers):
-                        mimic = etree.SubElement(dep, "mimic")
-                        mimic.set("joint", driver_name)
-                        mimic.set("multiplier", str(m))
-                        mimic.set("offset", "0")
-                    return
+                if not closed:
+                    break
+            if closed:
+                for dep, m in zip(free, multipliers):
+                    mimic = etree.SubElement(dep, "mimic")
+                    mimic.set("joint", driver_name)
+                    mimic.set("multiplier", str(m))
+                    mimic.set("offset", "0")
+                return
 
     @staticmethod
     def _write_loop_closures_yaml(config, directory):
@@ -1346,7 +1492,8 @@ class RobotAssembly:
                  "module_b": c.module_b, "port_b": c.port_b,
                  "x": c.x, "y": c.y, "z": c.z,
                  "roll": c.roll, "pitch": c.pitch, "yaw": c.yaw,
-                 "attach": c.attach, "loop": c.loop}
+                 "attach": c.attach, "loop": c.loop,
+                 "dependent": list(c.dependent) if c.dependent else None}
                 for c in self.connections
             ],
             "root": {"instance": self.root_instance, "port": self.root_port} if self.root_instance else None,
@@ -1373,7 +1520,9 @@ class RobotAssembly:
                 roll=conn.get("roll", 0.0), pitch=conn.get("pitch", 0.0),
                 yaw=conn.get("yaw", 0.0),
                 attach=conn.get("attach", "root"),
-                loop=conn.get("loop", False))
+                loop=conn.get("loop", False),
+                dependent=(tuple(conn["dependent"])
+                           if conn.get("dependent") else None))
         if data.get("root_instance"):
             assembly.set_root(data["root_instance"], data["root_port"])
         return assembly

--- a/skrobot/assembly/module_assembly.py
+++ b/skrobot/assembly/module_assembly.py
@@ -362,6 +362,20 @@ class Connection:
         automatically: the movable joint nearest the root drives, the
         rest are solved.  A 1-DOF planar loop solves 2 joints; a 2-DOF
         loop (e.g. a five-bar) needs this made explicit.
+    joint_type : str
+        Type of the joint the connection becomes in the built URDF:
+        ``'fixed'`` (default), ``'revolute'``, ``'continuous'`` or
+        ``'prismatic'``.  A movable connection turns the mated port
+        pair itself into an articulation, so modules do not need an
+        internal joint to move relative to each other.
+    axis : Tuple[float, float, float]
+        Movable connections only: the joint axis, expressed in the
+        child attachment link's frame (= the URDF joint frame).
+        Default Z.
+    lower, upper : float, optional
+        Joint limits; required for ``'revolute'`` and ``'prismatic'``.
+    effort, velocity : float
+        Limit attributes the URDF requires alongside lower/upper.
     """
 
     module_a: str
@@ -376,6 +390,12 @@ class Connection:
     yaw: float = 0.0
     loop: bool = False
     dependent: Optional[Tuple[str, ...]] = None
+    joint_type: str = "fixed"
+    axis: Tuple[float, float, float] = (0.0, 0.0, 1.0)
+    lower: Optional[float] = None
+    upper: Optional[float] = None
+    effort: float = 100.0
+    velocity: float = 1.0
     # How the CHILD-side node attaches when the tree is built.  The
     # connection is undirected: whichever endpoint ends up the child once
     # the tree is rooted attaches via ITS declared port.
@@ -541,6 +561,12 @@ class RobotAssembly:
         attach: str = "root",
         loop: bool = False,
         dependent: Optional[Tuple[str, ...]] = None,
+        joint_type: str = "fixed",
+        axis: Tuple[float, float, float] = (0.0, 0.0, 1.0),
+        lower: Optional[float] = None,
+        upper: Optional[float] = None,
+        effort: float = 100.0,
+        velocity: float = 1.0,
     ) -> None:
         """
         Create a connection between two module ports.
@@ -605,6 +631,26 @@ class RobotAssembly:
             nearest the root drives, the rest are solved -- right for a
             1-DOF loop, but a multi-DOF loop (five-bar and up) needs the
             solved joints named explicitly.
+        joint_type : str
+            ``'fixed'`` (default) welds the connection; ``'revolute'``,
+            ``'continuous'`` or ``'prismatic'`` turn the mated port pair
+            itself into an articulation.  A movable connection must be
+            declared parent-side first (``module_a`` ends up the parent
+            once the tree is rooted): reversing a movable joint would
+            relocate its frame, which the build refuses rather than
+            approximates.
+        axis : Tuple[float, float, float]
+            Joint axis of a movable connection, expressed in the child
+            attachment link's frame (in URDF the joint frame IS the
+            child frame): the module root frame under ``attach='root'``,
+            the declared port frame under ``attach='port'`` -- combine
+            with ``attach='port'``/``mate`` to hinge about the port Z
+            of the keyed-mate convention.  Default Z.
+        lower, upper : float, optional
+            Joint limits in radians / metres; required for
+            ``'revolute'`` and ``'prismatic'``.
+        effort, velocity : float
+            Limit attributes required by URDF alongside lower/upper.
         """
         # Validate module instances exist
         if module_a not in self.instances:
@@ -655,6 +701,32 @@ class RobotAssembly:
             raise ValueError(
                 'dependent only applies to a loop closure (loop=True): it '
                 'names the joints solved to keep the loop closed')
+        if joint_type not in ("fixed", "revolute", "continuous",
+                              "prismatic"):
+            raise ValueError(f"unknown joint_type: {joint_type!r} "
+                             "(expected 'fixed', 'revolute', 'continuous' "
+                             "or 'prismatic')")
+        if loop and joint_type != "fixed":
+            raise ValueError(
+                'a loop closure IS the passive cut hinge; it cannot carry '
+                'a joint_type -- make the tree connections movable instead')
+        if joint_type in ("fixed", "continuous") and \
+                (lower is not None or upper is not None):
+            raise ValueError(
+                f"lower/upper limits do not apply to a {joint_type} "
+                "connection joint (URDF only limits revolute/prismatic)")
+        if joint_type in ("revolute", "prismatic") and \
+                (lower is None or upper is None):
+            raise ValueError(
+                f"a {joint_type} connection needs explicit lower and "
+                "upper limits")
+        if joint_type != "fixed":
+            axis = tuple(float(v) for v in axis)
+            if len(axis) != 3 or not all(math.isfinite(v) for v in axis) \
+                    or math.hypot(*axis) < 1e-12:
+                raise ValueError(
+                    f"connection joint axis must be a nonzero finite "
+                    f"3-vector, got {axis!r}")
         if mate:
             if any(abs(v) > 1e-12 for v in (x, y, z, roll, pitch)):
                 raise ValueError(
@@ -683,7 +755,11 @@ class RobotAssembly:
         self.connections.append(
             Connection(module_a, port_a, module_b, port_b, x=x, y=y, z=z,
                        roll=roll, pitch=pitch, yaw=yaw, attach=attach,
-                       loop=loop, dependent=dependent)
+                       loop=loop, dependent=dependent,
+                       joint_type=joint_type,
+                       axis=tuple(float(v) for v in axis),
+                       lower=lower, upper=upper,
+                       effort=effort, velocity=velocity)
         )
 
     @staticmethod
@@ -1017,6 +1093,7 @@ class RobotAssembly:
         self._validate_and_default_root()
         temp_dir = tempfile.mkdtemp(prefix=f"{self.name}_build_")
         robot = self._compose_inline(temp_dir)
+        self._apply_movable_connections(robot)
         # validates declared closures and injects parallelogram mimics;
         # the relay yaml sidecar only exists when building to a file
         self.loop_closures = self._apply_loop_closures(robot)
@@ -1178,6 +1255,61 @@ class RobotAssembly:
                 transforms[child] = transforms[link_name] @ transform
                 queue.append(child)
         return transforms
+
+    def _apply_movable_connections(self, robot):
+        """Turn movable connections into their declared joint type.
+
+        The composition emits every connection as a fixed joint with the
+        deterministic name ``{parent_link}_to_{child_link}_joint``; this
+        post-pass rewrites the type and adds ``<axis>``/``<limit>``.
+        Runs BEFORE the loop-closure pass, which then sees connection
+        joints as ordinary ring members.
+        """
+        movable = [c for c in self.connections
+                   if not c.loop and c.joint_type != "fixed"]
+        if not movable:
+            return
+        joints = {j.get("name"): j for j in robot.findall("joint")}
+
+        def link_name(instance_id, port):
+            return f"{instance_id}_{port}" if instance_id else port
+
+        def connector(instance_id, port, attach):
+            module = self.instances[instance_id].module
+            if attach == "port" and port != module.root_link:
+                return port
+            return module.root_link
+
+        for conn in movable:
+            child_fwd = connector(conn.module_b, conn.port_b, conn.attach)
+            child_rev = connector(conn.module_a, conn.port_a, conn.attach)
+            forward = (f"{link_name(conn.module_a, conn.port_a)}_to_"
+                       f"{link_name(conn.module_b, child_fwd)}_joint")
+            reverse = (f"{link_name(conn.module_b, conn.port_b)}_to_"
+                       f"{link_name(conn.module_a, child_rev)}_joint")
+            joint = joints.get(forward)
+            if joint is None:
+                if reverse in joints:
+                    raise ValueError(
+                        f"movable connection {conn.module_a}.{conn.port_a}"
+                        f" -> {conn.module_b}.{conn.port_b} was traversed "
+                        "in reverse when the tree was rooted; a reversed "
+                        "movable joint cannot keep its frame (only the "
+                        "new child's origin could carry the axis), so "
+                        "re-root the assembly or declare the connection "
+                        "parent-side first")
+                raise ValueError(
+                    f"internal error: connection joint '{forward}' not "
+                    "found in the composed URDF")
+            joint.set("type", conn.joint_type)
+            axis = etree.SubElement(joint, "axis")
+            axis.set("xyz", " ".join(str(v) for v in conn.axis))
+            if conn.joint_type in ("revolute", "prismatic"):
+                limit = etree.SubElement(joint, "limit")
+                limit.set("lower", str(conn.lower))
+                limit.set("upper", str(conn.upper))
+                limit.set("effort", str(conn.effort))
+                limit.set("velocity", str(conn.velocity))
 
     def _apply_loop_closures(self, robot):
         """Export the declared loop closures against the composed robot.
@@ -1515,6 +1647,7 @@ class RobotAssembly:
         """Compose the combined URDF and write it to disk."""
         temp_dir = tempfile.mkdtemp(prefix=f"{self.name}_build_")
         robot = self._compose_inline(temp_dir)
+        self._apply_movable_connections(robot)
         closures = self._apply_loop_closures(robot)
         self.loop_closures = closures
         if output_path is None:
@@ -1564,7 +1697,10 @@ class RobotAssembly:
                  "x": c.x, "y": c.y, "z": c.z,
                  "roll": c.roll, "pitch": c.pitch, "yaw": c.yaw,
                  "attach": c.attach, "loop": c.loop,
-                 "dependent": list(c.dependent) if c.dependent else None}
+                 "dependent": list(c.dependent) if c.dependent else None,
+                 "joint_type": c.joint_type, "axis": list(c.axis),
+                 "lower": c.lower, "upper": c.upper,
+                 "effort": c.effort, "velocity": c.velocity}
                 for c in self.connections
             ],
             "root": {"instance": self.root_instance, "port": self.root_port} if self.root_instance else None,
@@ -1608,7 +1744,12 @@ class RobotAssembly:
                 attach=conn.get("attach", "root"),
                 loop=conn.get("loop", False),
                 dependent=(tuple(conn["dependent"])
-                           if conn.get("dependent") else None))
+                           if conn.get("dependent") else None),
+                joint_type=conn.get("joint_type", "fixed"),
+                axis=tuple(conn.get("axis", (0.0, 0.0, 1.0))),
+                lower=conn.get("lower"), upper=conn.get("upper"),
+                effort=conn.get("effort", 100.0),
+                velocity=conn.get("velocity", 1.0))
         root = data.get("root") or {}
         root_instance = data.get("root_instance") or root.get("instance")
         root_port = data.get("root_port") or root.get("port")

--- a/skrobot/assembly/module_assembly.py
+++ b/skrobot/assembly/module_assembly.py
@@ -745,6 +745,53 @@ class RobotAssembly:
         return (float(out_xyz[0]), float(out_xyz[1]), float(out_xyz[2]),
                 float(out_rpy[0]), float(out_rpy[1]), float(out_rpy[2]))
 
+    def disconnect(self, module_a: str, port_a: str,
+                   module_b: str, port_b: str) -> None:
+        """Remove the connection between two ports.
+
+        The connection is matched in either declaration order (the
+        graph is undirected).
+
+        Raises
+        ------
+        ValueError
+            If no such connection exists.
+        """
+        for i, conn in enumerate(self.connections):
+            forward = (conn.module_a == module_a and conn.port_a == port_a
+                       and conn.module_b == module_b
+                       and conn.port_b == port_b)
+            reverse = (conn.module_a == module_b and conn.port_a == port_b
+                       and conn.module_b == module_a
+                       and conn.port_b == port_a)
+            if forward or reverse:
+                del self.connections[i]
+                return
+        raise ValueError(
+            f"no connection between {module_a}.{port_a} and "
+            f"{module_b}.{port_b}")
+
+    def remove_module_instance(self, instance_id: str) -> None:
+        """Remove an instance and every connection that involves it.
+
+        When the removed instance was the root, the root falls back to
+        the first remaining instance (through its module's root link),
+        or clears entirely on an empty assembly.
+        """
+        if instance_id not in self.instances:
+            raise ValueError(f"Module instance '{instance_id}' not found")
+        del self.instances[instance_id]
+        self.connections = [c for c in self.connections
+                            if not c.involves(instance_id)]
+        if self.root_instance == instance_id:
+            if self.instances:
+                first_id = next(iter(self.instances))
+                self.set_root(first_id,
+                              self.instances[first_id].module.root_link)
+            else:
+                self.root_instance = None
+                self.root_port = None
+
     def set_root(self, instance_id: str, port_name: str) -> None:
         """
         Set the root link for the assembled robot.
@@ -1480,20 +1527,37 @@ class RobotAssembly:
                 closures, os.path.dirname(os.path.abspath(output_path)))
         return output_path
 
-    def to_dict(self) -> dict:
+    def to_dict(self, embed: bool = False) -> dict:
         """
         Serialize the assembly to a dictionary.
 
         Useful for saving/loading assembly state or sending to frontend.
+
+        Parameters
+        ----------
+        embed : bool
+            Also embed each module's URDF XML (``urdf_content``), so
+            :meth:`from_dict` can rebuild the assembly without the
+            original files -- e.g. across machines or through a
+            storage backend.
         """
+        instances = {}
+        for inst_id, inst in self.instances.items():
+            entry = {"module_id": inst.module.module_id,
+                     "urdf_path": str(inst.module.urdf_path)}
+            if embed:
+                path = Path(inst.module.urdf_path)
+                if not path.is_file():
+                    raise ValueError(
+                        f"cannot embed instance '{inst_id}': its module "
+                        f"URDF '{path}' is not a readable file")
+                entry["urdf_content"] = path.read_text(encoding="utf-8")
+            instances[inst_id] = entry
         return {
             "name": self.name,
             "root_instance": self.root_instance,
             "root_port": self.root_port,
-            "instances": {
-                inst_id: {"module_id": inst.module.module_id, "urdf_path": str(inst.module.urdf_path)}
-                for inst_id, inst in self.instances.items()
-            },
+            "instances": instances,
             "connections": [
                 {"module_a": c.module_a, "port_a": c.port_a,
                  "module_b": c.module_b, "port_b": c.port_b,
@@ -1511,12 +1575,27 @@ class RobotAssembly:
         """Rebuild an assembly from :meth:`to_dict` output.
 
         Modules are re-parsed from the recorded ``urdf_path``s, so those
-        files must still exist.
+        files must still exist -- unless the dict was made with
+        ``to_dict(embed=True)``, in which case the embedded URDF content
+        is materialized into a temporary directory (the builds read the
+        module files from disk) and the original paths are not needed.
         """
         assembly = cls(data["name"])
-        for inst_id, inst in data.get("instances", {}).items():
-            module = RobotModule.from_urdf(inst["module_id"],
-                                           inst["urdf_path"])
+        embed_dir = None
+        for index, (inst_id, inst) in enumerate(
+                data.get("instances", {}).items()):
+            if inst.get("urdf_content"):
+                if embed_dir is None:
+                    embed_dir = tempfile.mkdtemp(prefix="assembly_modules_")
+                # instance ids are arbitrary strings ('a/b', '..'), so
+                # never let them name the file
+                path = os.path.join(embed_dir, f"module_{index}.urdf")
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(inst["urdf_content"])
+                module = RobotModule.from_urdf(inst["module_id"], path)
+            else:
+                module = RobotModule.from_urdf(inst["module_id"],
+                                               inst["urdf_path"])
             assembly.add_module_instance(inst_id, module)
         for conn in data.get("connections", []):
             assembly.connect(
@@ -1530,8 +1609,11 @@ class RobotAssembly:
                 loop=conn.get("loop", False),
                 dependent=(tuple(conn["dependent"])
                            if conn.get("dependent") else None))
-        if data.get("root_instance"):
-            assembly.set_root(data["root_instance"], data["root_port"])
+        root = data.get("root") or {}
+        root_instance = data.get("root_instance") or root.get("instance")
+        root_port = data.get("root_port") or root.get("port")
+        if root_instance:
+            assembly.set_root(root_instance, root_port)
         return assembly
 
     def __repr__(self) -> str:

--- a/skrobot/assembly/module_assembly.py
+++ b/skrobot/assembly/module_assembly.py
@@ -7,6 +7,11 @@ The architecture follows a 3-layer design:
 
 ``RobotAssembly.build()`` composes the combined URDF purely in memory --
 no external tools are involved.
+
+A closed linkage (four-bar, parallel mechanism) does not fit a URDF tree;
+declare its cut edge with ``connect(..., loop=True)`` and ``build()`` will
+export the closure as a ``loop_closures.yaml`` sidecar for runtime IK,
+plus exact ``<mimic>`` tags when the loop is a parallelogram.
 """
 
 from collections import deque
@@ -27,6 +32,7 @@ import numpy as np
 
 from skrobot.coordinates.math import matrix2xyzrpy
 from skrobot.coordinates.math import matrix_relative
+from skrobot.coordinates.math import rotation_matrix
 from skrobot.coordinates.math import rpy2homogeneous
 from skrobot.coordinates.math import xyzrpy2matrix
 from skrobot.urdf.xml_root_link_changer import change_urdf_root_link
@@ -343,6 +349,12 @@ class Connection:
         Pitch (rotation around Y axis) offset in radians.
     yaw : float
         Yaw (rotation around Z axis) offset in radians.
+    loop : bool
+        ``True`` marks this connection as a loop closure: the edge that a
+        kinematic tree cannot carry and that the assembly graph cuts.  A
+        loop connection never becomes a joint in the built URDF; instead
+        it is exported as a runtime-IK closure constraint (the two port
+        frames must stay coincident on their common hinge axis).
     """
 
     module_a: str
@@ -355,6 +367,7 @@ class Connection:
     roll: float = 0.0
     pitch: float = 0.0
     yaw: float = 0.0
+    loop: bool = False
     # How the CHILD-side node attaches when the tree is built.  The
     # connection is undirected: whichever endpoint ends up the child once
     # the tree is rooted attaches via ITS declared port.
@@ -512,6 +525,7 @@ class RobotAssembly:
         yaw: float = 0.0,
         mate: bool = False,
         attach: str = "root",
+        loop: bool = False,
     ) -> None:
         """
         Create a connection between two module ports.
@@ -558,6 +572,16 @@ class RobotAssembly:
             during the build so that port becomes the real attachment link.
             Applies to whichever endpoint becomes the child once the tree
             is rooted.
+        loop : bool
+            ``True`` declares this connection as a loop closure -- the cut
+            edge of a closed linkage (e.g. a four-bar).  It never becomes a
+            joint in the built URDF; the two ports must already coincide at
+            the zero pose of the rest of the assembly, and their common Z
+            axis is the passive hinge axis.  ``build()`` exports the
+            closure to a ``loop_closures.yaml`` sidecar for runtime IK and,
+            for a parallelogram four-bar, writes exact ``<mimic>`` tags.
+            A loop connection carries no transform, so the offset, ``mate``
+            and ``attach`` arguments cannot be combined with it.
         """
         # Validate module instances exist
         if module_a not in self.instances:
@@ -589,6 +613,14 @@ class RobotAssembly:
                 f"Port '{port_b}' not found on module '{module_b}'")
         self._check_port_compatibility(module_a, port_obj_a,
                                        module_b, port_obj_b)
+        if loop:
+            if mate or attach != "root" or \
+                    any(abs(v) > 1e-12 for v in (x, y, z, roll, pitch, yaw)):
+                raise ValueError(
+                    'a loop closure carries no transform: the cut hinge is '
+                    'where the two ports coincide at the zero pose, so '
+                    'xyz/rpy offsets, mate and attach cannot be combined '
+                    'with loop=True')
         if mate:
             if any(abs(v) > 1e-12 for v in (x, y, z, roll, pitch)):
                 raise ValueError(
@@ -616,7 +648,8 @@ class RobotAssembly:
 
         self.connections.append(
             Connection(module_a, port_a, module_b, port_b, x=x, y=y, z=z,
-                       roll=roll, pitch=pitch, yaw=yaw, attach=attach)
+                       roll=roll, pitch=pitch, yaw=yaw, attach=attach,
+                       loop=loop)
         )
 
     @staticmethod
@@ -711,11 +744,14 @@ class RobotAssembly:
             When traversed from module_b to module_a, the connection
             transform is inverted (rigid inverse, not a component-wise
             negation -- the latter is only correct for single-axis
-            rotations).
+            rotations).  Loop closures (``loop=True``) are cut edges, not
+            tree edges, so they do not appear here.
         """
         adj: Dict[str, List[Tuple[str, str, str, Tuple, Tuple, str]]] = {inst_id: [] for inst_id in self.instances}
         identity = np.eye(4)
         for conn in self.connections:
+            if conn.loop:
+                continue
             # Forward direction: module_a -> module_b uses original xyz/rpy
             adj[conn.module_a].append((conn.module_b, conn.port_a, conn.port_b, conn.xyz, conn.rpy, conn.attach))
             # Reverse direction: module_b -> module_a uses the inverse transform
@@ -809,16 +845,20 @@ class RobotAssembly:
                             node_map[neighbor_id] = child_node
                             queue.append(child_node)
 
-        # URDF is a tree: every connection must have been consumed as a
-        # forest edge.  Anything left over closes a cycle and would be
-        # silently dropped by the traversal -- refuse instead.
+        # URDF is a tree: every non-loop connection must have been consumed
+        # as a forest edge.  Anything left over closes an UNDECLARED cycle
+        # and would be silently dropped by the traversal -- refuse instead.
+        # Declared closures (loop=True) are cut edges by construction.
+        n_tree_conns = sum(1 for c in self.connections if not c.loop)
         tree_edges = len(self.instances) - len(root_nodes)
-        if len(self.connections) > tree_edges:
+        if n_tree_conns > tree_edges:
             raise ValueError(
-                f'assembly graph contains a cycle: {len(self.connections)} '
-                f'connections for {len(self.instances)} instance(s) in '
+                f'assembly graph contains an undeclared cycle: '
+                f'{n_tree_conns} tree connections for '
+                f'{len(self.instances)} instance(s) in '
                 f'{len(root_nodes)} component(s); a URDF kinematic tree '
-                'cannot represent closed loops')
+                'cannot represent closed loops -- declare the cut edge '
+                'with connect(..., loop=True)')
         return root_nodes, node_map
 
     def build(self, output_path: Optional[str] = None) -> str:
@@ -831,6 +871,12 @@ class RobotAssembly:
         to its own root link, with all element names prefixed by the
         instance id.  Modules keep their original kinematic structure (no
         chain reversal).
+
+        Connections declared with ``loop=True`` are cut edges: they never
+        become joints.  When any exist, a ``loop_closures.yaml`` sidecar
+        (the runtime-IK relay config) is written next to the output URDF,
+        and a parallelogram four-bar loop additionally gets exact
+        ``<mimic>`` tags on its dependent joints.
 
         Parameters
         ----------
@@ -890,6 +936,9 @@ class RobotAssembly:
         self._validate_and_default_root()
         temp_dir = tempfile.mkdtemp(prefix=f"{self.name}_build_")
         robot = self._compose_inline(temp_dir)
+        # validates declared closures and injects parallelogram mimics;
+        # the relay yaml sidecar only exists when building to a file
+        self._apply_loop_closures(robot)
         return RobotModelFromURDF(
             urdf=etree.tostring(robot, encoding="unicode"))
 
@@ -980,15 +1029,302 @@ class RobotAssembly:
 
         return robot
 
+    _MOVABLE_JOINT_TYPES = ("revolute", "continuous", "prismatic")
+
+    @staticmethod
+    def _link_transforms(robot, joint_values=None):
+        """World transform of every link in a composed robot element.
+
+        Walks the joint tree from the root link(s).  ``joint_values`` maps
+        joint names to positions; unlisted joints sit at zero, so with no
+        argument this is the zero-pose forward kinematics.
+
+        Parameters
+        ----------
+        robot : lxml.etree._Element
+            The ``<robot>`` element with top-level ``<link>``/``<joint>``
+            children.
+        joint_values : Dict[str, float], optional
+            Joint positions (radians / metres) for movable joints.
+
+        Returns
+        -------
+        Dict[str, numpy.ndarray]
+            Mapping from link name to its 4x4 world transform.
+        """
+        joint_values = joint_values or {}
+        children: Dict[str, list] = {}
+        child_links = set()
+        for j in robot.findall("joint"):
+            parent = j.find("parent").get("link")
+            child = j.find("child").get("link")
+            origin = j.find("origin")
+            if origin is not None:
+                xyz = [float(v) for v in
+                       origin.get("xyz", "0 0 0").split()]
+                rpy = [float(v) for v in
+                       origin.get("rpy", "0 0 0").split()]
+            else:
+                xyz = [0.0, 0.0, 0.0]
+                rpy = [0.0, 0.0, 0.0]
+            transform = xyzrpy2matrix(xyz, rpy)
+            q = float(joint_values.get(j.get("name"), 0.0))
+            if q != 0.0:
+                axis_elem = j.find("axis")
+                axis = np.array(
+                    [float(v) for v in axis_elem.get("xyz").split()]
+                ) if axis_elem is not None else np.array([0.0, 0.0, 1.0])
+                joint_type = j.get("type")
+                motion = np.eye(4)
+                if joint_type in ("revolute", "continuous"):
+                    motion[:3, :3] = rotation_matrix(q, axis)
+                elif joint_type == "prismatic":
+                    motion[:3, 3] = axis / np.linalg.norm(axis) * q
+                transform = transform @ motion
+            children.setdefault(parent, []).append((child, transform))
+            child_links.add(child)
+
+        transforms = {}
+        queue = deque()
+        for link in robot.findall("link"):
+            name = link.get("name")
+            if name not in child_links:
+                transforms[name] = np.eye(4)
+                queue.append(name)
+        while queue:
+            link_name = queue.popleft()
+            for child, transform in children.get(link_name, ()):
+                transforms[child] = transforms[link_name] @ transform
+                queue.append(child)
+        return transforms
+
+    def _apply_loop_closures(self, robot):
+        """Export the declared loop closures against the composed robot.
+
+        For every ``loop=True`` connection: validate that the two port
+        links coincide at the zero pose and share a hinge axis (their port
+        Z), split the movable joints on the loop ring into one driver
+        (independent) and solved (dependent) joints, and -- when the ring
+        is a parallelogram four-bar, verified numerically -- write exact
+        linear ``<mimic>`` tags onto the dependent joints so even
+        mimic-only consumers (robot_state_publisher) stay on the loop.
+
+        Returns
+        -------
+        dict or None
+            The runtime-IK relay config ``{closures: [{link_a, link_b,
+            point, axis}], dependent: [...], independent: [...]}`` with
+            ``point``/``axis`` in the URDF root frame at the zero pose,
+            or None when no closure is declared.
+        """
+        loops = [c for c in self.connections if c.loop]
+        if not loops:
+            return None
+        fk = self._link_transforms(robot)
+        parent_joint = {j.find("child").get("link"): j
+                        for j in robot.findall("joint")}
+        all_movable = [j.get("name") for j in robot.findall("joint")
+                       if j.get("type") in self._MOVABLE_JOINT_TYPES]
+
+        def links_up(link):
+            out = [link]
+            while link in parent_joint:
+                link = parent_joint[link].find("parent").get("link")
+                out.append(link)
+            return out
+
+        def ring_side(link, stop):
+            """Joint elements from ``link`` up to (excluding) ``stop``."""
+            out = []
+            while link != stop:
+                joint = parent_joint[link]
+                out.append(joint)
+                link = joint.find("parent").get("link")
+            return out
+
+        closures = []
+        dependent = set()
+        drivers = set()
+        for conn in loops:
+            label = (f"{conn.module_a}.{conn.port_a} <-> "
+                     f"{conn.module_b}.{conn.port_b}")
+            link_a = (f"{conn.module_a}_{conn.port_a}"
+                      if conn.module_a else conn.port_a)
+            link_b = (f"{conn.module_b}_{conn.port_b}"
+                      if conn.module_b else conn.port_b)
+            t_a, t_b = fk[link_a], fk[link_b]
+            gap = float(np.linalg.norm(t_a[:3, 3] - t_b[:3, 3]))
+            if gap > 1e-6:
+                raise ValueError(
+                    f"loop closure {label}: the zero pose leaves the two "
+                    f"ports {gap:.3g} m apart; a closure is the cut hinge "
+                    "of an assembled loop, so the tree connections must "
+                    "already place the ports coincident (e.g. via "
+                    "mate=True) before the loop edge is declared")
+            # the hinge is the LINE through the port origin along port Z;
+            # the axis sign is irrelevant (the closure constrains witness
+            # POINTS on that line, not a direction), so mated Z-opposed
+            # ports are as valid as aligned ones
+            axis_a, axis_b = t_a[:3, 2], t_b[:3, 2]
+            if float(np.linalg.norm(np.cross(axis_a, axis_b))) > 1e-6:
+                raise ValueError(
+                    f"loop closure {label}: the two port Z axes are not "
+                    "collinear at the zero pose, so they do not define a "
+                    "common hinge axis")
+            ancestors_b = set(links_up(link_b))
+            lca = next(link for link in links_up(link_a)
+                       if link in ancestors_b)
+            side_a = ring_side(link_a, lca)
+            side_b = ring_side(link_b, lca)
+            ring = ([j for j in side_a
+                     if j.get("type") in self._MOVABLE_JOINT_TYPES]
+                    + [j for j in reversed(side_b)
+                       if j.get("type") in self._MOVABLE_JOINT_TYPES])
+            if not ring:
+                raise ValueError(
+                    f"loop closure {label}: no movable joint on the loop "
+                    "ring -- the closure would weld a rigid ring, which a "
+                    "kinematic tree already represents without it")
+            # a joint that already mimics another, or that an earlier
+            # closure marked dependent, is solved -- it cannot drive
+            drivable = [j for j in ring if j.find("mimic") is None
+                        and j.get("name") not in dependent]
+            if not drivable:
+                raise ValueError(
+                    f"loop closure {label}: every movable joint on the "
+                    "loop ring is already solved (mimic or another "
+                    "closure's dependent), so nothing can drive the loop")
+            driver = min(
+                drivable,
+                key=lambda j: (len(links_up(j.find("child").get("link"))),
+                               j.get("name")))
+            drivers.add(driver.get("name"))
+            # never re-mark another closure's driver as dependent: a joint
+            # must end up on exactly one side of the split
+            deps = [j for j in ring if j is not driver
+                    and j.get("name") not in drivers]
+            dependent.update(j.get("name") for j in deps)
+            point = t_a[:3, 3]
+            closures.append({
+                "link_a": link_a, "link_b": link_b,
+                "point": [round(float(v), 8) for v in point],
+                "axis": [round(float(v), 8) for v in axis_a],
+            })
+            self._try_parallelogram_mimic(
+                robot, fk, ring, driver, deps, point, axis_a,
+                link_a, link_b)
+        return {
+            "closures": closures,
+            "dependent": sorted(dependent),
+            "independent": sorted(set(all_movable) - dependent),
+        }
+
+    def _try_parallelogram_mimic(self, robot, fk, ring, driver, deps,
+                                 cut_point, cut_axis, link_a, link_b):
+        """Write exact ``<mimic>`` tags when the loop is a parallelogram.
+
+        A four-bar whose hinge quadrilateral is a parallelogram (all four
+        axes parallel) couples its joints LINEARLY (multipliers of exactly
+        +/-1), which the URDF ``<mimic>`` tag can represent -- unlike a
+        general four-bar, whose coupling is nonlinear and is left to the
+        runtime-IK relay.  Candidate multipliers are certified by forward
+        kinematics before anything is written: the cut-hinge witness
+        points must still coincide at sampled nonzero driver angles.
+        Silently does nothing when the ring is not such a loop.
+        """
+        if len(ring) != 3 or len(deps) != 2:
+            return
+        if any(j.get("type") not in ("revolute", "continuous")
+               for j in ring):
+            return
+        if any(j.find("mimic") is not None for j in ring):
+            return
+        normal = cut_axis / np.linalg.norm(cut_axis)
+        world_axes = []
+        hinge_points = [np.asarray(cut_point, dtype=float)]
+        for j in ring:
+            child = j.find("child").get("link")
+            axis_elem = j.find("axis")
+            axis = np.array(
+                [float(v) for v in axis_elem.get("xyz").split()]
+            ) if axis_elem is not None else np.array([0.0, 0.0, 1.0])
+            world_axes.append(fk[child][:3, :3] @ axis)
+            hinge_points.append(fk[child][:3, 3])
+        if any(float(np.linalg.norm(np.cross(normal, a)))
+               > 1e-8 * np.linalg.norm(a) for a in world_axes):
+            return
+        # ring order is cut -> side_a joints -> side_b joints, a cyclic
+        # quadrilateral; parallelogram iff one side pair matches (the
+        # other follows), checked in the plane normal to the hinge axis
+        planar = [p - np.dot(p, normal) * normal for p in hinge_points]
+        if float(np.linalg.norm((planar[1] - planar[0])
+                                - (planar[2] - planar[3]))) > 1e-6:
+            return
+
+        driver_name = driver.get("name")
+        witness_local = []
+        for w in (cut_point, cut_point + 0.03 * normal):
+            w_h = np.append(w, 1.0)
+            witness_local.append((np.linalg.solve(fk[link_a], w_h),
+                                  np.linalg.solve(fk[link_b], w_h)))
+        for m0 in (1.0, -1.0):
+            for m1 in (1.0, -1.0):
+                multipliers = (m0, m1)
+                closed = True
+                for q in (0.3, -0.45):
+                    joint_values = {driver_name: q}
+                    for dep, m in zip(deps, multipliers):
+                        joint_values[dep.get("name")] = m * q
+                    fk_q = self._link_transforms(robot, joint_values)
+                    for local_a, local_b in witness_local:
+                        gap = np.linalg.norm(fk_q[link_a] @ local_a
+                                             - fk_q[link_b] @ local_b)
+                        if gap > 1e-9:
+                            closed = False
+                            break
+                    if not closed:
+                        break
+                if closed:
+                    for dep, m in zip(deps, multipliers):
+                        mimic = etree.SubElement(dep, "mimic")
+                        mimic.set("joint", driver_name)
+                        mimic.set("multiplier", str(m))
+                        mimic.set("offset", "0")
+                    return
+
+    @staticmethod
+    def _write_loop_closures_yaml(config, directory):
+        """Write the runtime-IK relay config next to the built URDF.
+
+        ``loop_closures.yaml`` is the contract consumed by downstream
+        loop-closure relay nodes: at every joint state they solve the
+        dependent joints so each closure's two link points coincide.
+        """
+        import yaml
+        head = ("# Closed-loop closures for a loop-closure relay "
+                "(runtime IK).\n"
+                "# independent = driven joints; dependent = solved so each "
+                "closure's\n"
+                "# two link points (the cut hinge) coincide.\n")
+        path = os.path.join(directory, "loop_closures.yaml")
+        with open(path, "w") as f:
+            f.write(head + yaml.safe_dump(config, sort_keys=False,
+                                          default_flow_style=None))
+        return path
+
     def _build_inline(self, output_path: Optional[str] = None) -> str:
         """Compose the combined URDF and write it to disk."""
         temp_dir = tempfile.mkdtemp(prefix=f"{self.name}_build_")
         robot = self._compose_inline(temp_dir)
+        closures = self._apply_loop_closures(robot)
         if output_path is None:
             output_path = os.path.join(temp_dir, f"{self.name}.urdf")
         with open(output_path, "wb") as f:
             f.write(etree.tostring(robot, pretty_print=True,
                                    xml_declaration=True, encoding="UTF-8"))
+        if closures is not None:
+            self._write_loop_closures_yaml(
+                closures, os.path.dirname(os.path.abspath(output_path)))
         return output_path
 
     def to_dict(self) -> dict:
@@ -1010,7 +1346,7 @@ class RobotAssembly:
                  "module_b": c.module_b, "port_b": c.port_b,
                  "x": c.x, "y": c.y, "z": c.z,
                  "roll": c.roll, "pitch": c.pitch, "yaw": c.yaw,
-                 "attach": c.attach}
+                 "attach": c.attach, "loop": c.loop}
                 for c in self.connections
             ],
             "root": {"instance": self.root_instance, "port": self.root_port} if self.root_instance else None,
@@ -1036,7 +1372,8 @@ class RobotAssembly:
                 z=conn.get("z", 0.0),
                 roll=conn.get("roll", 0.0), pitch=conn.get("pitch", 0.0),
                 yaw=conn.get("yaw", 0.0),
-                attach=conn.get("attach", "root"))
+                attach=conn.get("attach", "root"),
+                loop=conn.get("loop", False))
         if data.get("root_instance"):
             assembly.set_root(data["root_instance"], data["root_port"])
         return assembly

--- a/skrobot/assembly/module_assembly.py
+++ b/skrobot/assembly/module_assembly.py
@@ -462,6 +462,11 @@ class RobotAssembly:
         The instance ID that will become the root of the final URDF tree.
     root_port : Optional[str]
         The port on root_instance that will become the root link.
+    loop_closures : Optional[dict]
+        After a build: the closure config the loop connections produced
+        (the ``loop_closures.yaml`` content), ready to hand to
+        :class:`skrobot.kinematics.LoopClosureSolver`; None when the
+        assembly declares no loop.
 
     Examples
     --------
@@ -498,6 +503,7 @@ class RobotAssembly:
         self.connections: List[Connection] = []
         self.root_instance: Optional[str] = None
         self.root_port: Optional[str] = None
+        self.loop_closures: Optional[dict] = None
 
     def add_module_instance(self, instance_id: str, module: RobotModule) -> None:
         """
@@ -966,7 +972,7 @@ class RobotAssembly:
         robot = self._compose_inline(temp_dir)
         # validates declared closures and injects parallelogram mimics;
         # the relay yaml sidecar only exists when building to a file
-        self._apply_loop_closures(robot)
+        self.loop_closures = self._apply_loop_closures(robot)
         return RobotModelFromURDF(
             urdf=etree.tostring(robot, encoding="unicode"))
 
@@ -1463,6 +1469,7 @@ class RobotAssembly:
         temp_dir = tempfile.mkdtemp(prefix=f"{self.name}_build_")
         robot = self._compose_inline(temp_dir)
         closures = self._apply_loop_closures(robot)
+        self.loop_closures = closures
         if output_path is None:
             output_path = os.path.join(temp_dir, f"{self.name}.urdf")
         with open(output_path, "wb") as f:

--- a/skrobot/assembly/module_assembly.py
+++ b/skrobot/assembly/module_assembly.py
@@ -46,7 +46,7 @@ class Port:
     A port is a link in the URDF that can be connected to another module's port.
     Typically these are "dummy_link" elements in the URDF files.
 
-    Attributes
+    Parameters
     ----------
     name : str
         The link name in the URDF that serves as a connection point.
@@ -89,7 +89,7 @@ class RobotModule:
     This class does NOT hold parent-child relationships. It simply stores
     metadata about a single URDF file and its available connection ports.
 
-    Attributes
+    Parameters
     ----------
     module_id : str
         Unique identifier for this module type (e.g., "hinge_module", "branch_module").
@@ -327,7 +327,7 @@ class Connection:
 
     This is an edge in the undirected connection graph.
 
-    Attributes
+    Parameters
     ----------
     module_a : str
         Instance ID of the first module.

--- a/skrobot/kinematics/__init__.py
+++ b/skrobot/kinematics/__init__.py
@@ -18,6 +18,9 @@ from skrobot.kinematics.differentiable import extract_fk_parameters
 from skrobot.kinematics.differentiable import forward_kinematics
 from skrobot.kinematics.differentiable import forward_kinematics_ee
 
+# Loop-closure solving for cut kinematic loops
+from skrobot.kinematics.loop_closure import LoopClosureSolver
+
 # Reachability map
 from skrobot.kinematics.reachability_map import ReachabilityMap
 
@@ -28,5 +31,6 @@ __all__ = [
     'forward_kinematics_ee',
     'create_batch_ik_solver',
     'create_dynamic_limit_mask',
+    'LoopClosureSolver',
     'ReachabilityMap',
 ]

--- a/skrobot/kinematics/loop_closure.py
+++ b/skrobot/kinematics/loop_closure.py
@@ -2,7 +2,7 @@
 
 A URDF is a tree: building a closed linkage (four-bar, parallel
 mechanism) cuts every loop, and the cut is exported as a closure
-constraint -- :class:`skrobot.urdf.module_assembly.RobotAssembly`
+constraint -- :class:`skrobot.assembly.module_assembly.RobotAssembly`
 writes it to a ``loop_closures.yaml`` sidecar next to the built URDF.
 :class:`LoopClosureSolver` consumes that config and Gauss-Newton
 solves the DEPENDENT joints so each cut hinge's witness points

--- a/skrobot/kinematics/loop_closure.py
+++ b/skrobot/kinematics/loop_closure.py
@@ -1,0 +1,261 @@
+"""Close declared kinematic loops on a RobotModel by numerical IK.
+
+A URDF is a tree: building a closed linkage (four-bar, parallel
+mechanism) cuts every loop, and the cut is exported as a closure
+constraint -- :class:`skrobot.urdf.module_assembly.RobotAssembly`
+writes it to a ``loop_closures.yaml`` sidecar next to the built URDF.
+:class:`LoopClosureSolver` consumes that config and Gauss-Newton
+solves the DEPENDENT joints so each cut hinge's witness points
+coincide again: the same constraint a runtime relay node enforces on
+a ROS robot, made available to plain skrobot users (viewers,
+planners, analysis).
+"""
+
+import numpy as np
+
+
+class LoopClosureSolver(object):
+    """Solve a robot's declared loop closures in place.
+
+    Set the driven (independent) joints to their targets, then call
+    :meth:`solve`: the dependent joints are updated so every closure's
+    two witness points -- two points on the cut hinge axis, one frame
+    per side of the cut -- coincide.  Large driver motions are
+    sub-stepped so the solution stays on the assembled branch of the
+    mechanism instead of jumping to a mirror configuration.
+
+    Parameters
+    ----------
+    robot_model : skrobot.model.RobotModel
+        Robot built from the loop-cut URDF (e.g. via
+        :meth:`RobotAssembly.build_robot_model`).
+    config : dict
+        Closure config ``{closures: [{link_a, link_b, point, axis}],
+        dependent: [...], independent: [...]}`` with ``point`` and
+        ``axis`` expressed in the root frame at the zero pose -- the
+        ``loop_closures.yaml`` contract.
+
+    Examples
+    --------
+    >>> robot = assembly.build_robot_model()
+    >>> solver = LoopClosureSolver(robot, assembly.loop_closures)
+    >>> robot.crank_hinge.joint_angle(0.4)
+    >>> solver.solve()
+    """
+
+    def __init__(self, robot_model, config):
+        if not config:
+            raise ValueError(
+                "no closure config (the assembly declares no loop "
+                "connection, or the loop_closures.yaml is empty)")
+        closures = list(config.get("closures", []))
+        if not closures:
+            raise ValueError("config declares no closures to solve")
+        joints = {j.name: j for j in robot_model.joint_list}
+        links = {link.name: link for link in robot_model.link_list}
+        missing = [n for n in list(config.get("dependent", []))
+                   + list(config.get("independent", []))
+                   if n not in joints]
+        if missing:
+            raise ValueError(
+                f"config joint(s) {missing} do not exist on the robot")
+        self.robot_model = robot_model
+        self.dependent = [joints[n] for n in config.get("dependent", [])]
+        if not self.dependent:
+            raise ValueError(
+                "config marks no dependent joint; a closure with nothing "
+                "to solve cannot be enforced")
+        self.independent = [joints[n]
+                            for n in config.get("independent", [])]
+        multi_dof = [j.name for j in self.dependent + self.independent
+                     if getattr(j, "joint_dof", 1) != 1]
+        if multi_dof:
+            raise ValueError(
+                f"joint(s) {multi_dof} have more than one degree of "
+                "freedom; the solver only handles scalar (revolute / "
+                "continuous / prismatic) joints")
+
+        # capture the witness pairs in link-local coordinates at the
+        # zero pose, the frame the config's point/axis are expressed in.
+        # The zero-pose transforms are composed analytically from the
+        # joints' default_coords: actually zeroing and restoring the
+        # robot would leave tiny incremental-rotation drift in the link
+        # frames, which the solver would then bake into the dependents.
+        self._witnesses = []
+        for closure in closures:
+            unknown = [n for n in (closure["link_a"], closure["link_b"])
+                       if n not in links]
+            if unknown:
+                raise ValueError(
+                    f"closure link(s) {unknown} do not exist on the robot")
+            link_a = links[closure["link_a"]]
+            link_b = links[closure["link_b"]]
+            zero_a = self._zero_pose_transform(link_a)
+            zero_b = self._zero_pose_transform(link_b)
+            point = np.asarray(closure["point"], dtype=float)
+            axis = np.asarray(closure["axis"], dtype=float)
+            norm = np.linalg.norm(axis)
+            if not np.isfinite(norm) or norm < 1e-12:
+                raise ValueError(
+                    f"closure {closure['link_a']} <-> "
+                    f"{closure['link_b']} has a zero or non-finite "
+                    "hinge axis")
+            axis = axis / norm
+            for witness in (point, point + 0.03 * axis):
+                homogeneous = np.append(witness, 1.0)
+                self._witnesses.append(
+                    (link_a, np.linalg.solve(zero_a, homogeneous)[:3],
+                     link_b, np.linalg.solve(zero_b, homogeneous)[:3]))
+        self._last_independent = np.array(
+            [j.joint_angle() for j in self.independent])
+
+    @classmethod
+    def from_yaml(cls, robot_model, path):
+        """Build a solver from a ``loop_closures.yaml`` sidecar file."""
+        import yaml
+        with open(path) as f:
+            return cls(robot_model, yaml.safe_load(f))
+
+    @staticmethod
+    def _zero_pose_transform(link):
+        """4x4 world transform of ``link`` with every joint at zero.
+
+        Composes each parent joint's ``default_coords`` (the child link
+        frame relative to its parent, captured at model construction)
+        down the chain from the root, so the current joint values never
+        enter and the robot is not disturbed.
+        """
+        chain = []
+        current = link
+        while current.parent_link is not None and \
+                getattr(current, "joint", None) is not None:
+            chain.append(current.joint)
+            current = current.parent_link
+        coords = current.worldcoords()
+        transform = np.eye(4)
+        transform[:3, :3] = coords.worldrot()
+        transform[:3, 3] = coords.worldpos()
+        for joint in reversed(chain):
+            local = np.eye(4)
+            local[:3, :3] = joint.default_coords.rotation
+            local[:3, 3] = joint.default_coords.translation
+            transform = transform @ local
+        return transform
+
+    def _residual(self):
+        """Stacked witness-point gaps (3 scalars per witness)."""
+        out = np.empty(3 * len(self._witnesses))
+        for i, (link_a, local_a, link_b, local_b) in \
+                enumerate(self._witnesses):
+            coords_a = link_a.worldcoords()
+            coords_b = link_b.worldcoords()
+            gap = (coords_a.worldrot() @ local_a + coords_a.worldpos()
+                   - coords_b.worldrot() @ local_b - coords_b.worldpos())
+            out[3 * i:3 * i + 3] = gap
+        return out
+
+    def _jacobian(self, residual, eps=1e-6):
+        """Numeric Jacobian of the residual w.r.t. dependent joints."""
+        jacobian = np.empty((residual.shape[0], len(self.dependent)))
+        for k, joint in enumerate(self.dependent):
+            q = joint.joint_angle()
+            # perturb away from a limit so the clamped set is a no-op
+            step = eps if q + eps <= joint.max_angle else -eps
+            joint.joint_angle(q + step)
+            jacobian[:, k] = (self._residual() - residual) / step
+            joint.joint_angle(q)
+        return jacobian
+
+    def closure_error(self):
+        """Largest witness-point gap (metres) over all closures.
+
+        Unlike the stacked residual norm :meth:`solve` returns, this is
+        a per-witness maximum, so the two differ by up to ``sqrt(2 *
+        n_closures)`` on the same state.
+        """
+        residual = self._residual()
+        return float(max(np.linalg.norm(residual[3 * i:3 * i + 3])
+                         for i in range(len(self._witnesses))))
+
+    def solve(self, tol=1e-10, max_iter=50, max_step=0.1, max_dq=0.5,
+              raise_error=True):
+        """Update the dependent joints so every loop closes.
+
+        Reads the CURRENT independent joint values as the target,
+        interpolates from the previously solved values in steps of at
+        most ``max_step`` (radians / metres), and Gauss-Newton solves
+        the dependent joints at each sub-step.  Each update is the
+        minimum-norm least-squares step (SVD), which stays stable on
+        the rank-deficient Jacobians every planar mechanism produces
+        (the out-of-plane residual rows are identically zero).
+
+        Parameters
+        ----------
+        tol : float
+            Success threshold on the residual norm (metres).
+        max_iter : int
+            Gauss-Newton iterations per sub-step.
+        max_step : float
+            Largest independent-joint change per sub-step; keeps the
+            solution on the assembled branch of the mechanism.
+        max_dq : float
+            Cap on a single Gauss-Newton update per joint (radians /
+            metres), guarding against wild steps near singularities.
+        raise_error : bool
+            Raise ``ValueError`` when the final residual exceeds
+            ``tol`` (e.g. the loop cannot close at these driver
+            values).  Pass ``False`` to just return the residual.
+
+        Returns
+        -------
+        float
+            Final residual norm in metres.
+
+        Notes
+        -----
+        On failure the robot is left at the unconverged pose, but the
+        warm-start state is NOT advanced: the next call sub-steps from
+        the last successfully solved independent values, so one
+        unreachable target does not poison later reachable ones.
+        """
+        if max_step <= 0 or max_dq <= 0 or max_iter < 1 or tol < 0:
+            raise ValueError(
+                "max_step and max_dq must be positive, max_iter >= 1 "
+                "and tol >= 0")
+        target = np.array([j.joint_angle() for j in self.independent])
+        if target.size and self._last_independent.size:
+            delta = target - self._last_independent
+            n_sub = max(1, int(np.ceil(np.max(np.abs(delta)) / max_step)))
+        else:
+            delta = target
+            n_sub = 1
+        for step in range(1, n_sub + 1):
+            values = self._last_independent + delta * (step / n_sub)
+            for joint, value in zip(self.independent, values):
+                joint.joint_angle(value)
+            residual = self._residual()
+            for _ in range(max_iter):
+                if np.linalg.norm(residual) < tol:
+                    break
+                jacobian = self._jacobian(residual)
+                dq = np.linalg.lstsq(jacobian, residual, rcond=None)[0]
+                worst = np.max(np.abs(dq))
+                if worst > max_dq:
+                    dq *= max_dq / worst
+                q = np.array([j.joint_angle() for j in self.dependent])
+                for joint, value in zip(self.dependent, q - dq):
+                    joint.joint_angle(value)
+                residual = self._residual()
+        error = float(np.linalg.norm(self._residual()))
+        if error <= tol:
+            # commit the values actually applied (joint_angle clamps to
+            # limits), and only on success -- a failed target must not
+            # become the warm start for the next call
+            self._last_independent = np.array(
+                [j.joint_angle() for j in self.independent])
+        elif raise_error:
+            raise ValueError(
+                f"loop closure did not converge: residual {error:.3g} m "
+                f"exceeds tol {tol:.3g} (the loop may not close at these "
+                "driver values, e.g. a crank past its geometric limit)")
+        return error

--- a/tests/skrobot_tests/assembly_tests/test_module_assembly.py
+++ b/tests/skrobot_tests/assembly_tests/test_module_assembly.py
@@ -412,3 +412,205 @@ class TestV4PortsAndMating(unittest.TestCase):
         with self.assertRaises(ValueError):
             assembly.connect('a1', 'dummy_link1', 'b1', 'base_link')
         assembly.connect('a1', 'dummy_link1', 'b1', 'dummy_link1')
+
+
+_GROUND_URDF = """<?xml version="1.0"?>
+<robot name="ground">
+  <link name="base_link"/>
+  <link name="g1"/>
+  <link name="g2"/>
+  <joint name="fg1" type="fixed">
+    <parent link="base_link"/><child link="g1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+  <joint name="fg2" type="fixed">
+    <parent link="base_link"/><child link="g2"/>
+    <origin xyz="{g2_xyz}" rpy="0 0 0"/>
+  </joint>
+</robot>
+"""
+
+_BAR_URDF = """<?xml version="1.0"?>
+<robot name="bar">
+  <link name="base_link"/>
+  <link name="arm"/>
+  <link name="tip"/>
+  <joint name="hinge" type="revolute">
+    <parent link="base_link"/><child link="arm"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1.5" upper="1.5" effort="1" velocity="1"/>
+  </joint>
+  <joint name="tipj" type="fixed">
+    <parent link="arm"/><child link="tip"/>
+    <origin xyz="{tip_xyz}" rpy="{tip_rpy}"/>
+  </joint>
+</robot>
+"""
+
+
+class TestV5LoopClosures(unittest.TestCase):
+    """connect(loop=True): cut edges, the relay sidecar and exact mimic."""
+
+    @staticmethod
+    def _write(tmp, name, content):
+        path = os.path.join(tmp, name + '.urdf')
+        with open(path, 'w') as f:
+            f.write(content)
+        return RobotModule.from_urdf(name, path)
+
+    def _four_bar(self, tmp, g2_xyz='0.2 0 0', crank2_tip='0 0.1 0',
+                  coupler_tip_rpy='0 0 0'):
+        """Ground + two cranks + coupler, loop-closed at the coupler tip.
+
+        The defaults make the hinge quadrilateral a rectangle (a
+        parallelogram); pass a shifted ``g2_xyz``/``crank2_tip`` pair that
+        still closes at the zero pose for a non-parallelogram four-bar.
+        """
+        ground = self._write(tmp, 'ground',
+                             _GROUND_URDF.format(g2_xyz=g2_xyz))
+        crank = self._write(tmp, 'crank',
+                            _BAR_URDF.format(tip_xyz='0 0.1 0',
+                                             tip_rpy='0 0 0'))
+        crank2 = self._write(tmp, 'crank2',
+                             _BAR_URDF.format(tip_xyz=crank2_tip,
+                                              tip_rpy='0 0 0'))
+        coupler = self._write(tmp, 'coupler',
+                              _BAR_URDF.format(tip_xyz='0.2 0 0',
+                                               tip_rpy=coupler_tip_rpy))
+        assembly = RobotAssembly('fourbar')
+        assembly.add_module_instance('g', ground)
+        assembly.add_module_instance('c1', crank)
+        assembly.add_module_instance('c2', crank2)
+        assembly.add_module_instance('cp', coupler)
+        assembly.connect('g', 'g1', 'c1', 'base_link')
+        assembly.connect('g', 'g2', 'c2', 'base_link')
+        assembly.connect('c1', 'tip', 'cp', 'base_link')
+        assembly.connect('cp', 'tip', 'c2', 'tip', loop=True)
+        assembly.set_root('g', 'base_link')
+        return assembly
+
+    def test_loop_rejects_transform_mate_and_attach(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._four_bar(tmp)
+            for kwargs in ({'yaw': 0.5}, {'x': 0.1}, {'mate': True},
+                           {'attach': 'port'}):
+                with self.assertRaises(ValueError):
+                    assembly.connect('c1', 'arm', 'c2', 'arm',
+                                     loop=True, **kwargs)
+
+    def test_loop_builds_and_writes_relay_sidecar(self):
+        import yaml
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._four_bar(tmp)
+            path = assembly.build(
+                output_path=os.path.join(tmp, 'fourbar.urdf'))
+            sidecar = os.path.join(os.path.dirname(path),
+                                   'loop_closures.yaml')
+            self.assertTrue(os.path.exists(sidecar))
+            with open(sidecar) as f:
+                config = yaml.safe_load(f)
+        self.assertEqual(config['independent'], ['c1_hinge'])
+        self.assertEqual(config['dependent'], ['c2_hinge', 'cp_hinge'])
+        closure = config['closures'][0]
+        self.assertEqual(closure['link_a'], 'cp_tip')
+        self.assertEqual(closure['link_b'], 'c2_tip')
+        for got, want in zip(closure['point'], [0.2, 0.1, 0.0]):
+            self.assertAlmostEqual(got, want, places=8)
+        for got, want in zip(closure['axis'], [0.0, 0.0, 1.0]):
+            self.assertAlmostEqual(got, want, places=8)
+
+    def test_parallelogram_gets_exact_mimic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._four_bar(tmp)
+            root = ET.parse(assembly.build(
+                output_path=os.path.join(tmp, 'fourbar.urdf'))).getroot()
+        mimics = {j.get('name'): j.find('mimic')
+                  for j in root.findall('joint')
+                  if j.find('mimic') is not None}
+        self.assertEqual(sorted(mimics), ['c2_hinge', 'cp_hinge'])
+        for name, multiplier in (('c2_hinge', 1.0), ('cp_hinge', -1.0)):
+            self.assertEqual(mimics[name].get('joint'), 'c1_hinge')
+            self.assertAlmostEqual(
+                float(mimics[name].get('multiplier')), multiplier)
+
+    def test_general_four_bar_gets_no_mimic(self):
+        # crank2 is shorter and its ground pivot shifted so the loop still
+        # closes at zero but the quadrilateral is not a parallelogram
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._four_bar(tmp, g2_xyz='0.2 0.05 0',
+                                      crank2_tip='0 0.05 0')
+            root = ET.parse(assembly.build(
+                output_path=os.path.join(tmp, 'fourbar.urdf'))).getroot()
+            sidecar = os.path.join(tmp, 'loop_closures.yaml')
+            self.assertTrue(os.path.exists(sidecar))
+        self.assertEqual([j.get('name') for j in root.findall('joint')
+                          if j.find('mimic') is not None], [])
+
+    def test_z_opposed_loop_ports_still_close(self):
+        # the keyed-mate convention seats ports Z-opposed; the hinge is a
+        # LINE, so an anti-parallel port Z must work like an aligned one
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._four_bar(
+                tmp, coupler_tip_rpy='3.141592653589793 0 0')
+            root = ET.parse(assembly.build(
+                output_path=os.path.join(tmp, 'fourbar.urdf'))).getroot()
+        mimics = {j.get('name'): j.find('mimic')
+                  for j in root.findall('joint')
+                  if j.find('mimic') is not None}
+        self.assertEqual(sorted(mimics), ['c2_hinge', 'cp_hinge'])
+        for name, multiplier in (('c2_hinge', 1.0), ('cp_hinge', -1.0)):
+            self.assertEqual(mimics[name].get('joint'), 'c1_hinge')
+            self.assertAlmostEqual(
+                float(mimics[name].get('multiplier')), multiplier)
+
+    def test_unrelated_movable_joint_stays_independent(self):
+        # relay contract: independent = every movable joint the relay must
+        # take from the incoming joint states, loop-related or not
+        import yaml
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._four_bar(tmp)
+            extra = self._write(tmp, 'extra',
+                                _BAR_URDF.format(tip_xyz='0 0.1 0',
+                                                 tip_rpy='0 0 0'))
+            assembly.add_module_instance('x1', extra)
+            assembly.connect('g', 'g2', 'x1', 'base_link', x=1.0)
+            assembly.build(output_path=os.path.join(tmp, 'fourbar.urdf'))
+            with open(os.path.join(tmp, 'loop_closures.yaml')) as f:
+                config = yaml.safe_load(f)
+        self.assertEqual(config['independent'], ['c1_hinge', 'x1_hinge'])
+        self.assertEqual(config['dependent'], ['c2_hinge', 'cp_hinge'])
+
+    def test_open_zero_pose_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # skip the coupler: the two crank tips sit 0.2 m apart at zero
+            ground = self._write(tmp, 'ground',
+                                 _GROUND_URDF.format(g2_xyz='0.2 0 0'))
+            crank = self._write(tmp, 'crank',
+                                _BAR_URDF.format(tip_xyz='0 0.1 0',
+                                                 tip_rpy='0 0 0'))
+            assembly = RobotAssembly('open')
+            assembly.add_module_instance('g', ground)
+            assembly.add_module_instance('c1', crank)
+            assembly.add_module_instance('c2', crank)
+            assembly.connect('g', 'g1', 'c1', 'base_link')
+            assembly.connect('g', 'g2', 'c2', 'base_link')
+            assembly.connect('c1', 'tip', 'c2', 'tip', loop=True)
+            assembly.set_root('g', 'base_link')
+            with self.assertRaisesRegex(ValueError, 'apart'):
+                assembly.build(output_path=os.path.join(tmp, 'x.urdf'))
+
+    def test_loop_round_trips_through_dict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._four_bar(tmp)
+            rebuilt = RobotAssembly.from_dict(assembly.to_dict())
+            self.assertEqual(rebuilt.to_dict(), assembly.to_dict())
+            loops = [c for c in rebuilt.connections if c.loop]
+            self.assertEqual(len(loops), 1)
+
+    def test_build_robot_model_with_loop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._four_bar(tmp)
+            robot = assembly.build_robot_model()
+        joint_names = {j.name for j in robot.joint_list}
+        self.assertIn('c1_hinge', joint_names)

--- a/tests/skrobot_tests/assembly_tests/test_module_assembly.py
+++ b/tests/skrobot_tests/assembly_tests/test_module_assembly.py
@@ -430,6 +430,27 @@ _GROUND_URDF = """<?xml version="1.0"?>
 </robot>
 """
 
+_GROUND3_URDF = """<?xml version="1.0"?>
+<robot name="ground3">
+  <link name="base_link"/>
+  <link name="g1"/>
+  <link name="g2"/>
+  <link name="g3"/>
+  <joint name="fg1" type="fixed">
+    <parent link="base_link"/><child link="g1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+  <joint name="fg2" type="fixed">
+    <parent link="base_link"/><child link="g2"/>
+    <origin xyz="0.2 0 0" rpy="0 0 0"/>
+  </joint>
+  <joint name="fg3" type="fixed">
+    <parent link="base_link"/><child link="g3"/>
+    <origin xyz="0.4 0 0" rpy="0 0 0"/>
+  </joint>
+</robot>
+"""
+
 _BAR_URDF = """<?xml version="1.0"?>
 <robot name="bar">
   <link name="base_link"/>
@@ -580,6 +601,137 @@ class TestV5LoopClosures(unittest.TestCase):
                 config = yaml.safe_load(f)
         self.assertEqual(config['independent'], ['c1_hinge', 'x1_hinge'])
         self.assertEqual(config['dependent'], ['c2_hinge', 'cp_hinge'])
+
+    def test_explicit_dependent_overrides_heuristic(self):
+        import yaml
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._four_bar(tmp)
+            loop = [c for c in assembly.connections if c.loop][0]
+            loop.dependent = ('c1_hinge', 'cp_hinge')
+            root = ET.parse(assembly.build(
+                output_path=os.path.join(tmp, 'fourbar.urdf'))).getroot()
+            with open(os.path.join(tmp, 'loop_closures.yaml')) as f:
+                config = yaml.safe_load(f)
+        self.assertEqual(config['independent'], ['c2_hinge'])
+        self.assertEqual(config['dependent'], ['c1_hinge', 'cp_hinge'])
+        mimics = {j.get('name'): j.find('mimic')
+                  for j in root.findall('joint')
+                  if j.find('mimic') is not None}
+        for name, multiplier in (('c1_hinge', 1.0), ('cp_hinge', -1.0)):
+            self.assertEqual(mimics[name].get('joint'), 'c2_hinge')
+            self.assertAlmostEqual(
+                float(mimics[name].get('multiplier')), multiplier)
+
+    def test_explicit_dependent_is_validated(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._four_bar(tmp)
+            with self.assertRaises(ValueError):
+                assembly.connect('c1', 'arm', 'c2', 'arm',
+                                 dependent=('c1_hinge',))  # without loop
+            loop = [c for c in assembly.connections if c.loop][0]
+            loop.dependent = ('not_a_ring_joint',)
+            with self.assertRaisesRegex(ValueError, 'not movable joints'):
+                assembly.build(output_path=os.path.join(tmp, 'x.urdf'))
+
+    def test_chained_parallelograms_propagate_mimic(self):
+        import yaml
+        with tempfile.TemporaryDirectory() as tmp:
+            ground = self._write(tmp, 'ground3', _GROUND3_URDF)
+            crank = self._write(tmp, 'crank',
+                                _BAR_URDF.format(tip_xyz='0 0.1 0',
+                                                 tip_rpy='0 0 0'))
+            coupler = self._write(tmp, 'coupler',
+                                  _BAR_URDF.format(tip_xyz='0.2 0 0',
+                                                   tip_rpy='0 0 0'))
+            assembly = RobotAssembly('double')
+            assembly.add_module_instance('g', ground)
+            for cid in ('c1', 'c2', 'c3'):
+                assembly.add_module_instance(cid, crank)
+            for pid in ('cpA', 'cpB'):
+                assembly.add_module_instance(pid, coupler)
+            assembly.connect('g', 'g1', 'c1', 'base_link')
+            assembly.connect('g', 'g2', 'c2', 'base_link')
+            assembly.connect('g', 'g3', 'c3', 'base_link')
+            assembly.connect('c1', 'tip', 'cpA', 'base_link')
+            assembly.connect('c2', 'tip', 'cpB', 'base_link')
+            assembly.connect('cpA', 'tip', 'c2', 'tip', loop=True)
+            assembly.connect('cpB', 'tip', 'c3', 'tip', loop=True)
+            assembly.set_root('g', 'base_link')
+            root = ET.parse(assembly.build(
+                output_path=os.path.join(tmp, 'double.urdf'))).getroot()
+            with open(os.path.join(tmp, 'loop_closures.yaml')) as f:
+                config = yaml.safe_load(f)
+        # the whole chain has ONE degree of freedom: everything follows c1
+        self.assertEqual(config['independent'], ['c1_hinge'])
+        self.assertEqual(config['dependent'],
+                         ['c2_hinge', 'c3_hinge', 'cpA_hinge', 'cpB_hinge'])
+        mimics = {j.get('name'): j.find('mimic')
+                  for j in root.findall('joint')
+                  if j.find('mimic') is not None}
+        expected = {'c2_hinge': 1.0, 'cpA_hinge': -1.0,
+                    'c3_hinge': 1.0, 'cpB_hinge': -1.0}
+        self.assertEqual(sorted(mimics), sorted(expected))
+        for name, multiplier in expected.items():
+            self.assertEqual(mimics[name].get('joint'), 'c1_hinge')
+            self.assertAlmostEqual(
+                float(mimics[name].get('multiplier')), multiplier)
+
+    def test_five_bar_needs_and_takes_explicit_dependent(self):
+        import yaml
+        with tempfile.TemporaryDirectory() as tmp:
+            ground = self._write(tmp, 'ground',
+                                 _GROUND_URDF.format(g2_xyz='0.2 0 0'))
+            crank = self._write(tmp, 'crank',
+                                _BAR_URDF.format(tip_xyz='0 0.1 0',
+                                                 tip_rpy='0 0 0'))
+            fore_a = self._write(tmp, 'fore_a',
+                                 _BAR_URDF.format(tip_xyz='0.1 0 0',
+                                                  tip_rpy='0 0 0'))
+            fore_b = self._write(tmp, 'fore_b',
+                                 _BAR_URDF.format(tip_xyz='-0.1 0 0',
+                                                  tip_rpy='0 0 0'))
+            assembly = RobotAssembly('fivebar')
+            assembly.add_module_instance('g', ground)
+            assembly.add_module_instance('c1', crank)
+            assembly.add_module_instance('c2', crank)
+            assembly.add_module_instance('fa', fore_a)
+            assembly.add_module_instance('fb', fore_b)
+            assembly.connect('g', 'g1', 'c1', 'base_link')
+            assembly.connect('g', 'g2', 'c2', 'base_link')
+            assembly.connect('c1', 'tip', 'fa', 'base_link')
+            assembly.connect('c2', 'tip', 'fb', 'base_link')
+            assembly.connect('fa', 'tip', 'fb', 'tip', loop=True,
+                             dependent=('fa_hinge', 'fb_hinge'))
+            assembly.set_root('g', 'base_link')
+            root = ET.parse(assembly.build(
+                output_path=os.path.join(tmp, 'fivebar.urdf'))).getroot()
+            with open(os.path.join(tmp, 'loop_closures.yaml')) as f:
+                config = yaml.safe_load(f)
+        # 2-DOF loop: both cranks stay driven, both forearms are solved
+        self.assertEqual(config['independent'], ['c1_hinge', 'c2_hinge'])
+        self.assertEqual(config['dependent'], ['fa_hinge', 'fb_hinge'])
+        self.assertEqual([j.get('name') for j in root.findall('joint')
+                          if j.find('mimic') is not None], [])
+
+    def test_resolve_mimic_chain_composes_linearly(self):
+        from lxml import etree
+
+        robot = etree.fromstring(
+            '<robot name="r">'
+            '<joint name="a" type="revolute">'
+            '<parent link="w"/><child link="x"/>'
+            '<mimic joint="b" multiplier="2" offset="3"/></joint>'
+            '<joint name="b" type="revolute">'
+            '<parent link="x"/><child link="y"/>'
+            '<mimic joint="c" multiplier="5" offset="7"/></joint>'
+            '<joint name="c" type="revolute">'
+            '<parent link="y"/><child link="z"/></joint>'
+            '</robot>')
+        chain = RobotAssembly._resolve_mimic_chain(robot)
+        # a = 2*b + 3 and b = 5*c + 7  =>  a = 10*c + 17
+        self.assertEqual(chain['a'], ('c', 10.0, 17.0))
+        self.assertEqual(chain['b'], ('c', 5.0, 7.0))
+        self.assertNotIn('c', chain)
 
     def test_open_zero_pose_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/skrobot_tests/assembly_tests/test_module_assembly.py
+++ b/tests/skrobot_tests/assembly_tests/test_module_assembly.py
@@ -430,6 +430,107 @@ _GROUND_URDF = """<?xml version="1.0"?>
 </robot>
 """
 
+
+class TestGraphEditingAndEmbed(unittest.TestCase):
+    """disconnect / remove_module_instance / to_dict(embed=True)."""
+
+    def _chain(self, tmp, n=3):
+        assembly = RobotAssembly('chain')
+        for i in range(n):
+            module = RobotModule.from_urdf(f'm{i}',
+                                           _write_module(tmp, f'm{i}'))
+            assembly.add_module_instance(f'i{i}', module)
+        for i in range(n - 1):
+            assembly.connect(f'i{i}', 'dummy_link1', f'i{i + 1}',
+                             'base_link')
+        assembly.set_root('i0', 'base_link')
+        return assembly
+
+    def test_disconnect_matches_either_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._chain(tmp)
+            assembly.disconnect('i2', 'base_link', 'i1', 'dummy_link1')
+            self.assertEqual(len(assembly.connections), 1)
+            with self.assertRaisesRegex(ValueError, 'no connection'):
+                assembly.disconnect('i1', 'dummy_link1', 'i2', 'base_link')
+            # a disconnected edge can be declared again without tripping
+            # the duplicate check
+            assembly.connect('i1', 'dummy_link1', 'i2', 'base_link')
+        self.assertEqual(len(assembly.connections), 2)
+
+    def test_disconnect_removes_loop_edges_too(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._chain(tmp)
+            assembly.connect('i2', 'dummy_link1', 'i0', 'base_link',
+                             loop=True)
+            assembly.disconnect('i0', 'base_link', 'i2', 'dummy_link1')
+        self.assertEqual(len(assembly.connections), 2)
+        self.assertFalse(any(c.loop for c in assembly.connections))
+
+    def test_remove_module_instance_drops_its_connections(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._chain(tmp)
+            assembly.remove_module_instance('i1')
+        self.assertEqual(sorted(assembly.instances), ['i0', 'i2'])
+        self.assertEqual(assembly.connections, [])
+        # removing a non-root instance left the root untouched
+        self.assertEqual((assembly.root_instance, assembly.root_port),
+                         ('i0', 'base_link'))
+        # removing the root falls back to the first remaining instance
+        assembly.remove_module_instance('i0')
+        self.assertEqual(assembly.root_instance, 'i2')
+        assembly.remove_module_instance('i2')
+        self.assertIsNone(assembly.root_instance)
+        with self.assertRaises(ValueError):
+            assembly.remove_module_instance('i2')
+
+    def test_embed_round_trips_without_source_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._chain(tmp)
+            reference = ET.parse(assembly.build(
+                output_path=os.path.join(tmp, 'ref.urdf'))).getroot()
+            data = assembly.to_dict(embed=True)
+        # the source directory is gone -- only the embedded content
+        # remains, and building from it still works
+        rebuilt = RobotAssembly.from_dict(data)
+        with tempfile.TemporaryDirectory() as out:
+            built = ET.parse(rebuilt.build(
+                output_path=os.path.join(out, 'x.urdf'))).getroot()
+        for tag in ('link', 'joint'):
+            self.assertEqual(
+                {el.get('name') for el in reference.findall(tag)},
+                {el.get('name') for el in built.findall(tag)})
+
+    def test_embed_requires_readable_module_file(self):
+        module = RobotModule.from_urdf_string(
+            'm', _MODULE_URDF.format(name='m'))
+        assembly = RobotAssembly('combo')
+        assembly.add_module_instance('a1', module)
+        with self.assertRaisesRegex(ValueError, 'not a readable file'):
+            assembly.to_dict(embed=True)
+
+    def test_embed_survives_pathological_instance_ids(self):
+        # instance ids are arbitrary strings and must never name the
+        # materialized module files
+        with tempfile.TemporaryDirectory() as tmp:
+            module = RobotModule.from_urdf('m', _write_module(tmp, 'm'))
+            assembly = RobotAssembly('combo')
+            assembly.add_module_instance('../escape', module)
+            data = assembly.to_dict(embed=True)
+        rebuilt = RobotAssembly.from_dict(data)
+        self.assertEqual(sorted(rebuilt.instances), ['../escape'])
+
+    def test_from_dict_accepts_root_dict_form(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = self._chain(tmp)
+            data = assembly.to_dict()
+            del data['root_instance']
+            del data['root_port']
+            rebuilt = RobotAssembly.from_dict(data)
+        self.assertEqual((rebuilt.root_instance, rebuilt.root_port),
+                         ('i0', 'base_link'))
+
+
 _GROUND3_URDF = """<?xml version="1.0"?>
 <robot name="ground3">
   <link name="base_link"/>

--- a/tests/skrobot_tests/assembly_tests/test_module_assembly.py
+++ b/tests/skrobot_tests/assembly_tests/test_module_assembly.py
@@ -431,6 +431,181 @@ _GROUND_URDF = """<?xml version="1.0"?>
 """
 
 
+_PLATE_URDF = """<?xml version="1.0"?>
+<robot name="plate">
+  <link name="base_link"/>
+  <link name="tip"/>
+  <joint name="ext" type="fixed">
+    <parent link="base_link"/><child link="tip"/>
+    <origin xyz="{tip_xyz}" rpy="0 0 0"/>
+  </joint>
+</robot>
+"""
+
+
+class TestMovableConnections(unittest.TestCase):
+    """connect(joint_type=...) turns the mated port pair into a joint."""
+
+    @staticmethod
+    def _plate(tmp, name, tip_xyz):
+        path = os.path.join(tmp, name + '.urdf')
+        with open(path, 'w') as f:
+            f.write(_PLATE_URDF.format(tip_xyz=tip_xyz))
+        return RobotModule.from_urdf(name, path)
+
+    def test_revolute_connection_articulates(self):
+        import numpy as np
+        with tempfile.TemporaryDirectory() as tmp:
+            base = self._plate(tmp, 'base', '0.1 0 0')
+            arm = self._plate(tmp, 'arm', '0.1 0 0')
+            assembly = RobotAssembly('linkage')
+            assembly.add_module_instance('b', base)
+            assembly.add_module_instance('a', arm)
+            assembly.connect('b', 'tip', 'a', 'base_link',
+                             joint_type='revolute',
+                             lower=-2.0, upper=2.0)
+            assembly.set_root('b', 'base_link')
+            root = ET.parse(assembly.build(
+                output_path=os.path.join(tmp, 'x.urdf'))).getroot()
+            joint = next(j for j in root.findall('joint')
+                         if j.get('name') == 'b_tip_to_a_base_link_joint')
+            self.assertEqual(joint.get('type'), 'revolute')
+            self.assertEqual(joint.find('axis').get('xyz'), '0.0 0.0 1.0')
+            limit = joint.find('limit')
+            self.assertEqual((limit.get('lower'), limit.get('upper')),
+                             ('-2.0', '2.0'))
+            robot = assembly.build_robot_model()
+        robot.b_tip_to_a_base_link_joint.joint_angle(np.pi / 2)
+        # the arm tip swings from +X to +Y around the port Z axis
+        np.testing.assert_allclose(robot.a_tip.worldpos(),
+                                   [0.1, 0.1, 0.0], atol=1e-12)
+
+    def test_four_bar_from_bare_links(self):
+        import yaml
+        with tempfile.TemporaryDirectory() as tmp:
+            ground = self._write_ground(tmp)
+            crank = self._plate(tmp, 'crank', '0 0.1 0')
+            crank2 = self._plate(tmp, 'crank2', '0 0.1 0')
+            coupler = self._plate(tmp, 'coupler', '0.2 0 0')
+            assembly = RobotAssembly('fourbar')
+            assembly.add_module_instance('g', ground)
+            assembly.add_module_instance('b1', crank)
+            assembly.add_module_instance('b2', crank2)
+            assembly.add_module_instance('cp', coupler)
+            hinge = {'joint_type': 'revolute', 'lower': -3.0, 'upper': 3.0}
+            assembly.connect('g', 'g1', 'b1', 'base_link', **hinge)
+            assembly.connect('g', 'g2', 'b2', 'base_link', **hinge)
+            assembly.connect('b1', 'tip', 'cp', 'base_link', **hinge)
+            assembly.connect('cp', 'tip', 'b2', 'tip', loop=True)
+            assembly.set_root('g', 'base_link')
+            root = ET.parse(assembly.build(
+                output_path=os.path.join(tmp, 'fourbar.urdf'))).getroot()
+            with open(os.path.join(tmp, 'loop_closures.yaml')) as f:
+                config = yaml.safe_load(f)
+        # the loop machinery treats connection joints as ring members:
+        # no module-internal joint exists anywhere in this assembly
+        driver = 'g_g1_to_b1_base_link_joint'
+        self.assertEqual(config['independent'], [driver])
+        mimics = {j.get('name'): j.find('mimic')
+                  for j in root.findall('joint')
+                  if j.find('mimic') is not None}
+        expected = {'b1_tip_to_cp_base_link_joint': -1.0,
+                    'g_g2_to_b2_base_link_joint': 1.0}
+        self.assertEqual(sorted(mimics), sorted(expected))
+        for name, multiplier in expected.items():
+            self.assertEqual(mimics[name].get('joint'), driver)
+            self.assertAlmostEqual(
+                float(mimics[name].get('multiplier')), multiplier)
+
+    @staticmethod
+    def _write_ground(tmp):
+        path = os.path.join(tmp, 'ground.urdf')
+        with open(path, 'w') as f:
+            f.write(_GROUND_URDF.format(g2_xyz='0.2 0 0'))
+        return RobotModule.from_urdf('ground', path)
+
+    def test_reversed_movable_edge_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = self._plate(tmp, 'base', '0.1 0 0')
+            arm = self._plate(tmp, 'arm', '0.1 0 0')
+            assembly = RobotAssembly('linkage')
+            assembly.add_module_instance('b', base)
+            assembly.add_module_instance('a', arm)
+            # declared child-side first: rooting at 'b' traverses it in
+            # reverse, which cannot keep a movable joint's frame
+            assembly.connect('a', 'base_link', 'b', 'tip',
+                             joint_type='revolute',
+                             lower=-1.5, upper=1.5)
+            assembly.set_root('b', 'base_link')
+            with self.assertRaisesRegex(ValueError, 'reverse'):
+                assembly.build(output_path=os.path.join(tmp, 'x.urdf'))
+
+    def test_movable_connection_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = self._plate(tmp, 'base', '0.1 0 0')
+            arm = self._plate(tmp, 'arm', '0.1 0 0')
+        assembly = RobotAssembly('linkage')
+        assembly.add_module_instance('b', base)
+        assembly.add_module_instance('a', arm)
+        with self.assertRaisesRegex(ValueError, 'lower and upper'):
+            assembly.connect('b', 'tip', 'a', 'base_link',
+                             joint_type='revolute')
+        with self.assertRaisesRegex(ValueError, 'unknown joint_type'):
+            assembly.connect('b', 'tip', 'a', 'base_link',
+                             joint_type='floating')
+        with self.assertRaisesRegex(ValueError, 'do not apply'):
+            assembly.connect('b', 'tip', 'a', 'base_link', lower=-1.0,
+                             upper=1.0)
+        with self.assertRaisesRegex(ValueError, 'do not apply'):
+            # continuous would silently drop the bounds -- refuse instead
+            assembly.connect('b', 'tip', 'a', 'base_link',
+                             joint_type='continuous', lower=-1.0,
+                             upper=1.0)
+        with self.assertRaisesRegex(ValueError, 'nonzero finite'):
+            assembly.connect('b', 'tip', 'a', 'base_link',
+                             joint_type='continuous', axis=(0.0, 0.0, 0.0))
+        with self.assertRaisesRegex(ValueError, 'cut hinge'):
+            assembly.connect('b', 'tip', 'a', 'base_link', loop=True,
+                             joint_type='continuous')
+
+    def test_movable_connection_with_attach_port(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = self._plate(tmp, 'base', '0.1 0 0')
+            arm = self._plate(tmp, 'arm', '0.1 0 0')
+            assembly = RobotAssembly('linkage')
+            assembly.add_module_instance('b', base)
+            assembly.add_module_instance('a', arm)
+            # re-rooted at the declared port: the joint's child link is
+            # the port itself, and the axis hinges about the port frame
+            assembly.connect('b', 'tip', 'a', 'tip', attach='port',
+                             joint_type='revolute', lower=-2.0, upper=2.0)
+            assembly.set_root('b', 'base_link')
+            root = ET.parse(assembly.build(
+                output_path=os.path.join(tmp, 'x.urdf'))).getroot()
+        joint = next(j for j in root.findall('joint')
+                     if j.get('name') == 'b_tip_to_a_tip_joint')
+        self.assertEqual(joint.get('type'), 'revolute')
+        self.assertEqual(joint.find('child').get('link'), 'a_tip')
+
+    def test_joint_type_round_trips_through_dict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = self._plate(tmp, 'base', '0.1 0 0')
+            arm = self._plate(tmp, 'arm', '0.1 0 0')
+            assembly = RobotAssembly('linkage')
+            assembly.add_module_instance('b', base)
+            assembly.add_module_instance('a', arm)
+            assembly.connect('b', 'tip', 'a', 'base_link',
+                             joint_type='prismatic', axis=(1.0, 0.0, 0.0),
+                             lower=-0.05, upper=0.05, effort=10.0,
+                             velocity=0.2)
+            rebuilt = RobotAssembly.from_dict(assembly.to_dict())
+            self.assertEqual(rebuilt.to_dict(), assembly.to_dict())
+        conn = rebuilt.connections[0]
+        self.assertEqual(conn.joint_type, 'prismatic')
+        self.assertEqual(conn.axis, (1.0, 0.0, 0.0))
+        self.assertEqual((conn.lower, conn.upper), (-0.05, 0.05))
+
+
 class TestGraphEditingAndEmbed(unittest.TestCase):
     """disconnect / remove_module_instance / to_dict(embed=True)."""
 

--- a/tests/skrobot_tests/kinematics_tests/test_loop_closure.py
+++ b/tests/skrobot_tests/kinematics_tests/test_loop_closure.py
@@ -1,0 +1,169 @@
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+from skrobot.kinematics import LoopClosureSolver
+from skrobot.urdf import RobotAssembly
+from skrobot.urdf import RobotModule
+
+
+_GROUND_URDF = """<?xml version="1.0"?>
+<robot name="ground">
+  <link name="base_link"/>
+  <link name="g1"/>
+  <link name="g2"/>
+  <joint name="fg1" type="fixed">
+    <parent link="base_link"/><child link="g1"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+  <joint name="fg2" type="fixed">
+    <parent link="base_link"/><child link="g2"/>
+    <origin xyz="{g2_xyz}" rpy="0 0 0"/>
+  </joint>
+</robot>
+"""
+
+_BAR_URDF = """<?xml version="1.0"?>
+<robot name="bar">
+  <link name="base_link"/>
+  <link name="arm"/>
+  <link name="tip"/>
+  <joint name="hinge" type="revolute">
+    <parent link="base_link"/><child link="arm"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.0" upper="3.0" effort="1" velocity="1"/>
+  </joint>
+  <joint name="tipj" type="fixed">
+    <parent link="arm"/><child link="tip"/>
+    <origin xyz="{tip_xyz}" rpy="0 0 0"/>
+  </joint>
+</robot>
+"""
+
+
+def _four_bar(tmp, parallelogram):
+    """Ground + two cranks + coupler, loop-closed at the coupler tip.
+
+    ``parallelogram=False`` shortens the second crank and shifts its
+    ground pivot (still closing at the zero pose), so the coupling is
+    nonlinear and no exact ``<mimic>`` is emitted -- the solver is the
+    only thing that can close it.
+    """
+    def write(name, content):
+        path = os.path.join(tmp, name + '.urdf')
+        with open(path, 'w') as f:
+            f.write(content)
+        return RobotModule.from_urdf(name, path)
+
+    g2_xyz = '0.2 0 0' if parallelogram else '0.2 0.05 0'
+    crank2_tip = '0 0.1 0' if parallelogram else '0 0.05 0'
+    ground = write('ground', _GROUND_URDF.format(g2_xyz=g2_xyz))
+    crank = write('crank', _BAR_URDF.format(tip_xyz='0 0.1 0'))
+    crank2 = write('crank2', _BAR_URDF.format(tip_xyz=crank2_tip))
+    coupler = write('coupler', _BAR_URDF.format(tip_xyz='0.2 0 0'))
+    assembly = RobotAssembly('fourbar')
+    assembly.add_module_instance('g', ground)
+    assembly.add_module_instance('c1', crank)
+    assembly.add_module_instance('c2', crank2)
+    assembly.add_module_instance('cp', coupler)
+    assembly.connect('g', 'g1', 'c1', 'base_link')
+    assembly.connect('g', 'g2', 'c2', 'base_link')
+    assembly.connect('c1', 'tip', 'cp', 'base_link')
+    assembly.connect('cp', 'tip', 'c2', 'tip', loop=True)
+    assembly.set_root('g', 'base_link')
+    return assembly
+
+
+class TestLoopClosureSolver(unittest.TestCase):
+
+    def test_general_four_bar_closes_over_a_sweep(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = _four_bar(tmp, parallelogram=False)
+            robot = assembly.build_robot_model()
+        solver = LoopClosureSolver(robot, assembly.loop_closures)
+        coupler_length = 0.2
+        # this linkage's short crank can follow the driver up to
+        # theta ~ 0.49 rad; sweep inside that reachable arc
+        for angle in np.linspace(0.0, 0.45, 6):
+            robot.c1_hinge.joint_angle(angle)
+            error = solver.solve()
+            self.assertLess(error, 1e-9)
+            # independent invariant: the loop is closed exactly when the
+            # two crank tips stay one coupler length apart
+            span = np.linalg.norm(robot.c1_tip.worldpos()
+                                  - robot.c2_tip.worldpos())
+            self.assertAlmostEqual(span, coupler_length, places=9)
+        # the coupling is nonlinear, so the followers must have moved to
+        # values a linear mimic could not produce
+        self.assertNotAlmostEqual(robot.cp_hinge.joint_angle(), -0.45,
+                                  places=3)
+        self.assertGreater(abs(robot.cp_hinge.joint_angle()), 1e-3)
+
+    def test_parallelogram_agrees_with_injected_mimic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = _four_bar(tmp, parallelogram=True)
+            robot = assembly.build_robot_model()
+        solver = LoopClosureSolver(robot, assembly.loop_closures)
+        robot.c1_hinge.joint_angle(0.4)
+        error = solver.solve()
+        self.assertLess(error, 1e-8)
+        self.assertAlmostEqual(robot.cp_hinge.joint_angle(), -0.4, places=7)
+        self.assertAlmostEqual(robot.c2_hinge.joint_angle(), 0.4, places=7)
+
+    def test_unreachable_driver_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = _four_bar(tmp, parallelogram=False)
+            robot = assembly.build_robot_model()
+        solver = LoopClosureSolver(robot, assembly.loop_closures)
+        # the short crank cannot follow the long one this far around
+        robot.c1_hinge.joint_angle(2.5)
+        with self.assertRaisesRegex(ValueError, 'did not converge'):
+            solver.solve()
+
+    def test_from_yaml_sidecar(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = _four_bar(tmp, parallelogram=False)
+            assembly.build(output_path=os.path.join(tmp, 'fourbar.urdf'))
+            robot = assembly.build_robot_model()
+            solver = LoopClosureSolver.from_yaml(
+                robot, os.path.join(tmp, 'loop_closures.yaml'))
+            robot.c1_hinge.joint_angle(0.3)
+            self.assertLess(solver.solve(), 1e-8)
+
+    def test_failed_solve_does_not_poison_warm_start(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = _four_bar(tmp, parallelogram=False)
+            robot = assembly.build_robot_model()
+        solver = LoopClosureSolver(robot, assembly.loop_closures)
+        robot.c1_hinge.joint_angle(0.3)
+        self.assertLess(solver.solve(), 1e-9)
+        robot.c1_hinge.joint_angle(2.5)
+        with self.assertRaises(ValueError):
+            solver.solve()
+        # the failed target must not have become the warm start: a
+        # reachable target afterwards still solves
+        robot.c1_hinge.joint_angle(0.3)
+        self.assertLess(solver.solve(), 1e-9)
+
+    def test_config_validation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            assembly = _four_bar(tmp, parallelogram=False)
+            robot = assembly.build_robot_model()
+        config = assembly.loop_closures
+        with self.assertRaisesRegex(ValueError, 'no closure config'):
+            LoopClosureSolver(robot, None)
+        with self.assertRaises(ValueError):
+            LoopClosureSolver(robot, {'closures': []})
+        broken = dict(config, dependent=['nope'])
+        with self.assertRaisesRegex(ValueError, 'do not exist'):
+            LoopClosureSolver(robot, broken)
+        solver = LoopClosureSolver(robot, config)
+        with self.assertRaises(ValueError):
+            solver.solve(max_step=0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/skrobot_tests/kinematics_tests/test_loop_closure.py
+++ b/tests/skrobot_tests/kinematics_tests/test_loop_closure.py
@@ -4,9 +4,9 @@ import unittest
 
 import numpy as np
 
+from skrobot.assembly import RobotAssembly
+from skrobot.assembly import RobotModule
 from skrobot.kinematics import LoopClosureSolver
-from skrobot.urdf import RobotAssembly
-from skrobot.urdf import RobotModule
 
 
 _GROUND_URDF = """<?xml version="1.0"?>


### PR DESCRIPTION
Extends `skrobot.assembly` to closed linkages and richer editing:

- `connect(..., loop=True)` declares the cut edge of a closed loop (four-bar, parallel linkage). `build()` writes a `loop_closures.yaml` sidecar describing the closure for runtime IK consumers, and injects exact `<mimic>` tags when the loop is a parallelogram four-bar — certified by forward kinematics before writing. `dependent=` makes the driven/solved split explicit for multi-DOF loops, and existing mimic tags resolve transitively so chained parallelograms stay exact.
- `skrobot.kinematics.LoopClosureSolver` closes general (non-parallelogram) loops on a live `RobotModel` by Gauss-Newton on the cut-hinge witness points (closure error ~1e-16 over driver sweeps).
- `connect(joint_type='revolute'|'continuous'|'prismatic')` turns a connected port pair into an articulation, so linkages can be assembled from bare links; connection joints participate in loop rings like any other joint.
- Assembly editing (`disconnect`, `remove_module_instance`), `to_dict(embed=True)` for file-less round-trips, a docs reference page, and a runnable four-bar example.

Tests: assembly_tests 48 passed, loop-closure solver 6 passed; example verified headless.