### PR TITLE
Add URDF link/joint name sanitizing to skrobot.urdf

### DIFF
--- a/skrobot/urdf/__init__.py
+++ b/skrobot/urdf/__init__.py
@@ -9,6 +9,8 @@ from skrobot.urdf.modularize_urdf import transform_urdf_to_macro
 from skrobot.urdf.primitives_converter import convert_meshes_to_primitives
 from skrobot.urdf.robot_class_generator import generate_groups_from_geometry
 from skrobot.urdf.robot_class_generator import generate_robot_class_from_geometry
+from skrobot.urdf.sanitize import sanitize_name
+from skrobot.urdf.sanitize import sanitize_urdf_names
 from skrobot.urdf.scale_urdf import scale_urdf
 from skrobot.urdf.structure import kinematic_tree
 from skrobot.urdf.structure import print_urdf_tree
@@ -43,4 +45,6 @@ __all__ = [
     'build_grouping_prompt',
     'parse_grouping_response',
     'compute_jaw_gripper_frame',
+    'sanitize_name',
+    'sanitize_urdf_names',
 ]

--- a/skrobot/urdf/sanitize.py
+++ b/skrobot/urdf/sanitize.py
@@ -1,0 +1,104 @@
+"""Sanitize URDF link / joint names.
+
+Downstream tools (xacro, ROS, MoveIt) choke on names carrying hyphens,
+spaces, dots or other punctuation; these helpers rewrite identifiers to the
+safe ``[A-Za-z0-9_]`` alphabet while keeping every cross reference in the
+document consistent.
+"""
+
+import re
+
+
+__all__ = [
+    'sanitize_name',
+    'sanitize_urdf_names',
+]
+
+
+def sanitize_name(raw):
+    """Sanitize one URDF identifier (link / joint name).
+
+    Keeps ``[A-Za-z0-9_]``, collapses every other run of characters to a
+    single ``_``, strips leading/trailing underscores and never lets the
+    result start with a digit (or be empty) by prefixing ``c_``.  Idempotent
+    on names that are already valid.
+
+    Parameters
+    ----------
+    raw : str
+        The identifier to sanitize.
+
+    Returns
+    -------
+    name : str
+        A valid URDF identifier.
+
+    Examples
+    --------
+    >>> from skrobot.urdf.sanitize import sanitize_name
+    >>> sanitize_name('base link (rev.2)')
+    'base_link_rev_2'
+    >>> sanitize_name('42_arm')
+    'c_42_arm'
+    """
+    name = re.sub(r'[^0-9A-Za-z_]+', '_', raw)
+    name = name.strip('_')
+    if not name or name[0].isdigit():
+        name = 'c_' + name
+    return name
+
+
+def sanitize_urdf_names(root):
+    """Sanitize every link / joint name in a parsed URDF, in place.
+
+    Rewrites all ``<link>`` and ``<joint>`` names -- and their cross
+    references (joint ``<parent>``/``<child>`` links, ``<mimic>`` joints and
+    ``<transmission>`` joint entries) -- through :func:`sanitize_name`.  When
+    two distinct dirty names collapse to the same clean one, a numeric suffix
+    keeps them unique.
+
+    A no-op when the names are already clean, so it can be used as a safety
+    net over hand-edited or externally imported URDFs.
+
+    Parameters
+    ----------
+    root : xml.etree.ElementTree.Element or lxml.etree._Element
+        Root ``<robot>`` element; modified in place.
+    """
+    def _remap(elems, attr):
+        mapping = {}
+        used = set()
+        for el in elems:
+            orig = el.get(attr)
+            if orig is None or orig in mapping:
+                continue
+            cand = sanitize_name(orig)
+            i = 1
+            while cand in used:      # two dirty names -> the same clean one
+                i += 1
+                cand = '{}_{}'.format(sanitize_name(orig), i)
+            mapping[orig] = cand
+            used.add(cand)
+        return mapping
+
+    links = root.findall('link')
+    joints = root.findall('joint')
+    link_map = _remap(links, 'name')
+    joint_map = _remap(joints, 'name')
+    for link in links:
+        if link.get('name') in link_map:
+            link.set('name', link_map[link.get('name')])
+    for joint in joints:
+        if joint.get('name') in joint_map:
+            joint.set('name', joint_map[joint.get('name')])
+        for tag in ('parent', 'child'):
+            el = joint.find(tag)
+            if el is not None and el.get('link') in link_map:
+                el.set('link', link_map[el.get('link')])
+        mimic = joint.find('mimic')
+        if mimic is not None and mimic.get('joint') in joint_map:
+            mimic.set('joint', joint_map[mimic.get('joint')])
+    for transmission in root.findall('transmission'):
+        for el in transmission.findall('joint'):
+            if el.get('name') in joint_map:
+                el.set('name', joint_map[el.get('name')])

--- a/tests/skrobot_tests/urdf_tests/test_sanitize.py
+++ b/tests/skrobot_tests/urdf_tests/test_sanitize.py
@@ -1,0 +1,81 @@
+import unittest
+import xml.etree.ElementTree as ET
+
+from skrobot.urdf import sanitize_name
+from skrobot.urdf import sanitize_urdf_names
+
+
+class TestSanitizeName(unittest.TestCase):
+
+    def test_punctuation_collapses_to_underscore(self):
+        self.assertEqual(sanitize_name('base link (rev.2)'), 'base_link_rev_2')
+        self.assertEqual(sanitize_name('arm-upper/left'), 'arm_upper_left')
+
+    def test_leading_digit_and_empty(self):
+        self.assertEqual(sanitize_name('42_arm'), 'c_42_arm')
+        self.assertEqual(sanitize_name('---'), 'c_')
+
+    def test_idempotent_on_valid_names(self):
+        for name in ('base_link', 'joint_1', 'c_42'):
+            self.assertEqual(sanitize_name(name), name)
+
+
+class TestSanitizeUrdfNames(unittest.TestCase):
+
+    def test_names_and_cross_references(self):
+        root = ET.fromstring("""
+<robot name="r">
+  <link name="base link"/>
+  <link name="arm-1"/>
+  <joint name="shoulder joint" type="revolute">
+    <parent link="base link"/>
+    <child link="arm-1"/>
+  </joint>
+  <joint name="follower" type="revolute">
+    <parent link="base link"/>
+    <child link="arm-1"/>
+    <mimic joint="shoulder joint" multiplier="2"/>
+  </joint>
+  <transmission name="tr1">
+    <joint name="shoulder joint"><hardwareInterface>EffortJointInterface</hardwareInterface></joint>
+  </transmission>
+</robot>
+""")
+        sanitize_urdf_names(root)
+        link_names = [link.get('name') for link in root.findall('link')]
+        self.assertEqual(link_names, ['base_link', 'arm_1'])
+        joint = root.find('joint')
+        self.assertEqual(joint.get('name'), 'shoulder_joint')
+        self.assertEqual(joint.find('parent').get('link'), 'base_link')
+        self.assertEqual(joint.find('child').get('link'), 'arm_1')
+        mimic = root.findall('joint')[1].find('mimic')
+        self.assertEqual(mimic.get('joint'), 'shoulder_joint')
+        transmission_joint = root.find('transmission').find('joint')
+        self.assertEqual(transmission_joint.get('name'), 'shoulder_joint')
+
+    def test_colliding_dirty_names_stay_unique(self):
+        root = ET.fromstring("""
+<robot name="r">
+  <link name="arm 1"/>
+  <link name="arm-1"/>
+  <link name="arm_1"/>
+</robot>
+""")
+        sanitize_urdf_names(root)
+        names = sorted(link.get('name') for link in root.findall('link'))
+        self.assertEqual(len(set(names)), 3)
+        self.assertIn('arm_1', names)
+
+    def test_clean_document_is_untouched(self):
+        xml = ('<robot name="r"><link name="base_link"/>'
+               '<joint name="j1" type="fixed">'
+               '<parent link="base_link"/><child link="base_link"/>'
+               '</joint></robot>')
+        root = ET.fromstring(xml)
+        sanitize_urdf_names(root)
+        self.assertEqual(root.find('link').get('name'), 'base_link')
+        self.assertEqual(root.find('joint').get('name'), 'j1')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`sanitize_name` maps one identifier to the `[A-Za-z0-9_]` alphabet (idempotent on valid names); `sanitize_urdf_names` rewrites a parsed URDF's link/joint names in place, keeping parent/child/mimic cross references consistent and de-duplicating collisions.

Tests: urdf_tests green (incl. 8 new sanitize tests); ruff / flake8 / typos green.