### PR TITLE
Add mesh-based URDF link inertial computation to skrobot.utils

### DIFF
--- a/skrobot/utils/__init__.py
+++ b/skrobot/utils/__init__.py
@@ -19,5 +19,11 @@ from skrobot.utils.blender_mesh import remesh_with_blender
 from skrobot.utils.convex_decomposition import convex_decomposition
 from skrobot.utils.convex_decomposition import is_coacd_available
 
+from skrobot.utils.inertia import link_inertial_from_mesh
+from skrobot.utils.inertia import mesh_mass_properties
+from skrobot.utils.inertia import rescale_inertial_to_mass
+from skrobot.utils.inertia import transform_inertial
+from skrobot.utils.inertia import validate_inertia
+
 from skrobot.utils.primitive_fitting import fit_primitive_to_mesh
 from skrobot.utils.primitive_fitting import primitive_params_to_origin

--- a/skrobot/utils/inertia.py
+++ b/skrobot/utils/inertia.py
@@ -1,0 +1,287 @@
+"""Compute URDF link inertials (mass, centre of mass, inertia tensor) from
+meshes, so a generated URDF carries real dynamics instead of placeholders.
+
+The mesh is treated as a uniform-density solid.  Many meshes are NOT
+watertight, which makes trimesh's volume integral unreliable; the mass
+properties therefore fall back to the convex hull (always watertight, a mild
+over-estimate) and, failing that, the oriented bounding box -- and the used
+``method`` is reported instead of silently emitting wrong numbers.
+"""
+
+from logging import getLogger
+import os
+
+import numpy as np
+
+from skrobot._lazy_imports import _lazy_trimesh
+from skrobot.coordinates.math import rpy2matrix
+
+
+logger = getLogger(__name__)
+
+
+__all__ = [
+    'DEFAULT_DENSITY',
+    'mesh_mass_properties',
+    'transform_inertial',
+    'link_inertial_from_mesh',
+    'rescale_inertial_to_mass',
+    'validate_inertia',
+]
+
+
+DEFAULT_DENSITY = 1000.0  # kg/m^3 (water) -- generic light part
+
+
+def _solid_properties(mesh, density):
+    """(mass, com(3,), I 3x3 about the com) for ``mesh`` as a solid of
+    ``density``, or None if the mesh has no usable volume."""
+    if mesh is None or not hasattr(mesh, 'vertices') or len(mesh.vertices) == 0:
+        return None
+    volume = float(getattr(mesh, 'volume', 0.0) or 0.0)
+    if not np.isfinite(volume) or volume <= 0:
+        return None
+    mesh.density = float(density)
+    mass = float(mesh.mass)
+    com = np.asarray(mesh.center_mass, dtype=float)
+    inertia = np.asarray(mesh.moment_inertia, dtype=float)
+    if not (np.isfinite(mass) and mass > 0 and np.all(np.isfinite(com))
+            and np.all(np.isfinite(inertia))):
+        return None
+    return mass, com, inertia
+
+
+_PROPS_CACHE = {}
+
+
+def mesh_mass_properties(mesh_path, density=DEFAULT_DENSITY, scale=1.0):
+    """Mass properties of a mesh file treated as a uniform-density solid.
+
+    Non-watertight meshes fall back to the convex hull and then to the
+    oriented bounding box.  Results are cached by
+    ``(path, mtime, density, scale)``: loading plus the watertight checks
+    dominate the cost and the result is pose independent, so repeated
+    calls for an unchanged file are effectively free.
+
+    Parameters
+    ----------
+    mesh_path : str
+        Path to the mesh (any format trimesh can load).
+    density : float
+        Material density in kg/m^3.
+    scale : float
+        Mesh-unit to metre factor (e.g. 0.001 for millimetre meshes).
+
+    Returns
+    -------
+    props : tuple or None
+        ``(mass, com, inertia, method)`` where ``com`` has shape (3,),
+        ``inertia`` is the 3x3 tensor about the centre of mass (both in
+        scaled mesh coordinates) and ``method`` is ``'mesh'``, ``'hull'``
+        or ``'bbox'``.  None if no usable geometry was found.
+    """
+    try:
+        key = (os.path.abspath(mesh_path), os.path.getmtime(mesh_path),
+               float(density), float(scale))
+    except OSError:
+        return None
+    if key in _PROPS_CACHE:
+        return _PROPS_CACHE[key]
+    result = None
+    try:
+        trimesh = _lazy_trimesh()
+        mesh = trimesh.load(mesh_path, force='mesh')
+        if mesh is not None and hasattr(mesh, 'vertices') \
+                and len(mesh.vertices):
+            mesh = mesh.copy()
+            mesh.apply_scale(scale)
+            method = 'mesh'
+            props = _solid_properties(mesh, density) \
+                if mesh.is_watertight else None
+            if props is None:
+                method = 'hull'
+                try:
+                    props = _solid_properties(mesh.convex_hull, density)
+                except Exception:
+                    props = None
+            if props is None:
+                method = 'bbox'
+                try:
+                    props = _solid_properties(mesh.bounding_box_oriented,
+                                              density)
+                except Exception:
+                    props = None
+            if props is not None:
+                mass, com, inertia = props
+                result = (mass, com, inertia, method)
+    except Exception as e:  # noqa: BLE001
+        logger.debug('mass properties failed for %s (%s)', mesh_path, e)
+        result = None
+    _PROPS_CACHE[key] = result
+    return result
+
+
+def transform_inertial(mass, com, inertia, visual_xyz, visual_rpy,
+                       method='given'):
+    """Express mass properties given in a visual/mesh frame in the link frame.
+
+    The rotation rotates the tensor (taken about the centre of mass, so the
+    translation does not enter it) and the translation moves the centre of
+    mass -- exactly the mapping a URDF ``<visual><origin>`` defines.
+
+    Parameters
+    ----------
+    mass : float
+        Mass in kg.
+    com : sequence of 3 floats
+        Centre of mass in the source frame.
+    inertia : numpy.ndarray or sequence of 6 floats
+        Either the 3x3 tensor about the com, or the 6 components
+        ``(ixx, ixy, ixz, iyy, iyz, izz)``.
+    visual_xyz, visual_rpy : sequence of 3 floats
+        The URDF origin mapping the source frame into the link frame.
+    method : str
+        Provenance tag carried through to the result.
+
+    Returns
+    -------
+    info : dict or None
+        ``{'mass', 'com', 'inertia', 'method'}`` with ``inertia`` as the
+        6 components in the link frame, or None if the inputs are missing
+        or non-finite.
+    """
+    if mass is None or com is None or inertia is None:
+        return None
+    try:
+        mass = float(mass)
+        com = np.asarray(com, dtype=float)
+        inertia = np.asarray(inertia, dtype=float)
+        if inertia.shape == (6,):
+            ixx, ixy, ixz, iyy, iyz, izz = inertia
+            inertia = np.array([[ixx, ixy, ixz],
+                                [ixy, iyy, iyz],
+                                [ixz, iyz, izz]], dtype=float)
+    except (TypeError, ValueError):
+        return None
+    if not (np.isfinite(mass) and mass > 0 and com.shape == (3,)
+            and np.all(np.isfinite(com)) and inertia.shape == (3, 3)
+            and np.all(np.isfinite(inertia))):
+        return None
+    roll, pitch, yaw = visual_rpy
+    rot = rpy2matrix(float(roll), float(pitch), float(yaw))
+    com_link = rot @ com + np.asarray(visual_xyz, dtype=float)
+    tensor = rot @ inertia @ rot.T
+    return {
+        'mass': mass,
+        'com': [float(c) for c in com_link],
+        'inertia': (float(tensor[0, 0]), float(tensor[0, 1]),
+                    float(tensor[0, 2]), float(tensor[1, 1]),
+                    float(tensor[1, 2]), float(tensor[2, 2])),
+        'method': method,
+    }
+
+
+def link_inertial_from_mesh(mesh_path, visual_xyz, visual_rpy,
+                            density=DEFAULT_DENSITY, scale=1.0):
+    """URDF link inertial computed from a mesh, expressed in the link frame.
+
+    Parameters
+    ----------
+    mesh_path : str or None
+        Path to the link's mesh (any format trimesh can load).
+    visual_xyz, visual_rpy : sequence of 3 floats
+        The link's visual origin (mesh to link), in metres / radians.
+    density : float
+        Material density in kg/m^3.
+    scale : float
+        Mesh-unit to metre factor (e.g. 0.001 for millimetre meshes).
+
+    Returns
+    -------
+    info : dict or None
+        ``{'mass', 'com', 'inertia', 'method'}`` where ``inertia`` is
+        ``(ixx, ixy, ixz, iyy, iyz, izz)`` and ``method`` is ``'mesh'``,
+        ``'hull'`` or ``'bbox'``.  None if no usable geometry was found
+        (the caller should keep a placeholder).
+    """
+    if not mesh_path:
+        return None
+    props = mesh_mass_properties(mesh_path, density=density, scale=scale)
+    if props is None:
+        return None
+    mass, com, inertia, method = props
+    return transform_inertial(mass, com, inertia, visual_xyz, visual_rpy,
+                              method=method)
+
+
+def rescale_inertial_to_mass(info, target_mass):
+    """Rescale a computed inertial dict to an exact target mass (kg).
+
+    For a rigid body of fixed geometry, changing the (uniform) density scales
+    the mass and the full inertia tensor by the SAME factor while the centre
+    of mass is unchanged, so ``mass`` and all six inertia components are
+    multiplied by ``target_mass / mass`` and ``com`` is kept.  ``method`` is
+    annotated with ``'->mass'`` so provenance reporting shows the rescale.
+
+    Returns a new dict (does not mutate ``info``).  If ``info`` is falsy or
+    its mass is non-positive or non-finite, returns ``info`` unchanged.
+    """
+    if not info:
+        return info
+    try:
+        mass = float(info['mass'])
+        target = float(target_mass)
+    except (TypeError, ValueError, KeyError):
+        return info
+    if not (np.isfinite(mass) and mass > 0
+            and np.isfinite(target) and target > 0):
+        return info
+    factor = target / mass
+    return {
+        'mass': target,
+        'com': list(info['com']),
+        'inertia': tuple(float(x) * factor for x in info['inertia']),
+        'method': '{}->mass'.format(info.get('method', '?')),
+    }
+
+
+def validate_inertia(mass, inertia6, rel_tol=1e-6):
+    """Physics sanity-check one link's inertial; return a list of problem
+    strings (empty list means OK).
+
+    A real rigid body's inertia tensor (taken about the centre of mass) must
+    be symmetric positive definite -- all principal moments (eigenvalues
+    ``I1 <= I2 <= I3``) strictly positive -- and those moments must satisfy
+    the triangle inequality ``I1 + I2 >= I3`` (the geometric constraint every
+    physical mass distribution obeys; the other two combinations follow once
+    all are positive).  Violating either makes a simulator's integrator
+    diverge, and usually signals a units / frame / transform bug upstream.
+
+    ``rel_tol`` is applied relative to the largest principal moment so
+    ordinary floating-point / tessellation noise does not trip the checks.
+    """
+    problems = []
+    if mass is None or not np.isfinite(mass) or mass <= 0:
+        problems.append('mass is not positive (= {})'.format(mass))
+    try:
+        ixx, ixy, ixz, iyy, iyz, izz = (float(x) for x in inertia6)
+    except (TypeError, ValueError):
+        problems.append('inertia is not a 6-tuple (ixx,ixy,ixz,iyy,iyz,izz)')
+        return problems
+    tensor = np.array([[ixx, ixy, ixz],
+                       [ixy, iyy, iyz],
+                       [ixz, iyz, izz]], dtype=float)
+    if not np.all(np.isfinite(tensor)):
+        problems.append('inertia tensor has non-finite entries')
+        return problems
+    e = np.linalg.eigvalsh(tensor)            # ascending, real (symmetric)
+    atol = rel_tol * max(abs(float(e[-1])), 1e-12)
+    if e[0] <= atol:
+        problems.append(
+            'inertia tensor is not positive definite '
+            '(smallest principal moment {:.4g} <= 0)'.format(e[0]))
+    elif e[0] + e[1] < e[2] - atol:           # triangle inequality
+        problems.append(
+            'principal moments violate the triangle inequality '
+            '(I1+I2 < I3: {:.4g} + {:.4g} < {:.4g})'.format(e[0], e[1], e[2]))
+    return problems

--- a/tests/skrobot_tests/utils_tests/test_inertia.py
+++ b/tests/skrobot_tests/utils_tests/test_inertia.py
@@ -1,0 +1,154 @@
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import trimesh
+
+from skrobot.coordinates.math import rpy2matrix
+from skrobot.utils.inertia import link_inertial_from_mesh
+from skrobot.utils.inertia import mesh_mass_properties
+from skrobot.utils.inertia import rescale_inertial_to_mass
+from skrobot.utils.inertia import transform_inertial
+from skrobot.utils.inertia import validate_inertia
+
+
+def _box_mesh_file(directory, extents=(0.2, 0.1, 0.05)):
+    mesh = trimesh.creation.box(extents=extents)
+    path = os.path.join(directory, 'box.stl')
+    mesh.export(path)
+    return path, mesh
+
+
+class TestMeshMassProperties(unittest.TestCase):
+
+    def test_watertight_box_matches_analytic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path, _ = _box_mesh_file(tmp, extents=(0.2, 0.1, 0.05))
+            props = mesh_mass_properties(path, density=1000.0)
+            self.assertIsNotNone(props)
+            mass, com, inertia, method = props
+            self.assertEqual(method, 'mesh')
+            volume = 0.2 * 0.1 * 0.05
+            self.assertAlmostEqual(mass, 1000.0 * volume, places=6)
+            np.testing.assert_allclose(com, np.zeros(3), atol=1e-9)
+            # analytic solid box: I_xx = m (b^2 + c^2) / 12 etc.
+            m = 1000.0 * volume
+            expected = np.diag([
+                m * (0.1 ** 2 + 0.05 ** 2) / 12.0,
+                m * (0.2 ** 2 + 0.05 ** 2) / 12.0,
+                m * (0.2 ** 2 + 0.1 ** 2) / 12.0,
+            ])
+            np.testing.assert_allclose(inertia, expected, rtol=1e-6,
+                                       atol=1e-12)
+
+    def test_non_watertight_falls_back_to_hull(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mesh = trimesh.creation.box(extents=(0.1, 0.1, 0.1))
+            # drop one face -> not watertight
+            mesh = trimesh.Trimesh(vertices=mesh.vertices,
+                                   faces=mesh.faces[:-1],
+                                   process=False)
+            self.assertFalse(mesh.is_watertight)
+            path = os.path.join(tmp, 'open_box.stl')
+            mesh.export(path)
+            props = mesh_mass_properties(path, density=1000.0)
+            self.assertIsNotNone(props)
+            self.assertEqual(props[3], 'hull')
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(mesh_mass_properties('/nonexistent/mesh.stl'))
+
+
+class TestTransformInertial(unittest.TestCase):
+
+    def test_translation_moves_com_only(self):
+        inertia = np.diag([1.0, 2.0, 3.0])
+        info = transform_inertial(2.0, [0.0, 0.0, 0.0], inertia,
+                                  [0.5, -0.25, 1.0], [0.0, 0.0, 0.0])
+        np.testing.assert_allclose(info['com'], [0.5, -0.25, 1.0])
+        np.testing.assert_allclose(info['inertia'],
+                                   (1.0, 0.0, 0.0, 2.0, 0.0, 3.0),
+                                   atol=1e-12)
+
+    def test_rotation_rotates_tensor(self):
+        # 90 deg about Z swaps the x and y principal moments
+        inertia = np.diag([1.0, 2.0, 3.0])
+        info = transform_inertial(1.0, [0.0, 0.0, 0.0], inertia,
+                                  [0.0, 0.0, 0.0], [0.0, 0.0, np.pi / 2])
+        ixx, ixy, ixz, iyy, iyz, izz = info['inertia']
+        self.assertAlmostEqual(ixx, 2.0)
+        self.assertAlmostEqual(iyy, 1.0)
+        self.assertAlmostEqual(izz, 3.0)
+
+    def test_accepts_6_components(self):
+        info = transform_inertial(1.0, [0, 0, 0],
+                                  (1.0, 0.0, 0.0, 2.0, 0.0, 3.0),
+                                  [0, 0, 0], [0, 0, 0])
+        np.testing.assert_allclose(info['inertia'],
+                                   (1.0, 0.0, 0.0, 2.0, 0.0, 3.0))
+
+    def test_invalid_returns_none(self):
+        self.assertIsNone(transform_inertial(None, [0, 0, 0],
+                                             np.eye(3), [0, 0, 0], [0, 0, 0]))
+        self.assertIsNone(transform_inertial(-1.0, [0, 0, 0],
+                                             np.eye(3), [0, 0, 0], [0, 0, 0]))
+
+
+class TestLinkInertialFromMesh(unittest.TestCase):
+
+    def test_visual_origin_is_applied(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path, _ = _box_mesh_file(tmp)
+            xyz = [0.1, 0.2, 0.3]
+            rpy = [0.3, -0.2, 0.5]
+            info = link_inertial_from_mesh(path, xyz, rpy, density=500.0)
+            self.assertEqual(info['method'], 'mesh')
+            # box com is at the mesh origin -> link-frame com equals xyz
+            np.testing.assert_allclose(info['com'], xyz, atol=1e-9)
+            # tensor must stay physically valid under the rotation
+            self.assertEqual(validate_inertia(info['mass'],
+                                              info['inertia']), [])
+            # and equal the rotated diagonal tensor
+            props = mesh_mass_properties(path, density=500.0)
+            rot = rpy2matrix(*rpy)
+            expected = rot @ props[2] @ rot.T
+            got = info['inertia']
+            np.testing.assert_allclose(
+                [got[0], got[3], got[5]],
+                [expected[0, 0], expected[1, 1], expected[2, 2]],
+                rtol=1e-9)
+
+    def test_none_path_returns_none(self):
+        self.assertIsNone(link_inertial_from_mesh(None, [0, 0, 0], [0, 0, 0]))
+
+
+class TestRescaleAndValidate(unittest.TestCase):
+
+    def test_rescale(self):
+        info = {'mass': 2.0, 'com': [1.0, 2.0, 3.0],
+                'inertia': (1.0, 0.0, 0.0, 2.0, 0.0, 3.0), 'method': 'mesh'}
+        out = rescale_inertial_to_mass(info, 4.0)
+        self.assertEqual(out['mass'], 4.0)
+        self.assertEqual(out['com'], [1.0, 2.0, 3.0])
+        np.testing.assert_allclose(out['inertia'],
+                                   (2.0, 0.0, 0.0, 4.0, 0.0, 6.0))
+        self.assertEqual(out['method'], 'mesh->mass')
+        # invalid target leaves input unchanged
+        self.assertIs(rescale_inertial_to_mass(info, -1.0), info)
+
+    def test_validate(self):
+        self.assertEqual(
+            validate_inertia(1.0, (1.0, 0.0, 0.0, 1.0, 0.0, 1.0)), [])
+        self.assertTrue(
+            validate_inertia(-1.0, (1.0, 0.0, 0.0, 1.0, 0.0, 1.0)))
+        # triangle inequality violation: I1 + I2 < I3
+        problems = validate_inertia(1.0, (1.0, 0.0, 0.0, 1.0, 0.0, 3.0))
+        self.assertTrue(any('triangle' in p for p in problems))
+        # not positive definite
+        problems = validate_inertia(1.0, (-1.0, 0.0, 0.0, 1.0, 0.0, 1.0))
+        self.assertTrue(any('positive definite' in p for p in problems))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds `skrobot.utils.inertia`: `mesh_mass_properties` (uniform-density solid with hull/bbox fallbacks for non-watertight meshes, cached by file), `transform_inertial` / `link_inertial_from_mesh` (visual-origin mapping into the link frame), `rescale_inertial_to_mass`, and `validate_inertia` (positive-definiteness + triangle-inequality checks).

Tests: unit tests against analytic box inertia; utils_tests green; ruff / flake8 / typos green.