### PR TITLE
Fix quaternion_slerp raising on identical quaternions

### DIFF
--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -2415,7 +2415,7 @@ def quaternion_slerp(q0, q1, fraction, spin=0, shortestpath=True):
     elif fraction == 1.0:
         return q1
     d = np.dot(q0, q1)
-    if abs(abs(d) - 1.0) < 0.0:
+    if abs(abs(d) - 1.0) < _EPS:
         return q0
     if shortestpath and d < 0.0:
         # invert rotation

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -643,6 +643,16 @@ class TestMath(unittest.TestCase):
         testing.assert_almost_equal(math.acos(-np.dot(q0, q1)) / angle,
                                     2.0)
 
+    def test_quaternion_slerp_identical(self):
+        # dot(q, q) lands 1 ulp above 1.0 after normalization for many
+        # quaternions, which used to reach math.acos and raise.
+        rs = np.random.RandomState(0)
+        for _ in range(100):
+            q = random_quaternion()
+            for spin in (0, 1, -1):
+                out = quaternion_slerp(q, q.copy(), rs.rand(), spin=spin)
+                testing.assert_almost_equal(out, q)
+
     def test_quaternion_distance(self):
         q1 = rpy2quaternion([0, 0, 0])
         q2 = rpy2quaternion([0, 0, 0])


### PR DESCRIPTION
The early-out guard compares against `0.0`:

```python
if abs(abs(d) - 1.0) < 0.0:
    return q0
```

`abs(x) < 0.0` is never true, so the guard is dead. `normalize_vector` leaves
`dot(q, q)` one ulp above 1.0 for many quaternions, and `math.acos` then raises.

```python
q = np.array([0.18257419, 0.36514837, 0.54772256, 0.73029674])
quaternion_slerp(q, q, 0.5)   # ValueError: math domain error
```

847 of 2000 random `quaternion_slerp(q, q, t)` calls fail this way at the
default `spin=0`. With `spin != 0` it divides by `sin(pi)` instead and returns
~1e16 rather than raising.

The existing test only interpolates between two *distinct* quaternions, so it
never reached the guard. Added a regression test covering identical endpoints
for `spin` in `(0, 1, -1)`; it fails on the current code.