### PR TITLE
Add rotation_translation2matrix, matrix2rotation_translation and transform_point

### DIFF
--- a/skrobot/coordinates/__init__.py
+++ b/skrobot/coordinates/__init__.py
@@ -19,6 +19,7 @@ from skrobot.coordinates.math import look_at_rotation
 from skrobot.coordinates.math import make_matrix
 from skrobot.coordinates.math import manipulability
 from skrobot.coordinates.math import matrix2quaternion
+from skrobot.coordinates.math import matrix2rotation_translation
 from skrobot.coordinates.math import matrix2xyzrpy
 from skrobot.coordinates.math import matrix_relative
 from skrobot.coordinates.math import normalize_mask
@@ -31,5 +32,7 @@ from skrobot.coordinates.math import rotation_matrix_to_axis_angle_vector
 from skrobot.coordinates.math import rpy2homogeneous
 from skrobot.coordinates.math import rpy_angle
 from skrobot.coordinates.math import rpy_matrix
+from skrobot.coordinates.math import rotation_translation2matrix
 from skrobot.coordinates.math import sr_inverse
+from skrobot.coordinates.math import transform_point
 from skrobot.coordinates.math import xyzrpy2matrix

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -3151,6 +3151,80 @@ def xyzrpy2matrix(xyz, rpy):
     return matrix
 
 
+def rotation_translation2matrix(rotation, translation):
+    """Compose a 4x4 homogeneous transform from rotation and translation.
+
+    Inverse of :func:`matrix2rotation_translation`.
+
+    Parameters
+    ----------
+    rotation : list or tuple or numpy.ndarray
+        3x3 rotation matrix.
+    translation : list or tuple or numpy.ndarray
+        translation, shape (3,).
+
+    Returns
+    -------
+    matrix : numpy.ndarray
+        4x4 homogeneous transformation matrix.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skrobot.coordinates.math import rotation_translation2matrix
+    >>> rotation_translation2matrix(np.eye(3), [1.0, 2.0, 3.0])
+    array([[1., 0., 0., 1.],
+           [0., 1., 0., 2.],
+           [0., 0., 1., 3.],
+           [0., 0., 0., 1.]])
+    """
+    matrix = np.eye(4)
+    matrix[:3, :3] = np.array(rotation, dtype=np.float64)
+    matrix[:3, 3] = np.array(translation, dtype=np.float64)
+    return matrix
+
+
+def matrix2rotation_translation(matrix):
+    """Split a 4x4 homogeneous transform into rotation and translation.
+
+    Inverse of :func:`rotation_translation2matrix`.
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray
+        4x4 homogeneous transformation matrix.
+
+    Returns
+    -------
+    rotation : numpy.ndarray
+        3x3 rotation matrix (a copy).
+    translation : numpy.ndarray
+        translation, shape (3,) (a copy).
+    """
+    matrix = np.array(matrix, dtype=np.float64)
+    return matrix[:3, :3], matrix[:3, 3]
+
+
+def transform_point(matrix, point):
+    """Apply a 4x4 homogeneous transform to a 3D point.
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray
+        4x4 homogeneous transformation matrix.
+    point : list or tuple or numpy.ndarray
+        point, shape (3,).
+
+    Returns
+    -------
+    point : numpy.ndarray
+        transformed point, shape (3,).
+    """
+    matrix = np.asarray(matrix, dtype=np.float64)
+    point = np.asarray(point, dtype=np.float64)
+    return matrix[:3, :3] @ point + matrix[:3, 3]
+
+
 def matrix_relative(parent, child):
     """Express one homogeneous transform relative to another.
 

--- a/skrobot/kinematics/loop_closure.py
+++ b/skrobot/kinematics/loop_closure.py
@@ -13,6 +13,8 @@ planners, analysis).
 
 import numpy as np
 
+from skrobot.coordinates.math import rotation_translation2matrix
+
 
 class LoopClosureSolver(object):
     """Solve a robot's declared loop closures in place.
@@ -132,14 +134,11 @@ class LoopClosureSolver(object):
             chain.append(current.joint)
             current = current.parent_link
         coords = current.worldcoords()
-        transform = np.eye(4)
-        transform[:3, :3] = coords.worldrot()
-        transform[:3, 3] = coords.worldpos()
+        transform = rotation_translation2matrix(coords.worldrot(), coords.worldpos())
         for joint in reversed(chain):
-            local = np.eye(4)
-            local[:3, :3] = joint.default_coords.rotation
-            local[:3, 3] = joint.default_coords.translation
-            transform = transform @ local
+            transform = transform @ rotation_translation2matrix(
+                joint.default_coords.rotation,
+                joint.default_coords.translation)
         return transform
 
     def _residual(self):

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -18,6 +18,7 @@ from skrobot.coordinates.math import interpolate_rotation_matrices
 from skrobot.coordinates.math import invert_yaw_pitch_roll
 from skrobot.coordinates.math import look_at_rotation
 from skrobot.coordinates.math import matrix2quaternion
+from skrobot.coordinates.math import matrix2rotation_translation
 from skrobot.coordinates.math import matrix2rpy
 from skrobot.coordinates.math import matrix2xyzrpy
 from skrobot.coordinates.math import matrix2ypr
@@ -50,12 +51,14 @@ from skrobot.coordinates.math import rotation_matrix_from_axis
 from skrobot.coordinates.math import rotation_matrix_from_rpy
 from skrobot.coordinates.math import rotation_matrix_from_vectors
 from skrobot.coordinates.math import rotation_matrix_to_axis_angle_vector
+from skrobot.coordinates.math import rotation_translation2matrix
 from skrobot.coordinates.math import rotation_vector_to_quaternion
 from skrobot.coordinates.math import rpy2homogeneous
 from skrobot.coordinates.math import rpy2matrix
 from skrobot.coordinates.math import rpy2quaternion
 from skrobot.coordinates.math import rpy_matrix
 from skrobot.coordinates.math import skew_symmetric_matrix
+from skrobot.coordinates.math import transform_point
 from skrobot.coordinates.math import triple_product
 from skrobot.coordinates.math import wxyz2xyzw
 from skrobot.coordinates.math import xyzrpy2matrix
@@ -1117,6 +1120,36 @@ class TestMath(unittest.TestCase):
             r_xyz, r_rpy = matrix2xyzrpy(mat)
             testing.assert_almost_equal(r_xyz, xyz)
             testing.assert_almost_equal(r_rpy, rpy)
+
+    def test_rt2matrix_matrix2rt_round_trip(self):
+        rng = np.random.RandomState(7)
+        for _ in range(50):
+            xyz = rng.uniform(-3, 3, 3)
+            rpy = rng.uniform(-1, 1, 3)
+            matrix = xyzrpy2matrix(xyz, rpy)
+            rotation, translation = matrix2rotation_translation(matrix)
+            testing.assert_almost_equal(
+                rotation_translation2matrix(rotation, translation), matrix)
+        # matrix2rotation_translation returns copies: mutating them must not touch the source
+        matrix = xyzrpy2matrix([1, 2, 3], [0.1, 0.2, 0.3])
+        rotation, translation = matrix2rotation_translation(matrix)
+        rotation[0, 0] = 99.0
+        translation[0] = 99.0
+        testing.assert_almost_equal(
+            matrix, xyzrpy2matrix([1, 2, 3], [0.1, 0.2, 0.3]))
+
+    def test_transform_point(self):
+        rng = np.random.RandomState(8)
+        for _ in range(50):
+            matrix = xyzrpy2matrix(rng.uniform(-3, 3, 3),
+                                   rng.uniform(-1, 1, 3))
+            point = rng.uniform(-2, 2, 3)
+            homogeneous = matrix @ np.append(point, 1.0)
+            testing.assert_almost_equal(
+                transform_point(matrix, point), homogeneous[:3])
+        # identity transform leaves the point untouched
+        testing.assert_almost_equal(
+            transform_point(np.eye(4), [1, 2, 3]), [1, 2, 3])
 
     def test_matrix_relative(self):
         rng = np.random.RandomState(3)


### PR DESCRIPTION
Composing a 4x4 homogeneous transform from a rotation matrix and a translation (and applying one to a point) kept being hand-rolled at call sites; these join the `xyzrpy2matrix` / `matrix2xyzrpy` family with the same component-spelling naming. The loop-closure solver now uses the compose helper for its zero-pose chain.

Tests: round-trip over 50 random poses, copy semantics of the decompose, homogeneous-vector equivalence for `transform_point` (coordinates + solver + assembly suites green).