### PR TITLE
Keep vector alignment finite for denormal and huge magnitudes

### DIFF
--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -3057,8 +3057,18 @@ def rotation_matrix_from_vectors(a, b):
     >>> np.allclose(R.dot([1, 0, 0]), [0, 1, 0])
     True
     """
-    a = normalize_vector(np.array(a, dtype=np.float64))
-    b = normalize_vector(np.array(b, dtype=np.float64))
+    a = np.array(a, dtype=np.float64)
+    b = np.array(b, dtype=np.float64)
+    # pre-scale by the largest component so denormal (or huge) inputs
+    # survive normalization instead of underflowing to nan
+    scale_a = np.max(np.abs(a))
+    scale_b = np.max(np.abs(b))
+    if scale_a == 0.0 or scale_b == 0.0:
+        raise ValueError(
+            'rotation_matrix_from_vectors needs nonzero directions, '
+            f'got a={a.tolist()}, b={b.tolist()}')
+    a = normalize_vector(a / scale_a)
+    b = normalize_vector(b / scale_b)
     axis = np.cross(a, b)
     axis_norm = np.linalg.norm(axis)
     dot = float(np.clip(np.dot(a, b), -1.0, 1.0))

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -1078,6 +1078,21 @@ class TestMath(unittest.TestCase):
             testing.assert_almost_equal(
                 rot.dot(normalize_vector(a)), -normalize_vector(a))
 
+    def test_rotation_matrix_from_vectors_degenerate_magnitudes(self):
+        # denormal / huge magnitudes still describe a valid direction:
+        # normalization must not underflow or overflow to nan
+        for a, b in (([1e-300, 0, 0], [0, 1, 0]),
+                     ([1e300, 0, 0], [0, 1e-300, 0])):
+            rotation = rotation_matrix_from_vectors(a, b)
+            testing.assert_almost_equal(rotation @ [1, 0, 0], [0, 1, 0])
+            quat = quaternion_from_vectors(a, b)
+            self.assertTrue(np.all(np.isfinite(quat)))
+        # a zero vector has no direction: refuse instead of returning nan
+        with self.assertRaises(ValueError):
+            rotation_matrix_from_vectors([0, 0, 0], [1, 0, 0])
+        with self.assertRaises(ValueError):
+            rotation_matrix_from_vectors([1, 0, 0], [0, 0, 0])
+
     def test_quaternion_from_vectors(self):
         rng = np.random.RandomState(1)
         for _ in range(50):


### PR DESCRIPTION
`rotation_matrix_from_vectors` normalized its inputs directly, so a direction like `[1e-300, 0, 0]` underflowed to nan (with only a RuntimeWarning) even though the docstring promises that only the direction matters. Pre-scale by the largest component before normalizing, and refuse a true zero vector with `ValueError` instead of returning nan.

The regression test fails on the previous implementation (verified by reverting the fix) and covers denormal, huge, and zero inputs; `quaternion_from_vectors` inherits the fix.