### PR TITLE
Drop Python 3.8 / 3.9 support and remove Python 2 residue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: '3.10'
     - name: Install Formatting
       run: |
         python -m pip install --upgrade pip
@@ -84,27 +84,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: 3.8.16
-            os: ubuntu-latest
-            numpy-version: "1.21.0"
-            scipy-version: "1.6.3"
-            remove-setuptools: false
-          - python-version: 3.8.16
-            os: ubuntu-latest
-            numpy-version: "1.21.0"
-            scipy-version: "latest"
-            remove-setuptools: false
-          - python-version: 3.8.16
-            os: ubuntu-latest
-            numpy-version: "latest"
-            scipy-version: "1.6.3"
-            remove-setuptools: false
-          - python-version: 3.8.16
-            os: ubuntu-latest
-            numpy-version: "latest"
-            scipy-version: "latest"
-            remove-setuptools: false
-
           - python-version: 3.10.10
             os: ubuntu-latest
             numpy-version: "1.23.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,30 +1,19 @@
-cached-property;python_version>="3.0"
-cached-property<=1.5.2;python_version<"3.0"
+cached-property
 filelock
-future
 lxml
-networkx>=2.2.0;python_version<"3.8"
-networkx>=2.5;python_version>="3.8"
-numpy>=1.16.0;python_version<"3.8"
-numpy>=1.21.0;python_version>="3.8"
+networkx>=2.5
+numpy>=1.21.0
 ordered_set
 packaging
 pillow
 pooch>=1.5.0
-pycollada<0.9;python_version<"3.2"  # required for robot model using collada
-pycollada>=0.8,<=0.9;python_version>="3.2" and python_version<"3.9"
-pycollada>=0.8;python_version>="3.9"  # required for robot model using collada
+pycollada>=0.8  # required for robot model using collada
 pyglet<2.0
 pysdfgen>=0.2.0
 pyyaml
-repoze.lru;python_version<"3.2"
 rtree # need rtree for simplify_quadric_decimation
-scikit-learn;python_version<"3.8"
-scikit-learn>=0.24.0;python_version>="3.8"
+scikit-learn>=0.24.0
 scikit-robot-pyrender>=0.1.50
-scipy;python_version>="3.0" and python_version<"3.8"
-scipy<=1.2.3;python_version<"3.0"
-scipy>=1.6.3;python_version>="3.8"
-six
+scipy>=1.6.3
 trimesh>=3.9.0,!=3.23.0
 viser

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import re
 import sys
@@ -108,14 +106,14 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
+    python_requires='>=3.10',
     packages=find_packages(),
     package_data={'skrobot': listup_package_data()},
     zip_safe=False,

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import math
 from math import acos
 from math import cos

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -10,7 +10,6 @@ import warnings
 import numpy as np
 import numpy.linalg as LA
 from ordered_set import OrderedSet
-import six
 
 from skrobot._lazy_imports import _lazy_trimesh
 from skrobot.coordinates import CascadedCoords
@@ -3236,7 +3235,7 @@ class RobotModel(CascadedLink):
             although their mimic definitions are still processed and applied
             to the joints they mimic.
         """
-        if isinstance(file_obj, six.string_types):
+        if isinstance(file_obj, str):
             self.urdf_path = file_obj
         else:
             self.urdf_path = getattr(file_obj, 'name', None)

--- a/skrobot/pycompat.py
+++ b/skrobot/pycompat.py
@@ -1,13 +1,6 @@
-import functools
+from functools import lru_cache  # noqa: F401  re-exported for backward compatibility
 import os
 import platform
-
-
-if hasattr(functools, 'lru_cache'):
-    lru_cache = functools.lru_cache
-else:
-    import repoze.lru
-    lru_cache = repoze.lru.lru_cache
 
 
 # Ensure CPU backend on Mac before JAX imports

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from logging import getLogger
 from math import floor
 import os

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -23,7 +23,6 @@ from lxml import etree as ET
 import networkx as nx
 import numpy as np
 import PIL.Image
-import six
 
 from skrobot._lazy_imports import _lazy_trimesh
 from skrobot.coordinates import normalize_vector
@@ -1256,7 +1255,7 @@ class Mesh(URDFType):
 
     @meshes.setter
     def meshes(self, value):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             value = load_meshes(value)
             self._meshes = value
             return
@@ -1946,7 +1945,7 @@ class Material(URDFType):
     @texture.setter
     def texture(self, value):
         if value is not None:
-            if isinstance(value, six.string_types):
+            if isinstance(value, str):
                 image = PIL.Image.open(value)
                 value = Texture(filename=value, image=image)
             elif not isinstance(value, Texture):
@@ -3715,7 +3714,7 @@ class URDF(URDFType):
         urdf : :class:`.URDF`
             The parsed URDF.
         """
-        if isinstance(file_obj, six.string_types):
+        if isinstance(file_obj, str):
             path, _ = os.path.split(file_obj)
         else:
             path, _ = os.path.split(os.path.realpath(file_obj.name))
@@ -3792,7 +3791,7 @@ class URDF(URDFType):
         urdf : :class:`.URDF`
             The parsed URDF.
         """
-        if isinstance(file_obj, six.string_types):
+        if isinstance(file_obj, str):
             # Handle package:// URLs
             if file_obj.startswith('package://'):
                 resolved_path = resolve_filepath(os.getcwd(), file_obj)

--- a/skrobot/viewers/_notebook.py
+++ b/skrobot/viewers/_notebook.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import collections
 
 import numpy as np

--- a/skrobot/viewers/_pyrender.py
+++ b/skrobot/viewers/_pyrender.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import collections
 import os
 from pathlib import Path

--- a/skrobot/viewers/_trimesh.py
+++ b/skrobot/viewers/_trimesh.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import collections
 import logging
 import threading


### PR DESCRIPTION
setup.py advertised 3.8+ through classifiers but never set python_requires, so pip installed the latest release on any interpreter and failed at import; old interpreters now resolve to the last compatible release. 3.9 was already untested — the matrix never ran it. The floor makes the Python 2 leftovers dead, so six, the unused future dependency, repoze.lru and the pre-3.8 markers go too. The __future__ annotations imports stay; those are PEP 563.