### PR TITLE
Add URDF->MJCF converter and Unitree G1 model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ console_scripts.append("visualize-mesh=skrobot.apps.visualize_mesh:main")
 console_scripts.append("urdf-hash=skrobot.apps.urdf_hash:main")
 console_scripts.append("convert-wheel-collision=skrobot.apps.convert_wheel_collision:main")
 console_scripts.append("urdf-tree=skrobot.apps.urdf_tree:main")
+console_scripts.append("convert-urdf-to-mjcf=skrobot.apps.convert_urdf_to_mjcf:main")
 
 
 setup(

--- a/skrobot/apps/convert_urdf_to_mjcf.py
+++ b/skrobot/apps/convert_urdf_to_mjcf.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+"""
+Convert a URDF into a MuJoCo MJCF model.
+
+Walks the raw parsed URDF and emits an MJCF that MuJoCo can load directly --
+handling fixed joints (weld), mimic joints (equality constraints), primitive and
+mesh geometry (meshes exported to binary STL and decimated under MuJoCo's face
+limit), inertials (regularized to be positive-definite), and per-joint position
+actuators. Radians are pinned so angles match ROS.
+"""
+
+import argparse
+from pathlib import Path
+import sys
+
+from skrobot.urdf import urdf_to_mjcf
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Convert a URDF into a MuJoCo MJCF model',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  convert-urdf-to-mjcf robot.urdf
+  convert-urdf-to-mjcf robot.urdf -o out/robot.xml
+  convert-urdf-to-mjcf robot.urdf --floating-base --no-actuators
+        """
+    )
+    parser.add_argument('urdf_file', type=str, help='Path to the input URDF file')
+    parser.add_argument('-o', '--output', type=str, default=None,
+                        help='Output .xml path (default: <urdf_stem>.xml)')
+    parser.add_argument('--mesh-dir', type=str, default=None,
+                        help='Directory for exported mesh assets '
+                             '(default: <output_dir>/assets)')
+    parser.add_argument('--floating-base', action='store_true',
+                        help='Give the base link a free joint (default: welded)')
+    parser.add_argument('--no-actuators', action='store_true',
+                        help='Do not emit position actuators')
+    parser.add_argument('--actuator-kp', type=float, default=50.0,
+                        help='Proportional gain for position actuators')
+    parser.add_argument('--no-ground', action='store_true',
+                        help='Do not add a ground plane / light')
+    parser.add_argument('-v', '--verbose', action='store_true')
+    args = parser.parse_args()
+
+    urdf_path = Path(args.urdf_file)
+    if not urdf_path.exists():
+        print('error: URDF not found: {}'.format(urdf_path), file=sys.stderr)
+        return 1
+    out_path = args.output or str(urdf_path.with_suffix('.xml'))
+
+    urdf_to_mjcf(
+        str(urdf_path), out_path,
+        mesh_dir=args.mesh_dir,
+        floating_base=args.floating_base,
+        add_position_actuators=not args.no_actuators,
+        actuator_kp=args.actuator_kp,
+        add_ground=not args.no_ground,
+    )
+    print('wrote MJCF: {}'.format(out_path))
+    if args.verbose:
+        try:
+            import mujoco
+            m = mujoco.MjModel.from_xml_path(out_path)
+            print('MuJoCo loads OK: nq={} njnt={} nu={} nbody={} ngeom={}'.format(
+                m.nq, m.njnt, m.nu, m.nbody, m.ngeom))
+        except Exception as e:  # noqa: BLE001
+            print('note: MuJoCo verification skipped/failed: {}'.format(e),
+                  file=sys.stderr)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/skrobot/apps/convert_urdf_to_mjcf.py
+++ b/skrobot/apps/convert_urdf_to_mjcf.py
@@ -41,6 +41,17 @@ Examples:
                         help='Proportional gain for position actuators')
     parser.add_argument('--no-ground', action='store_true',
                         help='Do not add a ground plane / light')
+    parser.add_argument('--self-collision', action='store_true',
+                        help='Keep full self-collision (default: robot collides '
+                             'with ground but not itself)')
+    parser.add_argument('--no-actuator-forcerange', action='store_true',
+                        help='Do not cap actuator torque to the URDF effort limit')
+    parser.add_argument('--convex-decompose-collision', action='store_true',
+                        help='CoACD-decompose collision meshes into convex parts '
+                             '(accurate but slow; needs the coacd package)')
+    parser.add_argument('--coacd-quality', choices=['balanced', 'fine'],
+                        default='balanced',
+                        help='CoACD preset for --convex-decompose-collision')
     parser.add_argument('-v', '--verbose', action='store_true')
     args = parser.parse_args()
 
@@ -57,6 +68,10 @@ Examples:
         add_position_actuators=not args.no_actuators,
         actuator_kp=args.actuator_kp,
         add_ground=not args.no_ground,
+        self_collision=args.self_collision,
+        add_actuator_forcerange=not args.no_actuator_forcerange,
+        convex_decompose_collision=args.convex_decompose_collision,
+        coacd_quality=args.coacd_quality,
     )
     print('wrote MJCF: {}'.format(out_path))
     if args.verbose:

--- a/skrobot/coordinates/__init__.py
+++ b/skrobot/coordinates/__init__.py
@@ -20,6 +20,8 @@ from skrobot.coordinates.math import make_matrix
 from skrobot.coordinates.math import manipulability
 from skrobot.coordinates.math import matrix2quaternion
 from skrobot.coordinates.math import matrix2rotation_translation
+from skrobot.coordinates.math import matrix2translation_quaternion_wxyz
+from skrobot.coordinates.math import matrix2translation_quaternion_xyzw
 from skrobot.coordinates.math import matrix2xyzrpy
 from skrobot.coordinates.math import matrix_relative
 from skrobot.coordinates.math import normalize_mask

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -3159,6 +3159,77 @@ def xyzrpy2matrix(xyz, rpy):
     return matrix
 
 
+def matrix2translation_quaternion_wxyz(matrix):
+    """Split a 4x4 homogeneous transform into translation and quaternion.
+
+    Same split as :func:`matrix2xyzrpy`, but the rotation is returned as a
+    quaternion in ``[w, x, y, z]`` order (the convention of
+    :func:`matrix2quaternion`, and the one MuJoCo/MJCF uses). Use
+    :func:`matrix2translation_quaternion_xyzw` for the ``[x, y, z, w]`` order
+    used by ROS and SciPy.
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray
+        4x4 homogeneous transformation matrix.
+
+    Returns
+    -------
+    translation : numpy.ndarray
+        translation, shape (3,).
+    quaternion : numpy.ndarray
+        quaternion ``[w, x, y, z]``, shape (4,).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skrobot.coordinates.math import matrix2translation_quaternion_wxyz
+    >>> from skrobot.coordinates.math import xyzrpy2matrix
+    >>> T = xyzrpy2matrix([1, 2, 3], [0, 0, 0])
+    >>> translation, quaternion = matrix2translation_quaternion_wxyz(T)
+    >>> np.allclose(translation, [1, 2, 3])
+    True
+    >>> np.allclose(quaternion, [1, 0, 0, 0])
+    True
+    """
+    matrix = np.array(matrix, dtype=np.float64)
+    return matrix[:3, 3].copy(), matrix2quaternion(matrix[:3, :3])
+
+
+def matrix2translation_quaternion_xyzw(matrix):
+    """Split a 4x4 homogeneous transform into translation and quaternion.
+
+    Same as :func:`matrix2translation_quaternion_wxyz`, but the quaternion is
+    returned in ``[x, y, z, w]`` order (the convention used by ROS and SciPy).
+
+    Parameters
+    ----------
+    matrix : numpy.ndarray
+        4x4 homogeneous transformation matrix.
+
+    Returns
+    -------
+    translation : numpy.ndarray
+        translation, shape (3,).
+    quaternion : numpy.ndarray
+        quaternion ``[x, y, z, w]``, shape (4,).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skrobot.coordinates.math import matrix2translation_quaternion_xyzw
+    >>> from skrobot.coordinates.math import xyzrpy2matrix
+    >>> T = xyzrpy2matrix([1, 2, 3], [0, 0, 0])
+    >>> translation, quaternion = matrix2translation_quaternion_xyzw(T)
+    >>> np.allclose(translation, [1, 2, 3])
+    True
+    >>> np.allclose(quaternion, [0, 0, 0, 1])
+    True
+    """
+    translation, quaternion = matrix2translation_quaternion_wxyz(matrix)
+    return translation, wxyz2xyzw(quaternion)
+
+
 def rotation_translation2matrix(rotation, translation):
     """Compose a 4x4 homogeneous transform from rotation and translation.
 

--- a/skrobot/data/__init__.py
+++ b/skrobot/data/__init__.py
@@ -197,6 +197,40 @@ def jaxon_urdfpath():
     return path
 
 
+def g1_urdfpath(dof=23):
+    """Path to the Unitree G1 humanoid URDF.
+
+    Downloads a pinned snapshot of
+    `isri-aist/g1_description
+    <https://github.com/isri-aist/g1_description>`_ (URDF + STL meshes
+    derived from Unitree's official ``g1_description``), licensed under
+    BSD-3-Clause. The same archive also ships reference MJCF files under
+    ``mjcf/`` which are handy for cross-checking our URDF->MJCF converter.
+
+    Parameters
+    ----------
+    dof : int
+        Which G1 variant to load. ``23`` (default: 12 leg + waist_yaw + 10 arm
+        joints, the standard locomotion model) or ``29`` (adds waist
+        roll/pitch and wrist pitch/yaw).
+    """
+    if dof not in (23, 29):
+        raise ValueError('g1 dof must be 23 or 29, got {}'.format(dof))
+    sha = 'e4fa30ffcd239fe405ec3942a58b554131598615'
+    base = 'g1_description-{}'.format(sha)
+    path = osp.join(get_cache_dir(), base, 'urdf', 'g1_{}dof.urdf'.format(dof))
+    if osp.exists(path):
+        return path
+    _retrieve(
+        url=('https://github.com/isri-aist/g1_description'
+             '/archive/{}.tar.gz'.format(sha)),
+        fname='{}.tar.gz'.format(base),
+        md5='849dc7df75eab91509e345c554e926b2',
+        extract=True,
+    )
+    return path
+
+
 def jedy_urdfpath():
     path = osp.join(get_cache_dir(),
                     'jedy_description', 'urdf', 'jedy.urdf')

--- a/skrobot/models/__init__.py
+++ b/skrobot/models/__init__.py
@@ -3,6 +3,7 @@
 from skrobot.models.aero import Aero
 from skrobot.models.differential_wrist_sample import DifferentialWristSample
 from skrobot.models.fetch import Fetch
+from skrobot.models.g1 import G1
 from skrobot.models.griphis import Griphis
 from skrobot.models.hydrus import Hydrus
 from skrobot.models.jaxon_jvrc import JaxonJVRC

--- a/skrobot/models/g1.py
+++ b/skrobot/models/g1.py
@@ -1,0 +1,78 @@
+from cached_property import cached_property
+
+from skrobot.coordinates import CascadedCoords
+from skrobot.data import g1_urdfpath
+from skrobot.models.urdf import RobotModelFromURDF
+
+
+class G1(RobotModelFromURDF):
+    """Unitree G1 humanoid.
+
+    ~1.3 m / ~35 kg humanoid. By default the 23-DOF locomotion model is
+    loaded (6 + 6 leg, 1 waist-yaw and 5 + 5 arm joints); pass ``dof=29`` for
+    the extended model (waist roll/pitch and wrist pitch/yaw). The URDF +
+    meshes are fetched on first use from
+    `isri-aist/g1_description
+    <https://github.com/isri-aist/g1_description>`_, derived from Unitree's
+    official ``g1_description`` (BSD-3-Clause).
+    """
+
+    def __init__(self, dof=23, urdf=None, urdf_file=None):
+        self._dof = dof
+        super(G1, self).__init__(urdf=urdf, urdf_file=urdf_file)
+
+        # Foot sole frames, ~0.03 m below the ankle-roll link origin.
+        self.rleg_end_coords = CascadedCoords(
+            parent=self.right_ankle_roll_link,
+            pos=[0.0, 0.0, -0.03],
+            name='rleg_end_coords')
+        self.lleg_end_coords = CascadedCoords(
+            parent=self.left_ankle_roll_link,
+            pos=[0.0, 0.0, -0.03],
+            name='lleg_end_coords')
+
+        # Hand frames (23-DOF model ends at wrist_roll; 29-DOF adds wrist
+        # pitch/yaw). Use whichever end link the loaded model exposes.
+        self.rarm_end_coords = CascadedCoords(
+            parent=self._arm_end_link('right'), name='rarm_end_coords')
+        self.larm_end_coords = CascadedCoords(
+            parent=self._arm_end_link('left'), name='larm_end_coords')
+
+        self.end_coords = [self.rarm_end_coords, self.larm_end_coords]
+
+        self.reset_pose()
+
+    @cached_property
+    def default_urdf_path(self):
+        return g1_urdfpath(dof=self._dof)
+
+    def _arm_end_link(self, side):
+        for name in ('{}_wrist_yaw_link'.format(side),
+                     '{}_wrist_roll_rubber_hand'.format(side),
+                     '{}_wrist_roll_link'.format(side),
+                     '{}_rubber_hand'.format(side)):
+            link = getattr(self, name, None)
+            if link is not None:
+                return link
+        raise AttributeError('no arm end link found for side {}'.format(side))
+
+    def reset_pose(self):
+        """A statically-stable half-crouch: hips/knees/ankles flexed so the
+        soles sit flat and the CoM is inside the support polygon."""
+        angles = {
+            'left_hip_pitch_joint': -0.10,
+            'right_hip_pitch_joint': -0.10,
+            'left_knee_joint': 0.30,
+            'right_knee_joint': 0.30,
+            'left_ankle_pitch_joint': -0.20,
+            'right_ankle_pitch_joint': -0.20,
+            'left_shoulder_roll_joint': 0.20,
+            'right_shoulder_roll_joint': -0.20,
+            'left_elbow_joint': 0.30,
+            'right_elbow_joint': 0.30,
+        }
+        for name, ang in angles.items():
+            joint = getattr(self, name, None)
+            if joint is not None:
+                joint.joint_angle(float(ang))
+        return self.angle_vector()

--- a/skrobot/urdf/__init__.py
+++ b/skrobot/urdf/__init__.py
@@ -21,6 +21,7 @@ from skrobot.urdf.wheel_collision_converter import convert_wheel_collisions_to_c
 from skrobot.urdf.wheel_collision_converter import get_mesh_dimensions
 from skrobot.urdf.xml_root_link_changer import change_urdf_root_link
 from skrobot.urdf.xml_root_link_changer import URDFXMLRootLinkChanger
+from skrobot.utils.mjcf_converter import urdf_to_mjcf
 
 
 __all__ = [
@@ -47,4 +48,5 @@ __all__ = [
     'compute_jaw_gripper_frame',
     'sanitize_name',
     'sanitize_urdf_names',
+    'urdf_to_mjcf',
 ]

--- a/skrobot/utils/mjcf_converter.py
+++ b/skrobot/utils/mjcf_converter.py
@@ -44,6 +44,10 @@ class _MeshAssets:
         self.mesh_dir = mesh_dir
         self._by_id = {}      # id(trimesh) -> asset name
         self.entries = []     # (name, filename, scale)
+        # collision-only: run CoACD on collision meshes so MuJoCo gets accurate
+        # convex parts instead of one coarse convex hull. Set by urdf_to_mjcf.
+        self.convex_decompose = False
+        self.coacd_quality = 'balanced'
         os.makedirs(mesh_dir, exist_ok=True)
 
     def _decimate(self, mesh):
@@ -102,6 +106,48 @@ class _MeshAssets:
             out.append((name, scale, color))
         return out
 
+    def add_convex_parts(self, mesh_geometry):
+        """CoACD-decompose a collision mesh into convex parts and return one
+        ``(asset_name, scale, None)`` entry per part. Falls back to the plain
+        convex hull if CoACD is unavailable or fails. Results are cached by
+        sub-mesh id since CoACD is expensive."""
+        import trimesh
+        from trimesh.exchange.stl import export_stl
+
+        from skrobot.utils.convex_decomposition import convex_decomposition
+
+        submeshes = [m for m in (getattr(mesh_geometry, "meshes", None) or [])
+                     if isinstance(m, trimesh.Trimesh) and len(m.faces) > 0]
+        scale = getattr(mesh_geometry, "scale", None)
+        base = os.path.splitext(os.path.basename(
+            getattr(mesh_geometry, "filename", "") or "mesh"))[0]
+
+        out = []
+        for sub in submeshes:
+            key = ("coacd", id(sub))
+            if key in self._by_id:
+                for name in self._by_id[key]:
+                    out.append((name, scale, None))
+                continue
+            try:
+                parts = convex_decomposition(sub, quality=self.coacd_quality)
+            except Exception:
+                parts = [sub.convex_hull]
+            names = []
+            for part in parts:
+                if len(part.faces) == 0:
+                    continue
+                name = "{}_col{}".format(base or "mesh", len(self.entries))
+                fname = name + ".stl"
+                with open(os.path.join(self.mesh_dir, fname), "wb") as f:
+                    f.write(export_stl(part))  # MuJoCo needs BINARY STL
+                self.entries.append((name, fname, scale))
+                names.append(name)
+            self._by_id[key] = names
+            for name in names:
+                out.append((name, scale, None))
+        return out
+
 
 def _add_geom(parent_el, visual_or_collision, assets, *, collision, rgba=None):
     """Emit one <geom> for a Visual/Collision; return True if emitted."""
@@ -143,7 +189,10 @@ def _add_geom(parent_el, visual_or_collision, assets, *, collision, rgba=None):
         ET.SubElement(parent_el, "geom", a)
         return True
     if geom.mesh is not None:
-        subs = assets.add(geom.mesh)
+        if collision and getattr(assets, "convex_decompose", False):
+            subs = assets.add_convex_parts(geom.mesh)
+        else:
+            subs = assets.add(geom.mesh)
         if not subs:
             return False
         for name, scale, mesh_color in subs:
@@ -209,7 +258,8 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
                  joint_armature=0.0, joint_damping=0.0,
                  add_ground=True, gravity=(0, 0, -9.81),
                  self_collision=False, add_actuator_forcerange=True,
-                 home=None, home_base_height=0.0):
+                 home=None, home_base_height=0.0,
+                 convex_decompose_collision=False, coacd_quality='balanced'):
     """Convert a URDF to an MJCF file.
 
     Parameters
@@ -245,6 +295,15 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
     home_base_height : float
         Base-link height (m) used for the free-joint part of the home keyframe
         when ``floating_base`` is True.
+    convex_decompose_collision : bool
+        If True, run CoACD on every *collision* mesh and emit its convex parts
+        as separate geoms, instead of letting MuJoCo collapse the mesh to a
+        single coarse convex hull. Off by default because CoACD is slow
+        (seconds to tens of seconds per mesh). Needs the optional ``coacd``
+        package; falls back to the plain convex hull per mesh if it fails.
+    coacd_quality : str
+        CoACD preset when ``convex_decompose_collision`` is True: ``'balanced'``
+        (default, faster) or ``'fine'`` (tighter fit).
 
     Returns
     -------
@@ -260,6 +319,8 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
     if mesh_dir is None:
         mesh_dir = os.path.join(out_dir, "assets")
     assets = _MeshAssets(mesh_dir)
+    assets.convex_decompose = convex_decompose_collision
+    assets.coacd_quality = coacd_quality
 
     # children map: parent link name -> [joints]
     children_map = {}

--- a/skrobot/utils/mjcf_converter.py
+++ b/skrobot/utils/mjcf_converter.py
@@ -1,0 +1,392 @@
+"""Convert a URDF into a MuJoCo MJCF model.
+
+MuJoCo's own URDF importer is strict (it rejects empty ``<collision>`` geometry,
+ignores ``mimic`` joints, and needs ``<mujoco>`` extension tags for actuators and
+sensible defaults), so robots such as the JSK "jedy" fail to load directly. This
+converter walks the *raw* parsed URDF (``skrobot.utils.urdf.URDF``, which retains
+fixed joints, per-geometry origins, primitive shapes, mesh filenames+scale, and
+mimic couplings) and emits a clean MJCF:
+
+* URDF link tree -> MuJoCo ``<body>`` tree (a fixed joint simply produces a body
+  with no ``<joint>``, i.e. a weld -- no collapsing needed).
+* revolute/continuous -> ``hinge``, prismatic -> ``slide`` (limits -> range).
+* URDF ``<inertial>`` -> MJCF ``<inertial ... fullinertia=...>``.
+* box/cylinder/sphere primitives and meshes -> geoms; meshes exported to STL
+  assets and referenced from ``<asset>``. Empty geometry is skipped.
+* ``mimic`` -> ``<equality><joint polycoef=...>``.
+* one ``<position>`` actuator per actuated (non-mimic) joint (optional).
+* ``<compiler angle="radian">`` so radians match ROS.
+
+Entry point: :func:`urdf_to_mjcf`.
+"""
+
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+from skrobot.coordinates.math import matrix2translation_quaternion_wxyz
+
+
+def _fmt(values):
+    return " ".join("{:.9g}".format(float(v)) for v in np.ravel(values))
+
+
+class _MeshAssets:
+    """Collects unique meshes, exports them to STL, and hands out asset names."""
+
+    # MuJoCo's STL decoder rejects meshes with more than this many faces.
+    MAX_FACES = 200000
+
+    def __init__(self, mesh_dir):
+        self.mesh_dir = mesh_dir
+        self._by_id = {}      # id(trimesh) -> asset name
+        self.entries = []     # (name, filename, scale)
+        os.makedirs(mesh_dir, exist_ok=True)
+
+    def _decimate(self, mesh):
+        if len(mesh.faces) <= self.MAX_FACES:
+            return mesh
+        target = int(self.MAX_FACES * 0.9)
+        try:  # quadric decimation (needs fast-simplification); best visual result
+            simplified = mesh.simplify_quadric_decimation(face_count=target)
+            if simplified is not None and len(simplified.faces) > 0:
+                return simplified
+        except Exception:
+            pass
+        try:  # guaranteed-valid fallback: convex hull (few faces)
+            return mesh.convex_hull
+        except Exception:
+            return mesh
+
+    def add(self, mesh_geometry):
+        """Return a list of ``(asset_name, scale, rgba)`` -- one entry PER
+        sub-mesh. A single URDF visual mesh (e.g. a .glb) often bundles several
+        differently-coloured parts; emitting one geom per sub-mesh keeps those
+        colours, since MuJoCo has only a single colour per geom."""
+        import trimesh
+        from trimesh.exchange.stl import export_stl
+
+        submeshes = [m for m in (getattr(mesh_geometry, "meshes", None) or [])
+                     if isinstance(m, trimesh.Trimesh) and len(m.faces) > 0]
+        scale = getattr(mesh_geometry, "scale", None)
+        base = os.path.splitext(os.path.basename(
+            getattr(mesh_geometry, "filename", "") or "mesh"))[0]
+
+        out = []
+        for sub in submeshes:
+            # colour from the ORIGINAL sub-mesh (decimation's convex-hull
+            # fallback drops vertex colours); STL cannot carry it either.
+            color = None
+            try:
+                mc = sub.visual.main_color  # RGBA uint8
+                color = [c / 255.0 for c in mc]
+            except Exception:
+                pass
+
+            key = id(sub)
+            if key in self._by_id:
+                name = self._by_id[key]
+            else:
+                mesh = self._decimate(sub)
+                if len(mesh.faces) == 0:
+                    continue
+                name = "{}_{}".format(base or "mesh", len(self.entries))
+                fname = name + ".stl"
+                with open(os.path.join(self.mesh_dir, fname), "wb") as f:
+                    f.write(export_stl(mesh))  # MuJoCo needs BINARY STL
+                self._by_id[key] = name
+                self.entries.append((name, fname, scale))
+            out.append((name, scale, color))
+        return out
+
+
+def _add_geom(parent_el, visual_or_collision, assets, *, collision, rgba=None):
+    """Emit one <geom> for a Visual/Collision; return True if emitted."""
+    geom = getattr(visual_or_collision, "geometry", None)
+    if geom is None:
+        return False
+    origin = getattr(visual_or_collision, "origin", None)
+    if origin is None:
+        origin = np.eye(4)
+    pos, quat = matrix2translation_quaternion_wxyz(origin)
+
+    base_attrib = {"pos": _fmt(pos), "quat": _fmt(quat)}
+    if collision:
+        base_attrib["group"] = "3"
+    else:
+        # visual-only: no contact, distinct group so viewers can toggle it.
+        base_attrib["group"] = "2"
+        base_attrib["contype"] = "0"
+        base_attrib["conaffinity"] = "0"
+
+    if geom.box is not None:
+        a = dict(base_attrib, type="box",
+                 size=_fmt(np.asarray(geom.box.size, dtype=float) / 2.0))
+        if rgba is not None:
+            a["rgba"] = _fmt(rgba)
+        ET.SubElement(parent_el, "geom", a)
+        return True
+    if geom.cylinder is not None:
+        a = dict(base_attrib, type="cylinder",
+                 size=_fmt([geom.cylinder.radius, geom.cylinder.length / 2.0]))
+        if rgba is not None:
+            a["rgba"] = _fmt(rgba)
+        ET.SubElement(parent_el, "geom", a)
+        return True
+    if geom.sphere is not None:
+        a = dict(base_attrib, type="sphere", size=_fmt([geom.sphere.radius]))
+        if rgba is not None:
+            a["rgba"] = _fmt(rgba)
+        ET.SubElement(parent_el, "geom", a)
+        return True
+    if geom.mesh is not None:
+        subs = assets.add(geom.mesh)
+        if not subs:
+            return False
+        for name, scale, mesh_color in subs:
+            a = dict(base_attrib, type="mesh", mesh=name)
+            # URDF <material> colour wins; else the sub-mesh's own colour.
+            eff = rgba if rgba is not None else mesh_color
+            if eff is not None:
+                a["rgba"] = _fmt(eff)
+            ET.SubElement(parent_el, "geom", a)
+        return True
+    return False
+
+
+def _visual_rgba(visual):
+    material = getattr(visual, "material", None)
+    if material is not None and getattr(material, "color", None) is not None:
+        return np.asarray(material.color, dtype=float)
+    return None
+
+
+def _emit_body(link, joint_from_parent, urdf, assets, children_map,
+               parent_el, actuated):
+    """Recursively emit <body> for `link` under `parent_el`."""
+    body_attrib = {"name": link.name}
+    if joint_from_parent is not None:
+        pos, quat = matrix2translation_quaternion_wxyz(joint_from_parent.origin)
+        body_attrib["pos"] = _fmt(pos)
+        body_attrib["quat"] = _fmt(quat)
+    body = ET.SubElement(parent_el, "body", body_attrib)
+
+    # joint (movable only; fixed joint -> no <joint> element = weld)
+    if joint_from_parent is not None and joint_from_parent.joint_type != "fixed":
+        jt = joint_from_parent.joint_type
+        j = {"name": joint_from_parent.name, "pos": "0 0 0",
+             "axis": _fmt(joint_from_parent.axis)}
+        if jt == "prismatic":
+            j["type"] = "slide"
+        else:
+            j["type"] = "hinge"
+        limit = getattr(joint_from_parent, "limit", None)
+        if jt != "continuous" and limit is not None and \
+                limit.lower is not None and limit.upper is not None:
+            j["range"] = _fmt([limit.lower, limit.upper])
+        ET.SubElement(body, "joint", j)
+        if joint_from_parent.mimic is None:
+            actuated.append(joint_from_parent)
+
+    _emit_link_content(link, body, assets)
+
+    # recurse
+    for child_joint in children_map.get(link.name, []):
+        child_link = urdf.link_map[child_joint.child]
+        _emit_body(child_link, child_joint, urdf, assets, children_map,
+                   body, actuated)
+
+
+def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
+                 add_position_actuators=True, actuator_kp=50.0,
+                 actuator_type="position", actuator_kv=1.0,
+                 joint_armature=0.0, joint_damping=0.0,
+                 add_ground=True, gravity=(0, 0, -9.81)):
+    """Convert a URDF to an MJCF file.
+
+    Parameters
+    ----------
+    urdf : str or skrobot.utils.urdf.URDF
+        Path to a ``.urdf`` file, or an already-parsed URDF object.
+    out_path : str
+        Where to write the ``.xml`` MJCF. Mesh assets go in ``mesh_dir``
+        (default ``<out_dir>/assets``), referenced relatively via ``meshdir``.
+    floating_base : bool
+        If True the base link gets a free joint; otherwise it is welded to world.
+    add_position_actuators : bool
+        Emit one ``<position>`` actuator per actuated joint.
+    actuator_kp : float
+        Proportional gain for the position actuators.
+    add_ground : bool
+        Add a ground plane + light for a usable scene.
+
+    Returns
+    -------
+    str
+        The MJCF XML written to ``out_path``.
+    """
+    from skrobot.utils.urdf import URDF
+
+    if isinstance(urdf, str):
+        urdf = URDF.load(urdf)
+
+    out_dir = os.path.dirname(os.path.abspath(out_path)) or "."
+    if mesh_dir is None:
+        mesh_dir = os.path.join(out_dir, "assets")
+    assets = _MeshAssets(mesh_dir)
+
+    # children map: parent link name -> [joints]
+    children_map = {}
+    for joint in urdf.joints:
+        children_map.setdefault(joint.parent, []).append(joint)
+
+    root = ET.Element("mujoco", {"model": urdf.name or "robot"})
+    ET.SubElement(root, "compiler", {
+        "angle": "radian", "autolimits": "true",
+        "meshdir": os.path.relpath(mesh_dir, out_dir)})
+    ET.SubElement(root, "option", {"gravity": _fmt(gravity)})
+
+    # A little rotor inertia (armature) and damping on every joint models real
+    # geared servos and keeps velocity/position actuators numerically stable --
+    # bare URDF inertias are often too small for a stiff servo at these timesteps.
+    if joint_armature or joint_damping:
+        default = ET.SubElement(root, "default")
+        jd = {}
+        if joint_armature:
+            jd["armature"] = "{:.9g}".format(joint_armature)
+        if joint_damping:
+            jd["damping"] = "{:.9g}".format(joint_damping)
+        ET.SubElement(default, "joint", jd)
+
+    asset_el = ET.SubElement(root, "asset")
+    worldbody = ET.SubElement(root, "worldbody")
+    if add_ground:
+        ET.SubElement(worldbody, "light", {"pos": "0 0 3", "dir": "0 0 -1",
+                                           "directional": "true"})
+        ET.SubElement(worldbody, "geom", {"name": "ground", "type": "plane",
+                                          "size": "5 5 0.1", "rgba": "0.8 0.8 0.8 1"})
+
+    base_link = urdf.base_link
+    if base_link.name == "world":
+        # URDF virtual root: MuJoCo already has a built-in "world" body, so don't
+        # create another (would collide); attach the base link's children to it.
+        base_body = worldbody
+    else:
+        base_body = ET.SubElement(worldbody, "body",
+                                  {"name": base_link.name, "pos": "0 0 0"})
+        if floating_base:
+            ET.SubElement(base_body, "freejoint", {"name": "floating_base"})
+        _emit_link_content(base_link, base_body, assets)
+    actuated = []
+    for child_joint in children_map.get(base_link.name, []):
+        child_link = urdf.link_map[child_joint.child]
+        _emit_body(child_link, child_joint, urdf, assets, children_map,
+                   base_body, actuated)
+
+    # mesh assets
+    for name, fname, scale in assets.entries:
+        attrs = {"name": name, "file": fname}
+        if scale is not None:
+            attrs["scale"] = _fmt(scale)
+        ET.SubElement(asset_el, "mesh", attrs)
+
+    # mimic joints -> equality constraints
+    mimic_joints = [j for j in urdf.joints
+                    if getattr(j, "mimic", None) is not None]
+    if mimic_joints:
+        eq = ET.SubElement(root, "equality")
+        for j in mimic_joints:
+            m = j.mimic
+            ET.SubElement(eq, "joint", {
+                "joint1": j.name, "joint2": m.joint,
+                "polycoef": _fmt([m.offset, m.multiplier, 0, 0, 0])})
+
+    # actuators
+    # One actuator per actuated joint. actuator_type selects the operating mode:
+    #   position -> <position kp>  (joint tracks a target angle)
+    #   velocity -> <velocity kv>  (joint tracks a target rate)
+    #   motor    -> <motor>        (direct torque/force command)
+    if add_position_actuators and actuated:
+        act = ET.SubElement(root, "actuator")
+        for j in actuated:
+            limit = getattr(j, "limit", None)
+            has_pos_range = (j.joint_type != "continuous" and limit is not None
+                             and limit.lower is not None and limit.upper is not None)
+            a = {"name": j.name + "_act", "joint": j.name}
+            if actuator_type == "velocity":
+                a["kv"] = "{:.9g}".format(actuator_kv)
+                if limit is not None and getattr(limit, "velocity", None):
+                    a["ctrlrange"] = _fmt([-limit.velocity, limit.velocity])
+                ET.SubElement(act, "velocity", a)
+            elif actuator_type == "motor":
+                if limit is not None and getattr(limit, "effort", None):
+                    a["ctrlrange"] = _fmt([-limit.effort, limit.effort])
+                ET.SubElement(act, "motor", a)
+            else:  # position
+                a["kp"] = "{:.9g}".format(actuator_kp)
+                if has_pos_range:
+                    a["ctrlrange"] = _fmt([limit.lower, limit.upper])
+                ET.SubElement(act, "position", a)
+
+    _indent(root)
+    tree = ET.ElementTree(root)
+    tree.write(out_path, encoding="unicode", xml_declaration=False)
+    return ET.tostring(root, encoding="unicode")
+
+
+def _inertial_attrib(inertial):
+    """Return MJCF <inertial> attributes as pos + mass + diaginertia + quat,
+    regularizing the tensor so MuJoCo accepts it (positive eigenvalues and the
+    triangle inequality, both of which raw URDF inertias frequently violate)."""
+    origin = np.asarray(getattr(inertial, "origin", np.eye(4)), dtype=float)
+    pos = origin[:3, 3]
+    rot = origin[:3, :3]
+    inertia = rot @ np.asarray(inertial.inertia, dtype=float) @ rot.T
+    inertia = 0.5 * (inertia + inertia.T)               # symmetrize
+    moments, axes = np.linalg.eigh(inertia)             # ascending, orthonormal cols
+    if np.linalg.det(axes) < 0:                         # make it a proper rotation
+        axes[:, 0] = -axes[:, 0]
+    moments = np.clip(moments, 1e-9, None)              # positive-definite
+    lo, mid, hi = moments                               # ascending
+    if hi > lo + mid:                                   # triangle inequality
+        hi = lo + mid
+    moments = np.array([lo, mid, hi])
+    from skrobot.coordinates.math import matrix2quaternion
+    quat = matrix2quaternion(axes)                      # principal-axes frame [wxyz]
+    return {
+        "pos": _fmt(pos),
+        "mass": "{:.9g}".format(float(inertial.mass)),
+        "diaginertia": _fmt(moments),
+        "quat": _fmt(quat),
+    }
+
+
+def _emit_link_content(link, body_el, assets):
+    inertial = getattr(link, "inertial", None)
+    if inertial is not None and getattr(inertial, "mass", 0.0):
+        try:
+            ET.SubElement(body_el, "inertial", _inertial_attrib(inertial))
+        except Exception:
+            pass  # degenerate inertial -> let MuJoCo infer from geoms
+    for vis in getattr(link, "visuals", []) or []:
+        _add_geom(body_el, vis, assets, collision=False, rgba=_visual_rgba(vis))
+    for col in getattr(link, "collisions", []) or []:
+        _add_geom(body_el, col, assets, collision=True)
+
+
+def _indent(elem, level=0):
+    pad = "\n" + "  " * level
+    if len(elem):
+        if not (elem.text or "").strip():
+            elem.text = pad + "  "
+        for child in elem:
+            _indent(child, level + 1)
+        if not (elem.tail or "").strip():
+            elem.tail = pad
+        if not (child.tail or "").strip():
+            child.tail = pad
+    elif level and not (elem.tail or "").strip():
+        elem.tail = pad

--- a/skrobot/utils/mjcf_converter.py
+++ b/skrobot/utils/mjcf_converter.py
@@ -149,8 +149,17 @@ class _MeshAssets:
         return out
 
 
-def _add_geom(parent_el, visual_or_collision, assets, *, collision, rgba=None):
-    """Emit one <geom> for a Visual/Collision; return True if emitted."""
+def _add_geom(parent_el, visual_or_collision, assets, *, collision, rgba=None,
+              name_prefix=None, name_counter=None):
+    """Emit one <geom> for a Visual/Collision; return True if emitted.
+
+    ``name_prefix`` (normally the link name) makes every geom addressable by
+    name, following the MuJoCo convention ``<link>_collision<N>`` /
+    ``<link>_visual<N>``. Tools commonly select geoms by name (e.g. to enable
+    contact only on the feet, or to attach a contact sensor), and such filtering
+    silently breaks down on a model whose geoms are all unnamed. Emitting a
+    unique name for each geom keeps the model addressable.
+    """
     geom = getattr(visual_or_collision, "geometry", None)
     if geom is None:
         return False
@@ -160,6 +169,17 @@ def _add_geom(parent_el, visual_or_collision, assets, *, collision, rgba=None):
     pos, quat = matrix2translation_quaternion_wxyz(origin)
 
     base_attrib = {"pos": _fmt(pos), "quat": _fmt(quat)}
+
+    def _named(attrib):
+        """Attach a unique ``<link>_collision<N>`` / ``<link>_visual<N>`` name."""
+        if name_prefix is None:
+            return attrib
+        kind = "collision" if collision else "visual"
+        index = 0 if name_counter is None else name_counter[kind]
+        if name_counter is not None:
+            name_counter[kind] += 1
+        return dict(attrib, name="{}_{}{}".format(name_prefix, kind, index))
+
     if collision:
         base_attrib["group"] = "3"
     else:
@@ -173,20 +193,20 @@ def _add_geom(parent_el, visual_or_collision, assets, *, collision, rgba=None):
                  size=_fmt(np.asarray(geom.box.size, dtype=float) / 2.0))
         if rgba is not None:
             a["rgba"] = _fmt(rgba)
-        ET.SubElement(parent_el, "geom", a)
+        ET.SubElement(parent_el, "geom", _named(a))
         return True
     if geom.cylinder is not None:
         a = dict(base_attrib, type="cylinder",
                  size=_fmt([geom.cylinder.radius, geom.cylinder.length / 2.0]))
         if rgba is not None:
             a["rgba"] = _fmt(rgba)
-        ET.SubElement(parent_el, "geom", a)
+        ET.SubElement(parent_el, "geom", _named(a))
         return True
     if geom.sphere is not None:
         a = dict(base_attrib, type="sphere", size=_fmt([geom.sphere.radius]))
         if rgba is not None:
             a["rgba"] = _fmt(rgba)
-        ET.SubElement(parent_el, "geom", a)
+        ET.SubElement(parent_el, "geom", _named(a))
         return True
     if geom.mesh is not None:
         if collision and getattr(assets, "convex_decompose", False):
@@ -201,7 +221,7 @@ def _add_geom(parent_el, visual_or_collision, assets, *, collision, rgba=None):
             eff = rgba if rgba is not None else mesh_color
             if eff is not None:
                 a["rgba"] = _fmt(eff)
-            ET.SubElement(parent_el, "geom", a)
+            ET.SubElement(parent_el, "geom", _named(a))
         return True
     return False
 
@@ -214,14 +234,24 @@ def _visual_rgba(visual):
 
 
 def _emit_body(link, joint_from_parent, urdf, assets, children_map,
-               parent_el, actuated, qpos_layout):
-    """Recursively emit <body> for `link` under `parent_el`."""
+               parent_el, actuated, qpos_layout, add_free_joint=False):
+    """Recursively emit <body> for `link` under `parent_el`.
+
+    When ``add_free_joint`` is True a ``<freejoint>`` is emitted on this body,
+    turning it into a floating base. This is used when the URDF root is a
+    virtual ``world`` link whose single child (the real base, e.g. a torso) is
+    attached by a fixed joint: with ``floating_base`` the weld must become a
+    free joint instead. Recursive children always default to False.
+    """
     body_attrib = {"name": link.name}
     if joint_from_parent is not None:
         pos, quat = matrix2translation_quaternion_wxyz(joint_from_parent.origin)
         body_attrib["pos"] = _fmt(pos)
         body_attrib["quat"] = _fmt(quat)
     body = ET.SubElement(parent_el, "body", body_attrib)
+
+    if add_free_joint:
+        ET.SubElement(body, "freejoint", {"name": "floating_base"})
 
     # joint (movable only; fixed joint -> no <joint> element = weld)
     if joint_from_parent is not None and joint_from_parent.joint_type != "fixed":
@@ -365,10 +395,24 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
 
     base_link = urdf.base_link
     has_free_joint = False
+    free_world_children = False
     if base_link.name == "world":
         # URDF virtual root: MuJoCo already has a built-in "world" body, so don't
         # create another (would collide); attach the base link's children to it.
         base_body = worldbody
+        if floating_base:
+            world_children = children_map.get(base_link.name, [])
+            if len(world_children) == 1:
+                # The single real base (torso) is welded to `world` by a fixed
+                # joint; with floating_base that weld must become a free joint.
+                free_world_children = True
+                has_free_joint = True
+            else:
+                import warnings
+                warnings.warn(
+                    "floating_base requested but URDF root 'world' has "
+                    "{} children; leaving the base welded (a single floating "
+                    "base is ambiguous).".format(len(world_children)))
     else:
         base_body = ET.SubElement(worldbody, "body",
                                   {"name": base_link.name, "pos": "0 0 0"})
@@ -381,7 +425,8 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
     for child_joint in children_map.get(base_link.name, []):
         child_link = urdf.link_map[child_joint.child]
         _emit_body(child_link, child_joint, urdf, assets, children_map,
-                   base_body, actuated, qpos_layout)
+                   base_body, actuated, qpos_layout,
+                   add_free_joint=free_world_children)
 
     # mesh assets
     for name, fname, scale in assets.entries:
@@ -487,10 +532,15 @@ def _emit_link_content(link, body_el, assets):
             ET.SubElement(body_el, "inertial", _inertial_attrib(inertial))
         except Exception:
             pass  # degenerate inertial -> let MuJoCo infer from geoms
+    # One counter per link so names are unique and stable across sub-meshes.
+    counter = {"visual": 0, "collision": 0}
+    link_name = getattr(link, "name", None)
     for vis in getattr(link, "visuals", []) or []:
-        _add_geom(body_el, vis, assets, collision=False, rgba=_visual_rgba(vis))
+        _add_geom(body_el, vis, assets, collision=False, rgba=_visual_rgba(vis),
+                  name_prefix=link_name, name_counter=counter)
     for col in getattr(link, "collisions", []) or []:
-        _add_geom(body_el, col, assets, collision=True)
+        _add_geom(body_el, col, assets, collision=True,
+                  name_prefix=link_name, name_counter=counter)
 
 
 def _indent(elem, level=0):

--- a/skrobot/utils/mjcf_converter.py
+++ b/skrobot/utils/mjcf_converter.py
@@ -165,7 +165,7 @@ def _visual_rgba(visual):
 
 
 def _emit_body(link, joint_from_parent, urdf, assets, children_map,
-               parent_el, actuated):
+               parent_el, actuated, qpos_layout):
     """Recursively emit <body> for `link` under `parent_el`."""
     body_attrib = {"name": link.name}
     if joint_from_parent is not None:
@@ -188,6 +188,9 @@ def _emit_body(link, joint_from_parent, urdf, assets, children_map,
                 limit.lower is not None and limit.upper is not None:
             j["range"] = _fmt([limit.lower, limit.upper])
         ET.SubElement(body, "joint", j)
+        # every movable joint (mimic included) contributes one qpos entry, in
+        # this creation order -- used to lay out the optional home keyframe.
+        qpos_layout.append(joint_from_parent.name)
         if joint_from_parent.mimic is None:
             actuated.append(joint_from_parent)
 
@@ -197,14 +200,16 @@ def _emit_body(link, joint_from_parent, urdf, assets, children_map,
     for child_joint in children_map.get(link.name, []):
         child_link = urdf.link_map[child_joint.child]
         _emit_body(child_link, child_joint, urdf, assets, children_map,
-                   body, actuated)
+                   body, actuated, qpos_layout)
 
 
 def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
                  add_position_actuators=True, actuator_kp=50.0,
                  actuator_type="position", actuator_kv=1.0,
                  joint_armature=0.0, joint_damping=0.0,
-                 add_ground=True, gravity=(0, 0, -9.81)):
+                 add_ground=True, gravity=(0, 0, -9.81),
+                 self_collision=False, add_actuator_forcerange=True,
+                 home=None, home_base_height=0.0):
     """Convert a URDF to an MJCF file.
 
     Parameters
@@ -222,6 +227,24 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
         Proportional gain for the position actuators.
     add_ground : bool
         Add a ground plane + light for a usable scene.
+    self_collision : bool
+        If False (default) the robot's collision geoms are put on a
+        ``contype=2 conaffinity=1`` mask while the ground stays ``1/1``, so the
+        robot collides with the ground but *not with itself*. Legged-locomotion
+        training almost always wants this off unless an explicit adjacency
+        filter is provided -- self intersections of neighbouring links cause
+        spawn-time blow-ups. Set True to keep full self-collision.
+    add_actuator_forcerange : bool
+        If True (default) position/velocity actuators get a ``forcerange`` taken
+        from the URDF joint effort limit, so RL policies cannot command
+        physically impossible torques (a classic "the humanoid flies" exploit).
+    home : dict[str, float] or None
+        Optional joint-name -> angle (rad) map. When given, a ``<keyframe>``
+        named ``home`` is emitted so callers can reset to a known stable pose.
+        Joints absent from the map default to 0.
+    home_base_height : float
+        Base-link height (m) used for the free-joint part of the home keyframe
+        when ``floating_base`` is True.
 
     Returns
     -------
@@ -252,14 +275,22 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
     # A little rotor inertia (armature) and damping on every joint models real
     # geared servos and keeps velocity/position actuators numerically stable --
     # bare URDF inertias are often too small for a stiff servo at these timesteps.
-    if joint_armature or joint_damping:
+    if joint_armature or joint_damping or not self_collision:
         default = ET.SubElement(root, "default")
-        jd = {}
-        if joint_armature:
-            jd["armature"] = "{:.9g}".format(joint_armature)
-        if joint_damping:
-            jd["damping"] = "{:.9g}".format(joint_damping)
-        ET.SubElement(default, "joint", jd)
+        if joint_armature or joint_damping:
+            jd = {}
+            if joint_armature:
+                jd["armature"] = "{:.9g}".format(joint_armature)
+            if joint_damping:
+                jd["damping"] = "{:.9g}".format(joint_damping)
+            ET.SubElement(default, "joint", jd)
+        if not self_collision:
+            # Default mask for every geom: contype=2 conaffinity=1. Collision
+            # geoms inherit it; the ground overrides to 1/1 below and visual
+            # geoms override to 0/0. Two robot geoms (2/1 vs 2/1) then never
+            # collide, while robot(2/1)-vs-ground(1/1) does.
+            ET.SubElement(default, "geom",
+                          {"contype": "2", "conaffinity": "1"})
 
     asset_el = ET.SubElement(root, "asset")
     worldbody = ET.SubElement(root, "worldbody")
@@ -267,9 +298,12 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
         ET.SubElement(worldbody, "light", {"pos": "0 0 3", "dir": "0 0 -1",
                                            "directional": "true"})
         ET.SubElement(worldbody, "geom", {"name": "ground", "type": "plane",
-                                          "size": "5 5 0.1", "rgba": "0.8 0.8 0.8 1"})
+                                          "size": "5 5 0.1",
+                                          "contype": "1", "conaffinity": "1",
+                                          "rgba": "0.8 0.8 0.8 1"})
 
     base_link = urdf.base_link
+    has_free_joint = False
     if base_link.name == "world":
         # URDF virtual root: MuJoCo already has a built-in "world" body, so don't
         # create another (would collide); attach the base link's children to it.
@@ -279,12 +313,14 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
                                   {"name": base_link.name, "pos": "0 0 0"})
         if floating_base:
             ET.SubElement(base_body, "freejoint", {"name": "floating_base"})
+            has_free_joint = True
         _emit_link_content(base_link, base_body, assets)
     actuated = []
+    qpos_layout = []  # ordered movable-joint names, for the home keyframe
     for child_joint in children_map.get(base_link.name, []):
         child_link = urdf.link_map[child_joint.child]
         _emit_body(child_link, child_joint, urdf, assets, children_map,
-                   base_body, actuated)
+                   base_body, actuated, qpos_layout)
 
     # mesh assets
     for name, fname, scale in assets.entries:
@@ -316,20 +352,39 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
             has_pos_range = (j.joint_type != "continuous" and limit is not None
                              and limit.lower is not None and limit.upper is not None)
             a = {"name": j.name + "_act", "joint": j.name}
+            effort = getattr(limit, "effort", None) if limit is not None else None
             if actuator_type == "velocity":
                 a["kv"] = "{:.9g}".format(actuator_kv)
                 if limit is not None and getattr(limit, "velocity", None):
                     a["ctrlrange"] = _fmt([-limit.velocity, limit.velocity])
+                if add_actuator_forcerange and effort:
+                    a["forcerange"] = _fmt([-effort, effort])
                 ET.SubElement(act, "velocity", a)
             elif actuator_type == "motor":
-                if limit is not None and getattr(limit, "effort", None):
-                    a["ctrlrange"] = _fmt([-limit.effort, limit.effort])
+                if effort:
+                    a["ctrlrange"] = _fmt([-effort, effort])
                 ET.SubElement(act, "motor", a)
             else:  # position
                 a["kp"] = "{:.9g}".format(actuator_kp)
                 if has_pos_range:
                     a["ctrlrange"] = _fmt([limit.lower, limit.upper])
+                # Cap the torque a position servo can apply to the real motor's
+                # effort limit, so an RL policy cannot exploit unbounded torque
+                # (the classic "small humanoid learns to fly" failure).
+                if add_actuator_forcerange and effort:
+                    a["forcerange"] = _fmt([-effort, effort])
                 ET.SubElement(act, "position", a)
+
+    # home keyframe: qpos = [free-joint (7)] + one entry per movable joint,
+    # in creation order (qpos_layout). Joints absent from `home` default to 0.
+    if home is not None:
+        qpos = []
+        if has_free_joint:
+            qpos += [0.0, 0.0, float(home_base_height), 1.0, 0.0, 0.0, 0.0]
+        for jname in qpos_layout:
+            qpos.append(float(home.get(jname, 0.0)))
+        key_el = ET.SubElement(root, "keyframe")
+        ET.SubElement(key_el, "key", {"name": "home", "qpos": _fmt(qpos)})
 
     _indent(root)
     tree = ET.ElementTree(root)

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -20,6 +20,8 @@ from skrobot.coordinates.math import look_at_rotation
 from skrobot.coordinates.math import matrix2quaternion
 from skrobot.coordinates.math import matrix2rotation_translation
 from skrobot.coordinates.math import matrix2rpy
+from skrobot.coordinates.math import matrix2translation_quaternion_wxyz
+from skrobot.coordinates.math import matrix2translation_quaternion_xyzw
 from skrobot.coordinates.math import matrix2xyzrpy
 from skrobot.coordinates.math import matrix2ypr
 from skrobot.coordinates.math import matrix_relative
@@ -1135,6 +1137,23 @@ class TestMath(unittest.TestCase):
             r_xyz, r_rpy = matrix2xyzrpy(mat)
             testing.assert_almost_equal(r_xyz, xyz)
             testing.assert_almost_equal(r_rpy, rpy)
+
+    def test_matrix2translation_quaternion(self):
+        rng = np.random.RandomState(3)
+        for _ in range(50):
+            xyz = rng.uniform(-5, 5, 3)
+            rpy = rng.uniform(-1, 1, 3)
+            mat = xyzrpy2matrix(xyz, rpy)
+
+            translation, quat_wxyz = matrix2translation_quaternion_wxyz(mat)
+            testing.assert_almost_equal(translation, xyz)
+            self.assertEqual(quat_wxyz.shape, (4,))
+            testing.assert_almost_equal(
+                quaternion2matrix(quat_wxyz), mat[:3, :3])
+
+            translation, quat_xyzw = matrix2translation_quaternion_xyzw(mat)
+            testing.assert_almost_equal(translation, xyz)
+            testing.assert_almost_equal(quat_xyzw, wxyz2xyzw(quat_wxyz))
 
     def test_rt2matrix_matrix2rt_round_trip(self):
         rng = np.random.RandomState(7)


### PR DESCRIPTION
Adds `skrobot.urdf.urdf_to_mjcf` (plus a `convert-urdf-to-mjcf` CLI) that walks a parsed URDF and emits an MJCF MuJoCo can load directly: fixed joints as welds, mimic joints as equality constraints, meshes exported to binary STL with decimation, regularized inertials, and per-joint position actuators.

Options cover the things a legged-locomotion model usually needs: self-collision off by default, actuator `forcerange` taken from the URDF effort limit, an optional `home` keyframe, and optional CoACD convex decomposition of collision meshes. Every geom is emitted with a unique name so tools can select geoms by name.

Also adds the Unitree G1 model (`skrobot.models.g1`).