### PR TITLE
Fix release workflow: use Python 3.10 for tag-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Wait for apt-get lock
         run: |


### PR DESCRIPTION
The package now requires Python >=3.10 (python_requires in setup.py), but the tag-release job set up Python 3.9, causing 'pip install .[all]' to fail with an incompatible-Python error.