### PR TITLE
Rewrite mesh package references in config bundle export

### DIFF
--- a/skrobot/urdf/ros_config/export.py
+++ b/skrobot/urdf/ros_config/export.py
@@ -15,6 +15,7 @@ from skrobot.urdf.ros_config.gazebo_generator import generate_gazebo_config
 from skrobot.urdf.ros_config.gazebo_generator import generate_ros2_control_xacro
 from skrobot.urdf.ros_config.moveit_generator import generate_controllers_yaml
 from skrobot.urdf.ros_config.moveit_generator import generate_srdf
+from skrobot.urdf.ros_package import rewrite_mesh_package_references
 
 
 def export_all_configs(
@@ -72,9 +73,13 @@ def export_all_configs(
     zip_buffer = io.BytesIO()
 
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-        # URDF (original)
+        # URDF (mesh package references rewritten to this package name so
+        # the bundle is self-contained under ``{robot_name}/``)
         if export_options.get("includeUrdf", True):
-            zf.writestr(f"{robot_name}/urdf/{robot_name}.urdf", urdf_content)
+            zf.writestr(
+                f"{robot_name}/urdf/{robot_name}.urdf",
+                rewrite_mesh_package_references(urdf_content, robot_name),
+            )
 
         # MoveIt SRDF and controllers
         if export_options.get("includeMoveIt", True):

--- a/skrobot/urdf/ros_package.py
+++ b/skrobot/urdf/ros_package.py
@@ -536,3 +536,30 @@ def replace_package_references(content, old_package, new_package):
     content = re.sub(r'\$\(find {}\)'.format(escaped),
                      '$(find {})'.format(new_package), content)
     return content
+
+
+def rewrite_mesh_package_references(urdf_content, package_name):
+    """Rewrite mesh ``package://`` references to a target package name.
+
+    Replaces the package portion of every
+    ``package://<any>/meshes/...`` reference with ``package_name``,
+    regardless of the original package name.  Unlike
+    :func:`replace_package_references`, the original name does not need
+    to be known -- this is useful when bundling a URDF into a freshly
+    named package whose meshes live under ``<package_name>/meshes/``.
+
+    Parameters
+    ----------
+    urdf_content : str
+        URDF XML content.
+    package_name : str
+        Target ROS package name.
+
+    Returns
+    -------
+    str
+        URDF with rewritten mesh package references.
+    """
+    return re.sub(r'package://[^/]+/meshes/',
+                  'package://{}/meshes/'.format(package_name),
+                  urdf_content)

--- a/tests/skrobot_tests/urdf_tests/test_ros_config.py
+++ b/tests/skrobot_tests/urdf_tests/test_ros_config.py
@@ -116,6 +116,33 @@ class TestExportAllConfigs(unittest.TestCase):
                 'two_link/urdf/ros2_control.xacro').decode('utf-8')
             self.assertIn('$(find two_link)/config/controllers.yaml', xacro)
 
+    def test_zip_bundle_rewrites_mesh_package(self):
+        # mesh references to a foreign package must be rewritten to the
+        # bundle's own package name so the archive is self-contained
+        urdf = (
+            '<?xml version="1.0"?>\n'
+            '<robot name="two_link">\n'
+            '  <link name="base_link">\n'
+            '    <visual><geometry>'
+            '<mesh filename="package://foreign_pkg/meshes/base.stl"/>'
+            '</geometry></visual>\n'
+            '  </link>\n'
+            '</robot>\n')
+        blob = export_all_configs(
+            urdf_content=urdf,
+            joints=[],
+            planning_groups=[],
+            controllers=[],
+            disabled_collision_pairs=[],
+            gazebo_physics={'gravity': [0, 0, -9.81]},
+            gazebo_plugins=[],
+            robot_name='two_link')
+        with zipfile.ZipFile(io.BytesIO(blob)) as archive:
+            urdf_out = archive.read(
+                'two_link/urdf/two_link.urdf').decode('utf-8')
+            self.assertIn('package://two_link/meshes/base.stl', urdf_out)
+            self.assertNotIn('foreign_pkg', urdf_out)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/skrobot_tests/urdf_tests/test_ros_package.py
+++ b/tests/skrobot_tests/urdf_tests/test_ros_package.py
@@ -12,6 +12,7 @@ from skrobot.urdf.ros_package import generate_ros1_display_launch
 from skrobot.urdf.ros_package import generate_ros1_display_package_xml
 from skrobot.urdf.ros_package import generate_ros1_rviz_config
 from skrobot.urdf.ros_package import replace_package_references
+from skrobot.urdf.ros_package import rewrite_mesh_package_references
 
 
 class TestPackageSkeleton(unittest.TestCase):
@@ -107,6 +108,24 @@ class TestResourceReferences(unittest.TestCase):
         self.assertIn('package://not_old_pkg/m.stl', out)
         self.assertIn('package://new_pkg/m.stl', out)
         self.assertTrue(out.endswith(' old_pkg'))
+
+    def test_rewrite_mesh_package_references(self):
+        # every mesh reference must point at the target package, regardless
+        # of the (possibly differing) original package names
+        content = ('a="package://foo/meshes/x.stl" '
+                   'b="package://bar/meshes/sub/y.dae"')
+        out = rewrite_mesh_package_references(content, 'robot')
+        self.assertIn('package://robot/meshes/x.stl', out)
+        self.assertIn('package://robot/meshes/sub/y.dae', out)
+        self.assertNotIn('package://foo/', out)
+        self.assertNotIn('package://bar/', out)
+
+    def test_rewrite_mesh_package_references_leaves_non_meshes(self):
+        # references outside meshes/ (e.g. textures) are left untouched
+        content = 'package://foo/materials/t.png package://foo/meshes/a.stl'
+        out = rewrite_mesh_package_references(content, 'robot')
+        self.assertIn('package://foo/materials/t.png', out)
+        self.assertIn('package://robot/meshes/a.stl', out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add rewrite_mesh_package_references helper and apply it to the URDF written by export_all_configs so mesh package:// references point at the bundle's own package name, keeping the archive self-contained.