### PR TITLE
Start the griphis base below the wall contacts

### DIFF
--- a/examples/griphis_wall_climb.py
+++ b/examples/griphis_wall_climb.py
@@ -68,6 +68,15 @@ ARC_SUBSTEPS = 20
 END1_START_XZ = np.array([0.10, 0.00])   # (x, z)
 END2_START_XZ = np.array([-0.10, 0.00])
 
+# How far below the wall contacts the base starts before the initial IK.
+# Two 4-DoF arms plus a 6-DoF base give 14 DoF against 12 constraints, so
+# the initial pose is not unique: the base can hang below the contacts or
+# sit above them, and the upper solution self-collides.  The default base
+# pose sits on the watershed between the two, which lets rounding decide
+# -- a different BLAS kernel or NumPy build then picks the colliding one.
+# Starting below the contacts commits to the hanging solution.
+BASE_START_DROP = 0.05
+
 _FULL_MASK_PAIR = [np.array([1, 1, 1]), np.array([1, 1, 1])]
 
 
@@ -141,9 +150,14 @@ def solve_initial_pose(robot, end1, end2):
     Seeds the yaw joints with ±90° so each gripper already faces the wall
     (+X → +Y) before the solver runs; without this seed the solver tends
     to stall in a local minimum with both arms extended sideways (±X).
+
+    Also drops the base below the contacts by ``BASE_START_DROP`` so the
+    solver commits to the hanging solution rather than the self-colliding
+    one above them.
     """
     robot.yaw_1.joint_angle(-np.pi / 2)
     robot.yaw_2.joint_angle(np.pi / 2)
+    robot.translate(np.array([0.0, 0.0, -BASE_START_DROP]), wrt='world')
 
     t1 = wall_contact_coords(END1_START_XZ)
     t2 = wall_contact_coords(END2_START_XZ)


### PR DESCRIPTION
`test_example[griphis_wall_climb.py]` fails on some CI runners with `initial pose is self-colliding (1 pairs, min=-0.5mm)`. Not flaky within a run — all retries agree; it is the runner that decides.

The initial pose has 14 DoF against 12 constraints, so it is not unique: the base can hang below the wall contacts or sit above them, and the upper solution self-collides. The default base pose sits on the watershed between the two, so rounding picks the basin. Reproduced locally by nudging the base up before the solve: it lands at base_z=+0.074 with -1.7mm, matching the failing runner.

Starting 5cm below the contacts commits to the hanging solution, which leaves ~5cm of margin to the watershed instead of none. This makes the example robust, it does not remove the redundancy — a real fix would constrain the null space or put collision avoidance in the IK.