### PR TITLE
Share the URDF mesh conversion between the CLI and the builder

### DIFF
--- a/skrobot/apps/convert_urdf_mesh.py
+++ b/skrobot/apps/convert_urdf_mesh.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import argparse
-import contextlib
 import os.path as osp
 from pathlib import Path
 import shutil
@@ -11,14 +10,11 @@ from lxml import etree
 from packaging.version import Version
 
 from skrobot import determine_version
-from skrobot.model import RobotModel
 from skrobot.urdf.modularize_urdf import find_root_link
 from skrobot.urdf.modularize_urdf import print_xacro_usage_instructions
 from skrobot.urdf.modularize_urdf import transform_urdf_to_macro
 from skrobot.utils.package import is_package_installed
-from skrobot.utils.urdf import apply_scale
-from skrobot.utils.urdf import export_mesh_format
-from skrobot.utils.urdf import force_visual_mesh_origin_to_zero
+from skrobot.utils.urdf import convert_urdf_meshes
 from skrobot.utils.urdf import source_urdf_path
 
 
@@ -181,55 +177,33 @@ def _process_urdf(urdf_file, args):
     else:
         output_path = Path(args.output)
 
-    if args.force_zero_origin:
-        force_visual_mesh_origin_to_zero_or_not = \
-            force_visual_mesh_origin_to_zero
-    else:
-        try:
-            from contextlib import nullcontext
-        except ImportError:
-            # for python3.6
-            @contextlib.contextmanager
-            def nullcontext(enter_result=None):
-                yield enter_result
-        force_visual_mesh_origin_to_zero_or_not = nullcontext
-
-    # Convert to absolute path to ensure correct mesh resolution
-    urdf_path_abs = urdf_path.resolve()
-
-    with force_visual_mesh_origin_to_zero_or_not():
-        print(f"Loading URDF from: {urdf_path}")
-        try:
-            r = RobotModel.from_urdf(str(urdf_path_abs))
-        except Exception as e:
-            print(f"[ERROR] Failed to load URDF: {e}")
-            return
-
-    # Verify that the robot model has valid links
-    if r.urdf_robot_model is None or not hasattr(r.urdf_robot_model, 'links') or len(r.urdf_robot_model.links) == 0:
-        print("[ERROR] URDF does not contain any valid links. Cannot proceed.")
-        return
-
-    with export_mesh_format(
+    print(f"Loading URDF from: {urdf_path}")
+    print(f"Saving new URDF to: {output_path}")
+    try:
+        convert_urdf_meshes(
+            urdf_path,
+            output_path,
             '.' + args.format,
+            collision_mesh_format='.' + args.collision_mesh_format,
+            scale=args.scale,
+            force_zero_visual_origin=args.force_zero_origin,
             decimation_area_ratio_threshold=args.decimation_area_ratio_threshold,  # NOQA
             simplify_vertex_clustering_voxel_size=args.voxel_size,
             target_triangles=args.target_triangles,
             overwrite_mesh=args.overwrite_mesh,
-            collision_mesh_format='.' + args.collision_mesh_format,
             blender_remesh=args.blender_remesh,
             blender_voxel_size=args.blender_voxel_size,
             blender_decimate=args.blender_decimate,
             blender_decimate_ratio=args.blender_decimate_ratio,
             blender_executable=args.blender_executable,
             remeshed_suffix=args.remeshed_suffix,
-            draco_compression=args.draco), apply_scale(args.scale):
-        print(f"Saving new URDF to: {output_path}")
-        # Ensure output directory exists
-        output_dir = output_path.parent
-        if not output_dir.exists():
-            output_dir.mkdir(parents=True, exist_ok=True)
-        r.urdf_robot_model.save(str(output_path))
+            draco_compression=args.draco)
+    except ValueError as e:
+        print(f"[ERROR] {e}")
+        return
+    except Exception as e:
+        print(f"[ERROR] Failed to convert URDF: {e}")
+        return
 
     if args.inplace:
         print(f"Moving {output_path} to {urdf_path} (inplace)")

--- a/skrobot/urdf/ros_config/moveit_package.py
+++ b/skrobot/urdf/ros_config/moveit_package.py
@@ -358,27 +358,23 @@ def _convert_urdf_meshes(urdf_path, output_path, visual_format="stl", collision_
         True if conversion succeeded.
     """
     try:
-        from skrobot.model import RobotModel
         from skrobot.utils.draco import is_dracopy_available
         from skrobot.utils.draco import register_dracopy_handlers
-        from skrobot.utils.urdf import apply_scale
-        from skrobot.utils.urdf import export_mesh_format
-        from skrobot.utils.urdf import source_urdf_path
+        from skrobot.utils.urdf import convert_urdf_meshes
 
+        # Registered globally so a .drc mesh referenced by the URDF can be
+        # read back while saving.
         if is_dracopy_available():
             register_dracopy_handlers()
 
         urdf_path = str(Path(urdf_path).resolve())
-
-        with source_urdf_path(str(Path(urdf_path).parent)):
-            r = RobotModel.from_urdf(urdf_path)
-
-            with export_mesh_format(
-                "." + visual_format,
-                collision_mesh_format="." + collision_format,
-                overwrite_mesh=True,
-            ), apply_scale(1.0):
-                r.urdf_robot_model.save(str(output_path))
+        convert_urdf_meshes(
+            urdf_path,
+            output_path,
+            "." + visual_format,
+            collision_mesh_format="." + collision_format,
+            overwrite_mesh=True,
+        )
 
         # Fix DAE up_axis: trimesh always writes Y_UP but mesh data is
         # in Z_UP (ROS convention).  Gazebo would apply an unwanted

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -180,6 +180,79 @@ def source_urdf_path(path):
         _CONFIGURABLE_VALUES['_source_urdf_path'] = previous
 
 
+def convert_urdf_meshes(urdf_path, output_path, mesh_format,
+                        collision_mesh_format=None, scale=1.0,
+                        force_zero_visual_origin=False, **export_options):
+    """Re-save a URDF with every mesh converted to another format.
+
+    Loads ``urdf_path`` and writes it to ``output_path`` inside an
+    :func:`export_mesh_format` context, so each referenced mesh is
+    written out in the requested format next to the new URDF. Mesh
+    filenames resolve against the input URDF's directory
+    (:func:`source_urdf_path`), which is what makes a URDF whose meshes
+    live beside it convertible to a different directory.
+
+    Parameters
+    ----------
+    urdf_path : str or pathlib.Path
+        Input URDF path.
+    output_path : str or pathlib.Path
+        Output URDF path. Parent directories are created.
+    mesh_format : str
+        Target format for visual meshes, with the leading dot
+        (``'.dae'``, ``'.stl'``, ``'.glb'``).
+    collision_mesh_format : str, optional
+        Target format for collision meshes, with the leading dot.
+        Defaults to ``mesh_format``.
+    scale : float
+        Scale applied while saving.
+    force_zero_visual_origin : bool
+        Move every visual mesh origin to zero while loading.
+    export_options : dict
+        Passed through to :func:`export_mesh_format` -- decimation,
+        remeshing, Draco compression and so on.
+
+    Returns
+    -------
+    str
+        ``output_path``, as a string.
+
+    Raises
+    ------
+    ValueError
+        If the URDF contains no links.
+    """
+    from skrobot.model import RobotModel
+
+    urdf_path = os.path.abspath(str(urdf_path))
+    output_path = str(output_path)
+
+    with source_urdf_path(os.path.dirname(urdf_path)):
+        origin_context = (force_visual_mesh_origin_to_zero()
+                          if force_zero_visual_origin
+                          else contextlib.nullcontext())
+        with origin_context:
+            robot = RobotModel.from_urdf(urdf_path)
+
+        urdf_robot_model = robot.urdf_robot_model
+        if urdf_robot_model is None or not getattr(
+                urdf_robot_model, 'links', None):
+            raise ValueError(
+                'URDF contains no links: {}'.format(urdf_path))
+
+        output_dir = os.path.dirname(output_path)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+
+        with export_mesh_format(
+                mesh_format,
+                collision_mesh_format=collision_mesh_format,
+                **export_options), apply_scale(scale):
+            urdf_robot_model.save(output_path)
+
+    return output_path
+
+
 def get_transparency(mesh):
     if hasattr(mesh, 'visual') and hasattr(mesh.visual, 'material'):
         material = mesh.visual.material


### PR DESCRIPTION
`convert-urdf-mesh` and the MoveIt package builder each had their own load-convert-save sequence: open the URDF as a `RobotModel`, re-save it inside an `export_mesh_format` context with mesh filenames resolving against the source directory. That sequence is now `skrobot.utils.urdf.convert_urdf_meshes` and both call it.

The builder gains the empty-links check the CLI had; the CLI now reports that case through the same path as any other failure. Line count is roughly flat — the point is one implementation of the sequence, not fewer lines.

Verified by converting panda.urdf before and after: byte-identical output URDF and 38 byte-identical meshes.