### PR TITLE
Let callers register and remove a single module

### DIFF
--- a/skrobot/assembly/module_registry.py
+++ b/skrobot/assembly/module_registry.py
@@ -65,16 +65,52 @@ class ModuleRegistry:
 
         for urdf_path in urdf_files:
             try:
-                self._register_urdf(urdf_path)
+                self.register_urdf(urdf_path)
             except Exception as e:
                 logger.warning("Failed to register %s: %s", urdf_path, e)
 
         return len(self._modules)
 
-    def _register_urdf(self, urdf_path: Path) -> None:
-        """Register a single URDF file."""
+    def register_urdf(self, urdf_path: Union[str, Path]) -> str:
+        """
+        Register a single URDF file.
+
+        Any module already registered under the same ID is replaced.
+
+        Parameters
+        ----------
+        urdf_path : str or Path
+            Path to the URDF file. Its filename stem becomes the module ID.
+
+        Returns
+        -------
+        str
+            The ID the module was registered under.
+        """
+        urdf_path = Path(urdf_path)
         module_id = urdf_path.stem
         self._modules[module_id] = RobotModule.from_urdf(module_id, str(urdf_path))
+        return module_id
+
+    def remove_module(self, module_id: str) -> bool:
+        """
+        Remove a module from the registry.
+
+        Parameters
+        ----------
+        module_id : str
+            The module identifier.
+
+        Returns
+        -------
+        bool
+            True if the module was registered, False otherwise.
+        """
+        return self._modules.pop(module_id, None) is not None
+
+    def _register_urdf(self, urdf_path: Path) -> None:
+        """Deprecated alias for :meth:`register_urdf`."""
+        self.register_urdf(urdf_path)
 
     def get_module(self, module_id: str) -> Optional[RobotModule]:
         """

--- a/tests/skrobot_tests/assembly_tests/test_module_registry.py
+++ b/tests/skrobot_tests/assembly_tests/test_module_registry.py
@@ -1,0 +1,75 @@
+import os
+import tempfile
+import unittest
+
+from skrobot.assembly import ModuleRegistry
+
+
+_MODULE_URDF = """<?xml version="1.0"?>
+<robot name="{name}">
+  <link name="base_link"/>
+  <link name="dummy_link1"/>
+  <joint name="j1" type="revolute">
+    <parent link="base_link"/>
+    <child link="dummy_link1"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1.0" upper="1.0" effort="1" velocity="1"/>
+  </joint>
+</robot>
+"""
+
+
+def _write_module(directory, name):
+    path = os.path.join(directory, name + '.urdf')
+    with open(path, 'w') as f:
+        f.write(_MODULE_URDF.format(name=name))
+    return path
+
+
+class TestModuleRegistry(unittest.TestCase):
+
+    def test_scan_registers_every_urdf(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_module(tmp, 'a')
+            _write_module(tmp, 'b')
+
+            registry = ModuleRegistry(tmp)
+
+            self.assertEqual(registry.scan(), 2)
+            self.assertEqual(sorted(registry.list_modules()), ['a', 'b'])
+
+    def test_register_urdf_adds_a_single_module(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_module(tmp, 'later')
+            registry = ModuleRegistry(tmp)
+
+            module_id = registry.register_urdf(path)
+
+            self.assertEqual(module_id, 'later')
+            self.assertIn('later', registry)
+            self.assertIsNotNone(registry.get_module('later'))
+            self.assertEqual(len(registry), 1)
+
+    def test_register_urdf_replaces_a_module_with_the_same_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_module(tmp, 'dup')
+            registry = ModuleRegistry(tmp)
+
+            registry.register_urdf(path)
+            first = registry.get_module('dup')
+            registry.register_urdf(path)
+
+            self.assertEqual(len(registry), 1)
+            self.assertIsNot(registry.get_module('dup'), first)
+
+    def test_remove_module_reports_whether_it_was_registered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_module(tmp, 'gone')
+            registry = ModuleRegistry(tmp)
+            registry.register_urdf(path)
+
+            self.assertTrue(registry.remove_module('gone'))
+            self.assertNotIn('gone', registry)
+            self.assertEqual(len(registry), 0)
+            self.assertFalse(registry.remove_module('gone'))


### PR DESCRIPTION
ModuleRegistry could only be filled by scanning a directory, so anything managing modules at runtime -- registering an uploaded URDF, dropping a deleted one -- had to reach into _modules and _register_urdf.

register_urdf() returns the module id it used and remove_module() reports whether the module was there; scan() now goes through the public method too.

_register_urdf stays as a deprecated alias so existing callers keep working until they migrate. ModuleRegistry had no tests, so this adds four.