### PR TITLE
Give ViserViewer the shared wait_until_close signature

### DIFF
--- a/docs/source/reference/viewers.rst
+++ b/docs/source/reference/viewers.rst
@@ -271,7 +271,7 @@ The following video demonstrates the interactive IK feature, where dragging the 
     # Open browser to view
     viewer.show()
 
-    # Block until the browser tab / window is closed
+    # Block until the viser server is stopped (Ctrl-C or viewer.close()).
     viewer.wait_until_close()
 
 **Command Line Usage:**
@@ -385,14 +385,17 @@ Every interactive viewer (``TrimeshSceneViewer``, ``PyrenderViewer`` and
 ``ViserViewer``) shares two convenience methods.
 
 **wait_until_close()**
-  Block until the viewer window is closed, pumping :func:`redraw` while
-  waiting. It replaces the boilerplate
+  Block until the viewer backend becomes inactive. On trimesh / pyrender it
+  waits for the window to close and pumps :func:`redraw` while waiting. On
+  viser it waits for the server to stop (for example Ctrl-C in the script or
+  :func:`close`) and does not timer-call :func:`redraw`. It replaces the
+  boilerplate
   ``while viewer.is_active: time.sleep(...); viewer.redraw()`` loop:
 
   .. code-block:: python
 
       viewer.show()
-      viewer.wait_until_close()   # returns once the window / tab is closed
+      viewer.wait_until_close()   # returns once the backend becomes inactive
 
 **pause(duration, fps=30.0)**
   Pause for ``duration`` seconds **while keeping the window interactive**. Use

--- a/docs/source/tutorials/visualization.rst
+++ b/docs/source/tutorials/visualization.rst
@@ -48,7 +48,9 @@ Keeping the viewer responsive
 Every interactive viewer provides two helpers:
 
 - ``viewer.wait_until_close()`` blocks until the window is closed, replacing the
-  manual ``while viewer.is_active: ...`` loop.
+  manual ``while viewer.is_active: ...`` loop. For ``ViserViewer`` this means
+  waiting until the server is stopped (for example Ctrl-C or ``viewer.close()``),
+  not browser-tab state.
 - ``viewer.pause(seconds)`` waits like ``time.sleep`` but keeps the window
   interactive -- use it in animation loops so the camera stays draggable during
   the pause. This matters on macOS, where the trimesh / pyrender GL loop runs on
@@ -76,7 +78,7 @@ It automatically generates GUI sliders for each joint, allowing real-time manipu
    viewer.add(robot)
    viewer.show()  # Opens browser automatically
 
-   # Keep the server running until the browser tab is closed
+   # Keep the server running until it is stopped (Ctrl-C or viewer.close()).
    viewer.wait_until_close()
 
 .. image:: ../../image/viser-viewer.jpg

--- a/skrobot/viewers/_viser.py
+++ b/skrobot/viewers/_viser.py
@@ -40,6 +40,9 @@ except ImportError:
     _LIMB_DESCRIPTOR_TYPES = (property, _functools_cached_property)
 
 
+_CHECK_INTERVAL_NOT_GIVEN = object()
+
+
 class ViserViewer(_InteractiveViewerMixin):
     """Viser-based 3D viewer for scikit-robot.
 
@@ -188,11 +191,21 @@ class ViserViewer(_InteractiveViewerMixin):
     def is_active(self) -> bool:
         return self._is_active
 
+    @property
+    def has_exit(self):
+        return not self.is_active
+
     def close(self):
         self._is_active = False
         self._server.stop()
 
-    def wait_until_close(self, check_interval=0.1):
+    def wait_until_close(
+        self,
+        redraw=True,
+        interval=0.1,
+        message='==> Press Ctrl-C in this terminal to stop the viser server',
+        check_interval=_CHECK_INTERVAL_NOT_GIVEN,
+    ):
         """Block until the viewer is closed.
 
         The Viser HTTP/WebSocket server runs in a background thread, so a
@@ -201,14 +214,47 @@ class ViserViewer(_InteractiveViewerMixin):
         keep the viewer alive; it returns when :meth:`close` is called or the
         user interrupts with Ctrl-C.
 
+        This method intentionally does not reuse
+        :meth:`skrobot.viewers._base._InteractiveViewerMixin.wait_until_close`:
+        that helper calls :meth:`redraw` on a timer while waiting, but
+        ``ViserViewer.redraw()`` can run IK/collision updates and is not a
+        cheap event pump.
+
         Parameters
         ----------
-        check_interval : float, optional
+        redraw : bool, optional
+            Accepted for cross-backend API compatibility, but ignored.
+            The browser client renders continuously, so there is no local
+            window event loop to pump from Python.
+        interval : float, optional
             Polling interval in seconds. Default ``0.1``.
+        message : str or None, optional
+            Message printed once before waiting starts. Pass ``None`` to
+            suppress it. The default differs from the mixin's
+            ``'Press [q] to close window'`` text because this backend runs
+            a browser client plus background server, not a keyboard-driven
+            native window.
+        check_interval : float, optional
+            Deprecated alias for ``interval``. Passing this emits a
+            ``DeprecationWarning``. Passing both ``interval`` and
+            ``check_interval`` raises ``TypeError``.
         """
+        if check_interval is not _CHECK_INTERVAL_NOT_GIVEN:
+            if interval != 0.1:
+                raise TypeError(
+                    "wait_until_close() got both 'interval' and deprecated "
+                    "'check_interval'. Use only 'interval'.")
+            warnings.warn(
+                "'check_interval' is deprecated; use 'interval' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            interval = check_interval
+        if message:
+            print(message)
         try:
             while self._is_active:
-                time.sleep(check_interval)
+                time.sleep(interval)
         except KeyboardInterrupt:
             self.close()
 

--- a/tests/skrobot_tests/viewers_tests/test_viser_viewer.py
+++ b/tests/skrobot_tests/viewers_tests/test_viser_viewer.py
@@ -1,0 +1,94 @@
+from contextlib import redirect_stdout
+import inspect
+import io
+import threading
+import time
+import unittest
+import warnings
+
+from skrobot.viewers import ViserViewer
+from skrobot.viewers._base import _InteractiveViewerMixin
+
+
+class _DummyServer(object):
+
+    def __init__(self):
+        self.stop_count = 0
+
+    def stop(self):
+        self.stop_count += 1
+
+
+def _viewer():
+    # Borrow methods without starting a real viser server / browser.
+    viewer = ViserViewer.__new__(ViserViewer)
+    viewer._is_active = True
+    viewer._server = _DummyServer()
+    return viewer
+
+
+class TestViserViewer(unittest.TestCase):
+
+    def test_wait_until_close_matches_shared_signature_except_message_default(self):
+        shared = inspect.signature(
+            _InteractiveViewerMixin.wait_until_close).parameters
+        mine = inspect.signature(ViserViewer.wait_until_close).parameters
+        for name in shared:
+            self.assertIn(name, mine)
+            if name == 'message':
+                self.assertNotEqual(shared[name].default, mine[name].default)
+                self.assertIsInstance(mine[name].default, str)
+                self.assertNotEqual(mine[name].default, '')
+            else:
+                self.assertEqual(shared[name].default, mine[name].default)
+
+    def test_wait_until_close_message_kwarg_prints_once_and_returns(self):
+        viewer = _viewer()
+
+        def _close_later():
+            time.sleep(0.05)
+            viewer.close()
+
+        close_thread = threading.Thread(target=_close_later)
+        close_thread.start()
+        out = io.StringIO()
+        with redirect_stdout(out):
+            viewer.wait_until_close(message='x', interval=0.01)
+        close_thread.join(timeout=1.0)
+
+        self.assertFalse(close_thread.is_alive())
+        self.assertEqual(out.getvalue().count('x'), 1)
+
+    def test_check_interval_alias_warns_and_waits(self):
+        viewer = _viewer()
+
+        def _close_later():
+            time.sleep(0.05)
+            viewer.close()
+
+        close_thread = threading.Thread(target=_close_later)
+        close_thread.start()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            viewer.wait_until_close(message=None, check_interval=0.01)
+        close_thread.join(timeout=1.0)
+
+        self.assertFalse(close_thread.is_alive())
+        self.assertTrue(caught)
+        self.assertEqual(caught[0].category, DeprecationWarning)
+        self.assertIn('interval', str(caught[0].message))
+
+    def test_check_interval_and_interval_together_raises_type_error(self):
+        viewer = _viewer()
+        with self.assertRaises(TypeError):
+            viewer.wait_until_close(interval=0.2, check_interval=0.1)
+
+    def test_has_exit_matches_not_is_active(self):
+        viewer = _viewer()
+        self.assertEqual(viewer.has_exit, not viewer.is_active)
+        viewer._is_active = False
+        self.assertEqual(viewer.has_exit, not viewer.is_active)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The trimesh, pyrender and mitsuba viewers take (redraw, interval, message) from _InteractiveViewerMixin. ViserViewer inherits the mixin but shadowed it with wait_until_close(check_interval=0.1), so examples/skeleton_visualization.py, which passes message=, raised TypeError under --viewer viser.

Adopt the shared parameters while keeping the Viser body: the mixin pumps redraw() on a timer, and Viser's redraw() updates every handle and can run IK, so it is not free to call repeatedly. check_interval keeps working as a deprecated alias, and the default message describes how a Viser session actually ends rather than talking about a window and a q key.

Add has_exit for parity, and correct the docs, which said is_active tracks the browser tab closing when it tracks the server's own lifetime.