### PR TITLE
Document the end-effector frame of each robot model

### DIFF
--- a/skrobot/models/aero.py
+++ b/skrobot/models/aero.py
@@ -21,6 +21,18 @@ class Aero(RobotModel):
         joints are part of ``angle_vector``.  If False, load the hand-less
         model whose arms end at the built-in ``*_eef_*`` frames.
 
+    Notes
+    -----
+    **End-effector frame.**
+    ``rarm_end_coords`` and ``larm_end_coords`` are attached to
+    ``{r,l}_eef_grasp_link`` with zero offset and identity mapping.
+    ``torso_end_coords`` is attached to ``leg_base_link`` with offset
+    ``[-0.032, 0.0, -0.3507]`` and identity mapping.
+    ``head_end_coords`` is attached to ``head_link`` with offset
+    ``[0.079, 0.0, 0.1035]`` and measured non-axis-aligned rotation
+    ``[[-0.173646458853, 0.0, 0.984808056084], [0.0, 1.0, 0.0],``
+    ``[-0.984808056084, 0.0, -0.173646458853]]`` (end relative to link).
+
     Examples
     --------
     >>> from skrobot.models import Aero

--- a/skrobot/models/differential_wrist_sample.py
+++ b/skrobot/models/differential_wrist_sample.py
@@ -22,6 +22,13 @@ class DifferentialWristSample(RobotModelFromURDF):
         If True (default), apply joint limit tables for the wrist joints.
         This enables dynamic joint limits where each wrist joint's limits
         depend on the other wrist joint's current angle.
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``end_coords`` is attached to ``end_effector_link`` with zero offset.
+    Measured mapping: end +X -> link +X, end +Y -> link +Y,
+    end +Z -> link +Z (identity).
     """
 
     def __init__(self, use_joint_limit_table=True):

--- a/skrobot/models/fetch.py
+++ b/skrobot/models/fetch.py
@@ -11,6 +11,14 @@ class Fetch(RobotModelFromURDF):
     """Fetch Robot Model.
 
     http://docs.fetchrobotics.com/robot_hardware.html
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``rarm_end_coords`` is attached to ``gripper_link`` with zero offset.
+    Measured mapping: end +X -> link +X, end +Y -> link +Y,
+    end +Z -> link +Z (identity).
+    Grasp/approach semantics are not documented in this model file.
     """
 
     def __init__(self, *args, **kwargs):

--- a/skrobot/models/g1.py
+++ b/skrobot/models/g1.py
@@ -15,6 +15,16 @@ class G1(RobotModelFromURDF):
     `isri-aist/g1_description
     <https://github.com/isri-aist/g1_description>`_, derived from Unitree's
     official ``g1_description`` (BSD-3-Clause).
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``rarm_end_coords`` and ``larm_end_coords`` are attached to the selected
+    wrist terminal link (e.g., ``{right,left}_wrist_roll_rubber_hand`` in the
+    23-DOF model) with zero offset and identity mapping.
+    ``rleg_end_coords`` and ``lleg_end_coords`` are attached to
+    ``{right,left}_ankle_roll_link`` with offset ``[0.0, 0.0, -0.03]`` and
+    identity mapping.
     """
 
     def __init__(self, dof=23, urdf=None, urdf_file=None):

--- a/skrobot/models/griphis.py
+++ b/skrobot/models/griphis.py
@@ -64,6 +64,15 @@ class Griphis(RobotModelFromURDF):
     access from the live nail-tip positions, so changes to
     ``worm_rotate_{1,2}`` (which move the tips via URDF mimic bindings)
     are reflected automatically — no manual refresh is required.
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``gripper_1_end_coords`` is attached to ``roll_1_link`` with offset
+    ``[0.140857, 0.0, 0.0]`` and identity mapping.
+    ``gripper_2_end_coords`` is attached to ``roll_2_link`` with offset
+    ``[-0.140857, 0.00005, 0.0]`` and mapping end +X -> link -X,
+    end +Y -> link -Y, end +Z -> link +Z.
     """
 
     def __init__(self, *args, **kwargs):

--- a/skrobot/models/hydrus.py
+++ b/skrobot/models/hydrus.py
@@ -38,6 +38,13 @@ class Hydrus(RobotModelFromURDF):
 
     The URDF and meshes are fetched on first use and cached under
     ``~/.skrobot/hydrus_description/``.
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``arm_end_coords`` is attached to ``leg5`` with zero offset.
+    Measured mapping: end +X -> link +X, end +Y -> link +Y,
+    end +Z -> link +Z (identity).
     """
 
     @cached_property

--- a/skrobot/models/jaxon_jvrc.py
+++ b/skrobot/models/jaxon_jvrc.py
@@ -16,6 +16,18 @@ class JaxonJVRC(RobotModelFromURDF):
     `robot-descriptions/jaxon_description
     <https://github.com/robot-descriptions/jaxon_description>`_,
     licensed under CC BY-SA 4.0.
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``rarm_end_coords`` and ``larm_end_coords`` are attached to
+    ``{RARM,LARM}_LINK7`` with offset ``[0.0, 0.0, -0.217]`` and mapping
+    end +X -> link -Z, end +Y -> link +Y, end +Z -> link +X.
+    ``rleg_end_coords`` and ``lleg_end_coords`` are attached to
+    ``{RLEG,LLEG}_LINK5`` with offset ``[0.0, 0.0, -0.1]`` and identity
+    mapping. ``head_end_coords`` is attached to ``HEAD_LINK1`` with offset
+    ``[0.1, 0.0, 0.1]`` and mapping end +X -> link -Z, end +Y -> link +Y,
+    end +Z -> link +X.
     """
 
     def __init__(self, *args, **kwargs):

--- a/skrobot/models/jedy.py
+++ b/skrobot/models/jedy.py
@@ -19,6 +19,15 @@ class Jedy(RobotModelFromURDF):
     colocates with the D405's **left** (infra1) imager, so the head end
     coordinates coincide with the left camera. It follows the optical-frame
     convention, so its z-axis points along the camera's viewing direction.
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``rarm_end_coords`` and ``larm_end_coords`` are attached to
+    ``{rarm,larm}_link6`` with offset ``[0.0, 0.0, -0.102466]`` and mapping
+    end +X -> link -Z, end +Y -> link +Y, end +Z -> link +X.
+    ``head_end_coords`` is attached to ``camera_depth_optical_frame`` with
+    zero offset and identity mapping.
     """
 
     def __init__(self, *args, **kwargs):

--- a/skrobot/models/kuka.py
+++ b/skrobot/models/kuka.py
@@ -8,7 +8,18 @@ from skrobot.models.urdf import RobotModelFromURDF
 
 
 class Kuka(RobotModelFromURDF):
-    """Kuka Robot Model."""
+    """Kuka Robot Model.
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``rarm_end_coords`` is attached to
+    ``lbr_iiwa_with_wsg50__lbr_iiwa_link_7`` with offset
+    ``[0.0, 0.03, 0.25]`` in the parent-link frame.
+    Measured mapping: end +X -> link +Z, end +Y -> link +X,
+    end +Z -> link +Y.
+    Grasp/approach semantics are not documented in this model file.
+    """
 
     def __init__(self, *args, **kwargs):
         super(Kuka, self).__init__(*args, **kwargs)

--- a/skrobot/models/nextage.py
+++ b/skrobot/models/nextage.py
@@ -16,6 +16,16 @@ class Nextage(RobotModelFromURDF):
     - Nextage Open Robot Description
 
       https://github.com/tork-a/rtmros_nextage/tree/indigo-devel/nextage_description/urdf
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``rarm_end_coords`` and ``larm_end_coords`` are attached to
+    ``{RARM,LARM}_JOINT5_Link`` with offset ``[-0.185, 0.0, -0.01]`` and
+    mapping end +X -> link +Z, end +Y -> link +Y, end +Z -> link -X.
+    ``head_end_coords`` is attached to ``HEAD_JOINT1_Link`` with offset
+    ``[0.06, 0.0, 0.025]`` and mapping end +X -> link -Z, end +Y -> link +Y,
+    end +Z -> link +X.
     """
 
     def __init__(self, *args, **kwargs):

--- a/skrobot/models/panda.py
+++ b/skrobot/models/panda.py
@@ -12,6 +12,16 @@ class Panda(RobotModelFromURDF):
     """Panda Robot Model.
 
     https://frankaemika.github.io/docs/control_parameters.html
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``rarm_end_coords`` is attached to ``panda_hand`` with offset
+    ``[0, 0, 0.1034]`` in the parent-link frame. Measured mapping:
+    end +X -> link +Z, end +Y -> link +Y, end +Z -> link -X.
+    Approach direction is local +X and finger-opening axis is local +Y.
+    For a top-down grasp with fingers along world Y, use target rotation
+    matrix ``[[0, 0, 1], [0, 1, 0], [-1, 0, 0]]``.
     """
 
     def __init__(self, *args, **kwargs):

--- a/skrobot/models/pr2.py
+++ b/skrobot/models/pr2.py
@@ -11,6 +11,16 @@ class PR2(RobotModelFromURDF):
 
     """PR2 Robot Model.
 
+    Notes
+    -----
+    **End-effector frame.**
+    ``rarm_end_coords`` and ``larm_end_coords`` are attached to
+    ``{r,l}_gripper_tool_frame`` with zero offset and identity mapping
+    (end +X/+Y/+Z -> link +X/+Y/+Z). ``torso_end_coords`` is identity on
+    ``torso_lift_link``.
+    ``head_end_coords`` is attached to ``head_tilt_link`` with offset
+    ``[0.08, 0.0, 0.13]`` and mapping end +X -> link -Z, end +Y -> link +Y,
+    end +Z -> link +X.
     """
 
     def __init__(self, use_tight_joint_limit=True):

--- a/skrobot/models/r8_6.py
+++ b/skrobot/models/r8_6.py
@@ -6,6 +6,16 @@ from skrobot.data import r8_6_urdfpath
 
 
 class R8_6(skrobot.model.RobotModel):
+    """R8.6 dual-arm mobile manipulator.
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``larm_end_coords`` and ``rarm_end_coords`` are attached to
+    ``{l,r}_hand_y_link`` with zero offset and identity mapping.
+    ``l_hand_camera_end_coords``, ``r_hand_camera_end_coords`` and
+    ``elv_camera_end_coords`` are also identity on their parent camera links.
+    """
 
     def __init__(self, urdf_path=None, *args, **kwargs):
         super(R8_6, self).__init__(*args, **kwargs)

--- a/skrobot/models/tycoon.py
+++ b/skrobot/models/tycoon.py
@@ -8,7 +8,17 @@ from skrobot.models.urdf import RobotModelFromURDF
 
 
 class RoverArmedTycoon(RobotModelFromURDF):
-    """Rover Armed Tycoon Robot Model."""
+    """Rover Armed Tycoon Robot Model.
+
+    Notes
+    -----
+    **End-effector frame.**
+    ``_arm_end_coords`` (exposed as ``arm_end_coords``) is attached to
+    ``tycoon_7_roll_link`` with offset ``[-0.05, 0.0, 0.0]``.
+    Measured mapping: end +X -> link -X, end +Y -> link -Y,
+    end +Z -> link +Z.
+    Grasp/approach semantics are not documented in this model file.
+    """
 
     def __init__(self, *args, **kwargs):
         super(RoverArmedTycoon, self).__init__(*args, **kwargs)


### PR DESCRIPTION
The rotation applied when building end_coords differs per model, so the approach direction is rarely the local +Z a user would assume. Record the measured axis mapping, and for Panda the rotation matrix for a top-down grasp.