### PR TITLE
Add a GripperCommand backend to the ROS 2 robot interface

### DIFF
--- a/skrobot/interfaces/ros2/gripper.py
+++ b/skrobot/interfaces/ros2/gripper.py
@@ -1,0 +1,151 @@
+import threading
+
+import control_msgs.action
+import rclpy
+from rclpy.action import ActionClient
+
+
+def _wait_for_future(node, future, timeout_sec=None):
+    """Block until ``future`` completes, whoever is spinning ``node``.
+
+    ``rclpy.spin_until_future_complete`` spins the node itself. If an external
+    executor is already spinning that same node -- which is how this interface
+    is meant to be used, and the only way ``/joint_states`` keeps arriving --
+    that makes two spinners share one wait set, and rclpy fails with
+    ``wait set index for status subscription is out of bounds``. Wait on a
+    callback instead whenever someone else is driving the node.
+
+    Parameters
+    ----------
+    node : rclpy.node.Node
+        Node the future belongs to.
+    future : rclpy.task.Future
+        Future to wait on.
+    timeout_sec : float or None
+        Optional timeout. ``None`` waits indefinitely.
+
+    Returns
+    -------
+    bool
+        True if the future completed, False on timeout.
+    """
+    if node.executor is None:
+        rclpy.spin_until_future_complete(node, future, timeout_sec=timeout_sec)
+        return future.done()
+    done = threading.Event()
+    future.add_done_callback(lambda _: done.set())
+    return done.wait(timeout=timeout_sec)
+
+
+class GripperCommandActionClient(object):
+    """Action client wrapper for ``control_msgs/action/GripperCommand``.
+
+    Parameters
+    ----------
+    node : rclpy.node.Node
+        Node used for action communication and logging.
+    action_name : str
+        Action namespace of ``GripperCommand``.
+    width_scale : float, default 0.5
+        Conversion factor from jaw gap width (meters) to the commanded
+        joint value. ``command.position = width * width_scale``.
+        For common symmetric two-finger grippers controlled by one
+        joint this is 0.5 because each finger tracks half the jaw gap.
+    max_effort : float, default 0.0
+        Default effort limit forwarded to ``command.max_effort``.
+
+    Notes
+    -----
+    ``move`` always accepts jaw gap width in meters to keep a consistent
+    external API, regardless of controller joint units.
+    """
+
+    def __init__(self,
+                 node,
+                 action_name,
+                 width_scale=0.5,
+                 max_effort=0.0):
+        self._node = node
+        self._width_scale = width_scale
+        self._max_effort = max_effort
+
+        self._action_client = ActionClient(
+            node,
+            control_msgs.action.GripperCommand,
+            action_name)
+
+        self._goal_future = None
+        self._goal_handle = None
+        self._goal_rejected_logged = False
+
+    @property
+    def available(self):
+        """Whether the action server is currently available."""
+        return self._action_client.wait_for_server(timeout_sec=0.0)
+
+    def _store_goal_handle(self, future):
+        goal_handle = future.result()
+        self._goal_handle = goal_handle
+        if goal_handle is None or not goal_handle.accepted:
+            self._node.get_logger().warn(
+                "GripperCommand goal was rejected by action server.")
+            self._goal_rejected_logged = True
+
+    def move(self, width, max_effort=None, wait=True):
+        """Send a gripper command using jaw gap width in meters.
+
+        Parameters
+        ----------
+        width : float
+            Target jaw gap width in meters.
+        max_effort : float or None
+            Effort limit for this goal. If None, uses the constructor
+            default.
+        wait : bool, default True
+            If True, wait for completion and return action result.
+            If False, return the goal future.
+        """
+        goal = control_msgs.action.GripperCommand.Goal()
+        goal.command.position = width * self._width_scale
+        goal.command.max_effort = (
+            self._max_effort if max_effort is None else max_effort)
+
+        self._goal_rejected_logged = False
+        self._goal_future = self._action_client.send_goal_async(goal)
+        self._goal_future.add_done_callback(self._store_goal_handle)
+
+        if wait:
+            _wait_for_future(self._node, self._goal_future)
+            goal_handle = self._goal_future.result()
+            if goal_handle is None or not goal_handle.accepted:
+                if not self._goal_rejected_logged:
+                    self._node.get_logger().warn(
+                        "GripperCommand goal was rejected by action server.")
+                return
+            self._goal_handle = goal_handle
+
+            result_future = goal_handle.get_result_async()
+            _wait_for_future(self._node, result_future)
+            return result_future.result()
+
+        return self._goal_future
+
+    def cancel(self, wait=True):
+        """Cancel the in-flight gripper goal if any."""
+        if self._goal_handle is None and self._goal_future is not None:
+            _wait_for_future(self._node, self._goal_future)
+            self._goal_handle = self._goal_future.result()
+
+        goal_handle = self._goal_handle
+        if goal_handle is None:
+            self._node.get_logger().warn("No GripperCommand goal to cancel.")
+            return
+
+        cancel_future = goal_handle.cancel_goal_async()
+        if wait:
+            _wait_for_future(self._node, cancel_future)
+            self._goal_handle = None
+            return cancel_future.result()
+
+        self._goal_handle = None
+        return cancel_future

--- a/skrobot/interfaces/ros2/panda.py
+++ b/skrobot/interfaces/ros2/panda.py
@@ -3,12 +3,14 @@ import rclpy
 from rclpy.action import ActionClient
 
 from skrobot.interfaces.ros2.base import ROS2RobotInterfaceBase
+from skrobot.interfaces.ros2.gripper import GripperCommandActionClient
 
 
 try:
     import franka_gripper.action
     FRANKA_GRIPPER_AVAILABLE = True
 except ImportError:
+    franka_gripper = None
     FRANKA_GRIPPER_AVAILABLE = False
 
 
@@ -49,41 +51,75 @@ class PandaROS2RobotInterface(ROS2RobotInterfaceBase):
         for sim setups (mock_components) where ``franka_gripper`` is not
         running, and for unit tests where blocking on
         ``wait_for_server`` is not desired.
+    gripper_backend : {'franka_gripper', 'gripper_command'}, default
+        'franka_gripper'
+        Backend used for gripper commands. ``'franka_gripper'`` keeps
+        the historical Franka-specific action API. ``'gripper_command'``
+        uses ``control_msgs/action/GripperCommand`` and is the preferred
+        backend for simulation and non-Franka grippers.
+    gripper_action_name : str or None
+        Action namespace for ``'gripper_command'`` backend. Defaults to
+        ``f'{arm_id}_hand_controller/gripper_cmd'``.
+    gripper_max_effort : float, default 0.0
+        Default ``max_effort`` sent to ``GripperCommand`` goals.
     """
 
     def __init__(self, *args,
                  arm_id='panda',
                  controller_name=None,
                  gripper_action_prefix=None,
+                 gripper_backend='franka_gripper',
+                 gripper_action_name=None,
+                 gripper_max_effort=0.0,
                  limb_attr='rarm',
                  load_gripper=True,
                  **kwargs):
+        valid_backends = ('franka_gripper', 'gripper_command')
+        if gripper_backend not in valid_backends:
+            raise ValueError(
+                "Unknown gripper_backend '{}'. "
+                "Expected one of {}.".format(
+                    gripper_backend, valid_backends))
+
         self._arm_id = arm_id
-        self._controller_name = controller_name or '{}_arm_controller'.format(arm_id)
+        self._controller_name = controller_name or \
+            '{}_arm_controller'.format(arm_id)
         self._gripper_action_prefix = gripper_action_prefix or 'franka_gripper'
+        self._gripper_backend = gripper_backend
+        self._gripper_action_name = gripper_action_name or \
+            '{}_hand_controller/gripper_cmd'.format(arm_id)
+        self._gripper_max_effort = gripper_max_effort
         self._limb_attr = limb_attr
+        self._warned_gripper_speed_ignored = False
 
         super(PandaROS2RobotInterface, self).__init__(*args, **kwargs)
 
         self.gripper_move = None
         self.gripper_stop = None
+        self.gripper_command = None
         if load_gripper:
-            if FRANKA_GRIPPER_AVAILABLE:
-                self.gripper_move = ActionClient(
-                    self,
-                    franka_gripper.action.Move,
-                    '{}/move'.format(self._gripper_action_prefix))
-                self.gripper_move.wait_for_server()
+            if self._gripper_backend == 'franka_gripper':
+                if FRANKA_GRIPPER_AVAILABLE:
+                    self.gripper_move = ActionClient(
+                        self,
+                        franka_gripper.action.Move,
+                        '{}/move'.format(self._gripper_action_prefix))
+                    self.gripper_move.wait_for_server()
 
-                self.gripper_stop = ActionClient(
-                    self,
-                    franka_gripper.action.Stop,
-                    '{}/stop'.format(self._gripper_action_prefix))
-                self.gripper_stop.wait_for_server()
+                    self.gripper_stop = ActionClient(
+                        self,
+                        franka_gripper.action.Stop,
+                        '{}/stop'.format(self._gripper_action_prefix))
+                    self.gripper_stop.wait_for_server()
+                else:
+                    self.get_logger().warn(
+                        "franka_gripper package not available. "
+                        "Gripper functions disabled.")
             else:
-                self.get_logger().warn(
-                    "franka_gripper package not available. "
-                    "Gripper functions disabled.")
+                self.gripper_command = GripperCommandActionClient(
+                    self,
+                    self._gripper_action_name,
+                    max_effort=self._gripper_max_effort)
 
     @property
     def arm_controller(self):
@@ -114,45 +150,65 @@ class PandaROS2RobotInterface(ROS2RobotInterfaceBase):
         self.move_gripper(width=WIDTH_MAX, **kwargs)
 
     def move_gripper(self, width, speed=WIDTH_MAX, wait=True):
-        if self.gripper_move is None:
-            self.get_logger().warn(
-                "Gripper ActionClient was not initialised "
-                "(load_gripper=False or franka_gripper not available). "
-                "Cannot move gripper.")
-            return
+        if self._gripper_backend == 'franka_gripper':
+            if self.gripper_move is None:
+                self.get_logger().warn(
+                    "Gripper ActionClient was not initialised "
+                    "(load_gripper=False or franka_gripper not available). "
+                    "Cannot move gripper.")
+                return
 
-        goal = franka_gripper.action.Move.Goal()
-        goal.width = width
-        goal.speed = speed
+            goal = franka_gripper.action.Move.Goal()
+            goal.width = width
+            goal.speed = speed
 
-        if wait:
-            future = self.gripper_move.send_goal_async(goal)
-            rclpy.spin_until_future_complete(self, future)
-            goal_handle = future.result()
-            if goal_handle.accepted:
-                result_future = goal_handle.get_result_async()
-                rclpy.spin_until_future_complete(self, result_future)
-                return result_future.result()
+            if wait:
+                future = self.gripper_move.send_goal_async(goal)
+                rclpy.spin_until_future_complete(self, future)
+                goal_handle = future.result()
+                if goal_handle.accepted:
+                    result_future = goal_handle.get_result_async()
+                    rclpy.spin_until_future_complete(self, result_future)
+                    return result_future.result()
+            else:
+                self.gripper_move.send_goal_async(goal)
         else:
-            self.gripper_move.send_goal_async(goal)
+            if self.gripper_command is None:
+                self.get_logger().warn(
+                    "GripperCommand ActionClient was not initialised "
+                    "(load_gripper=False). Cannot move gripper.")
+                return
+            if speed != WIDTH_MAX and not self._warned_gripper_speed_ignored:
+                self.get_logger().warn(
+                    "speed is ignored for gripper_backend='gripper_command'.")
+                self._warned_gripper_speed_ignored = True
+            return self.gripper_command.move(width=width, wait=wait)
 
     def stop_gripper(self, wait=True):
-        if self.gripper_stop is None:
-            self.get_logger().warn(
-                "Gripper ActionClient was not initialised "
-                "(load_gripper=False or franka_gripper not available). "
-                "Cannot stop gripper.")
-            return
+        if self._gripper_backend == 'franka_gripper':
+            if self.gripper_stop is None:
+                self.get_logger().warn(
+                    "Gripper ActionClient was not initialised "
+                    "(load_gripper=False or franka_gripper not available). "
+                    "Cannot stop gripper.")
+                return
 
-        goal = franka_gripper.action.Stop.Goal()
+            goal = franka_gripper.action.Stop.Goal()
 
-        if wait:
-            future = self.gripper_stop.send_goal_async(goal)
-            rclpy.spin_until_future_complete(self, future)
-            goal_handle = future.result()
-            if goal_handle.accepted:
-                result_future = goal_handle.get_result_async()
-                rclpy.spin_until_future_complete(self, result_future)
-                return result_future.result()
+            if wait:
+                future = self.gripper_stop.send_goal_async(goal)
+                rclpy.spin_until_future_complete(self, future)
+                goal_handle = future.result()
+                if goal_handle.accepted:
+                    result_future = goal_handle.get_result_async()
+                    rclpy.spin_until_future_complete(self, result_future)
+                    return result_future.result()
+            else:
+                self.gripper_stop.send_goal_async(goal)
         else:
-            self.gripper_stop.send_goal_async(goal)
+            if self.gripper_command is None:
+                self.get_logger().warn(
+                    "GripperCommand ActionClient was not initialised "
+                    "(load_gripper=False). Cannot stop gripper.")
+                return
+            return self.gripper_command.cancel(wait=wait)

--- a/tests/skrobot_tests/interfaces_tests/ros2/test_gripper.py
+++ b/tests/skrobot_tests/interfaces_tests/ros2/test_gripper.py
@@ -1,0 +1,168 @@
+"""Unit tests for the generic ROS 2 GripperCommand action client."""
+import unittest
+from unittest import mock
+
+import pytest
+
+
+try:
+    # No `import rclpy` here, unlike the sibling ROS 2 tests: those go on to
+    # call rclpy.init(), while these run against a fake node, so the import
+    # would be unused. Importing the module under test is enough of an
+    # availability probe -- gripper.py imports rclpy itself.
+    from skrobot.interfaces.ros2.gripper import GripperCommandActionClient
+    ROS2_AVAILABLE = True
+except ImportError:
+    ROS2_AVAILABLE = False
+
+
+pytestmark = pytest.mark.skipif(
+    not ROS2_AVAILABLE, reason="ROS 2 / rclpy not importable")
+
+
+class _ImmediateFuture(object):
+
+    def __init__(self, result):
+        self._result = result
+
+    def done(self):
+        return True
+
+    def result(self):
+        return self._result
+
+    def add_done_callback(self, callback):
+        callback(self)
+
+
+class _FakeGoalHandle(object):
+
+    def __init__(self, accepted=True):
+        self.accepted = accepted
+        self.cancel_called = False
+
+    def get_result_async(self):
+        return _ImmediateFuture('goal_result')
+
+    def cancel_goal_async(self):
+        self.cancel_called = True
+        return _ImmediateFuture('cancelled')
+
+
+class _FakeActionClient(object):
+
+    def __init__(self, node, action_type, action_name):
+        self.node = node
+        self.action_type = action_type
+        self.action_name = action_name
+        self.available = True
+        self.sent_goals = []
+        self.goal_handle = _FakeGoalHandle()
+
+    def wait_for_server(self, timeout_sec=0.0):
+        return self.available
+
+    def send_goal_async(self, goal):
+        self.sent_goals.append(goal)
+        return _ImmediateFuture(self.goal_handle)
+
+
+class _FakeNode(object):
+    """Minimal stand-in for an rclpy node.
+
+    The client only ever asks the node for its logger, and the action client is
+    faked here anyway, so a real node buys nothing. It costs something, though:
+    creating one initialises the global rclpy context and joins the DDS domain,
+    which makes these tests order-dependent with the rest of the ROS 2 suite.
+    """
+
+    def __init__(self, executor=None):
+        self.warnings = []
+        # `None` means nobody else is spinning this node, so the client is
+        # free to spin it itself -- which is the path these tests patch.
+        self.executor = executor
+
+    def get_logger(self):
+        return self
+
+    def warn(self, message):
+        self.warnings.append(message)
+
+
+class TestGripperCommandActionClient(unittest.TestCase):
+
+    def setUp(self):
+        self.node = _FakeNode()
+
+    def test_move_default_width_scale_converts_gap_to_joint_value(self):
+        with mock.patch(
+            'skrobot.interfaces.ros2.gripper.ActionClient',
+            _FakeActionClient
+        ), mock.patch(
+            'skrobot.interfaces.ros2.gripper.rclpy.spin_until_future_complete',
+            lambda n, f, timeout_sec=None: None
+        ):
+            client = GripperCommandActionClient(
+                self.node,
+                'test_gripper_cmd')
+            client.move(width=0.08, wait=True)
+
+            goal = client._action_client.sent_goals[-1]
+            assert goal.command.position == pytest.approx(0.04)
+            assert goal.command.max_effort == pytest.approx(0.0)
+
+    def test_move_custom_width_scale_is_applied(self):
+        with mock.patch(
+            'skrobot.interfaces.ros2.gripper.ActionClient',
+            _FakeActionClient
+        ), mock.patch(
+            'skrobot.interfaces.ros2.gripper.rclpy.spin_until_future_complete',
+            lambda n, f, timeout_sec=None: None
+        ):
+            client = GripperCommandActionClient(
+                self.node,
+                'test_gripper_cmd',
+                width_scale=0.25,
+                max_effort=12.0)
+            client.move(width=0.08, wait=True)
+
+            goal = client._action_client.sent_goals[-1]
+            assert goal.command.position == pytest.approx(0.02)
+            assert goal.command.max_effort == pytest.approx(12.0)
+
+    def test_move_overrides_max_effort_when_passed(self):
+        with mock.patch(
+            'skrobot.interfaces.ros2.gripper.ActionClient',
+            _FakeActionClient
+        ), mock.patch(
+            'skrobot.interfaces.ros2.gripper.rclpy.spin_until_future_complete',
+            lambda n, f, timeout_sec=None: None
+        ):
+            client = GripperCommandActionClient(
+                self.node,
+                'test_gripper_cmd',
+                max_effort=12.0)
+            client.move(width=0.08, max_effort=5.0, wait=True)
+
+            goal = client._action_client.sent_goals[-1]
+            assert goal.command.max_effort == pytest.approx(5.0)
+
+
+class TestGripperCommandActionClientExternalExecutor(unittest.TestCase):
+    """The node is usually spun by an external executor, not by the client.
+
+    Spinning it from both places shares one wait set between two spinners and
+    rclpy raises "wait set index for status subscription is out of bounds".
+    """
+
+    def test_move_does_not_spin_a_node_owned_by_an_executor(self):
+        node = _FakeNode(executor=object())
+        with mock.patch(
+                'skrobot.interfaces.ros2.gripper.ActionClient',
+                _FakeActionClient), \
+            mock.patch(
+                'skrobot.interfaces.ros2.gripper.rclpy'
+                '.spin_until_future_complete') as spin:
+            client = GripperCommandActionClient(node, 'gripper_cmd')
+            client.move(0.08)
+        spin.assert_not_called()

--- a/tests/skrobot_tests/interfaces_tests/ros2/test_panda.py
+++ b/tests/skrobot_tests/interfaces_tests/ros2/test_panda.py
@@ -1,5 +1,7 @@
 """Unit tests for the parameterised PandaROS2RobotInterface."""
+from types import SimpleNamespace
 import unittest
+from unittest import mock
 
 import pytest
 
@@ -7,7 +9,9 @@ import pytest
 try:
     import rclpy
 
+    import skrobot.interfaces.ros2.panda as panda_module
     from skrobot.interfaces.ros2.panda import PandaROS2RobotInterface
+    from skrobot.interfaces.ros2.panda import WIDTH_MAX
     from skrobot.models import Panda
     ROS2_AVAILABLE = True
 except ImportError:
@@ -34,6 +38,93 @@ def _make(node_name, load_gripper=False, **kwargs):
         joint_states_topic='_test_panda_' + node_name,
         **kwargs,
     )
+
+
+class _ImmediateFuture(object):
+
+    def __init__(self, result):
+        self._result = result
+
+    def result(self):
+        return self._result
+
+    def add_done_callback(self, callback):
+        callback(self)
+
+
+class _FakeGoalHandle(object):
+
+    def __init__(self, accepted=True):
+        self.accepted = accepted
+        self.cancel_called = False
+
+    def get_result_async(self):
+        return _ImmediateFuture('result')
+
+    def cancel_goal_async(self):
+        self.cancel_called = True
+        return _ImmediateFuture('cancelled')
+
+
+class _FakeActionClient(object):
+
+    def __init__(self, node, action_type, action_name):
+        self.node = node
+        self.action_type = action_type
+        self.action_name = action_name
+        self.sent_goals = []
+        self.goal_handle = _FakeGoalHandle()
+
+    def wait_for_server(self, timeout_sec=None):
+        return True
+
+    def send_goal_async(self, goal):
+        self.sent_goals.append(goal)
+        return _ImmediateFuture(self.goal_handle)
+
+
+class _FakeFrankaMoveGoal(object):
+
+    def __init__(self):
+        self.width = None
+        self.speed = None
+
+
+class _FakeFrankaStopGoal(object):
+    pass
+
+
+class _FakeFrankaMove(object):
+    Goal = _FakeFrankaMoveGoal
+
+
+class _FakeFrankaStop(object):
+    Goal = _FakeFrankaStopGoal
+
+
+class _FakeGripperCommandActionClient(object):
+
+    def __init__(self,
+                 node,
+                 action_name,
+                 width_scale=0.5,
+                 max_effort=0.0):
+        self.node = node
+        self.action_name = action_name
+        self.width_scale = width_scale
+        self.max_effort = max_effort
+        self.sent_joint_positions = []
+        self.cancel_count = 0
+
+    def move(self, width, max_effort=None, wait=True):
+        effort = self.max_effort if max_effort is None else max_effort
+        joint_value = width * self.width_scale
+        self.sent_joint_positions.append((joint_value, effort, wait))
+        return self.sent_joint_positions[-1]
+
+    def cancel(self, wait=True):
+        self.cancel_count += 1
+        return wait
 
 
 class TestPandaInterfaceDefaults(unittest.TestCase):
@@ -115,3 +206,84 @@ class TestPandaInterfaceGripperDisable(unittest.TestCase):
             ri.stop_gripper()
         finally:
             ri.destroy_node()
+
+
+class TestPandaInterfaceGripperBackends(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if not rclpy.ok():
+            rclpy.init()
+
+    def test_unknown_backend_raises_value_error(self):
+        with pytest.raises(ValueError):
+            PandaROS2RobotInterface(
+                robot=None,
+                node_name='test_unknown_backend',
+                gripper_backend='not_a_backend')
+
+    def test_gripper_command_backend_does_not_require_franka_gripper(self):
+        with mock.patch.object(
+            panda_module, 'FRANKA_GRIPPER_AVAILABLE', False
+        ), mock.patch.object(
+            panda_module,
+            'GripperCommandActionClient',
+            _FakeGripperCommandActionClient
+        ):
+            ri = _make(
+                'test_gripper_command_without_franka',
+                load_gripper=True,
+                gripper_backend='gripper_command')
+            try:
+                assert ri.gripper_command is not None
+                assert ri.gripper_move is None
+                assert ri.gripper_stop is None
+            finally:
+                ri.destroy_node()
+
+    def test_grasp_and_ungrasp_map_to_expected_joint_positions(self):
+        with mock.patch.object(
+            panda_module,
+            'GripperCommandActionClient',
+            _FakeGripperCommandActionClient
+        ):
+            ri = _make(
+                'test_gripper_command_grasp_ungrasp',
+                load_gripper=True,
+                gripper_backend='gripper_command')
+            try:
+                ri.grasp(width=0.02, wait=True)
+                ri.ungrasp(wait=True)
+                positions = [
+                    p for p, _, _ in ri.gripper_command.sent_joint_positions]
+                assert positions[0] == pytest.approx(0.01)
+                assert positions[1] == pytest.approx(WIDTH_MAX * 0.5)
+            finally:
+                ri.destroy_node()
+
+    def test_default_backend_move_gripper_path_is_unchanged(self):
+        fake_franka = SimpleNamespace(
+            action=SimpleNamespace(Move=_FakeFrankaMove, Stop=_FakeFrankaStop))
+        with mock.patch.object(
+            panda_module, 'FRANKA_GRIPPER_AVAILABLE', True
+        ), mock.patch.object(
+            panda_module, 'franka_gripper', fake_franka
+        ), mock.patch.object(
+            panda_module, 'ActionClient', _FakeActionClient
+        ), mock.patch.object(
+            panda_module.rclpy, 'spin_until_future_complete', lambda n, f: None
+        ):
+            ri = _make(
+                'test_default_backend_move',
+                load_gripper=True)
+            try:
+                ri.move_gripper(width=0.03, speed=0.02, wait=True)
+                move_goal = ri.gripper_move.sent_goals[-1]
+                assert move_goal.width == pytest.approx(0.03)
+                assert move_goal.speed == pytest.approx(0.02)
+
+                ri.stop_gripper(wait=True)
+                stop_goal = ri.gripper_stop.sent_goals[-1]
+                assert isinstance(stop_goal, _FakeFrankaStopGoal)
+            finally:
+                ri.destroy_node()


### PR DESCRIPTION
The ROS 2 Panda interface could only drive a gripper through `franka_gripper`, so it did not work against a stack using `position_controllers/GripperActionController` — the ROS 2 standard for a parallel gripper.

Add a generic `GripperCommandActionClient` and a `gripper_backend` switch. The `franka_gripper` path stays the default and is unchanged.

`GripperActionController` drives one joint, so the width-to-joint conversion now lives in the library rather than in every caller.