### PR TITLE
Add orthonormalize_rotation_matrix to coordinates.math

### DIFF
--- a/skrobot/coordinates/__init__.py
+++ b/skrobot/coordinates/__init__.py
@@ -26,6 +26,7 @@ from skrobot.coordinates.math import matrix2xyzrpy
 from skrobot.coordinates.math import matrix_relative
 from skrobot.coordinates.math import normalize_mask
 from skrobot.coordinates.math import normalize_vector
+from skrobot.coordinates.math import orthonormalize_rotation_matrix
 from skrobot.coordinates.math import quaternion2rpy
 from skrobot.coordinates.math import quaternion_from_vectors
 from skrobot.coordinates.math import rotation_geodesic_distance

--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -3103,6 +3103,69 @@ def quaternion_from_vectors(a, b):
     return matrix2quaternion(rotation_matrix_from_vectors(a, b))
 
 
+def orthonormalize_rotation_matrix(matrix):
+    """Return the rotation matrix closest to the given matrix.
+
+    Projects an approximately-orthogonal matrix back onto SO(3) by
+    solving the orthogonal Procrustes problem: with the singular value
+    decomposition ``M = U S V^T``, the rotation closest to ``M`` in the
+    Frobenius norm is ``U V^T``.  When ``U V^T`` is a reflection
+    (determinant -1), the singular vector of the smallest singular value
+    is flipped so the result always has determinant +1.
+
+    Useful to repair rotation matrices that drifted away from
+    orthogonality — e.g. through long chains of matrix products or
+    matrices imported from external CAD/robot APIs — before handing them
+    to functions that validate their input, such as
+    :func:`matrix2quaternion` or :class:`~skrobot.coordinates.Coordinates`.
+
+    Parameters
+    ----------
+    matrix : list or numpy.ndarray
+        rotation-like matrix of shape ``(3, 3)``, or a batch of them
+        with shape ``(..., 3, 3)``.
+
+    Returns
+    -------
+    rotation : numpy.ndarray
+        closest rotation matrix (or batch of matrices), same shape as
+        the input, with determinant +1.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skrobot.coordinates.math import orthonormalize_rotation_matrix
+    >>> noisy = np.eye(3) + 1e-4 * np.random.rand(3, 3)
+    >>> fixed = orthonormalize_rotation_matrix(noisy)
+    >>> np.allclose(fixed.T @ fixed, np.eye(3))
+    True
+    >>> np.isclose(np.linalg.det(fixed), 1.0)
+    True
+    """
+    m = np.asarray(matrix, dtype=np.float64)
+    if m.ndim < 2 or m.shape[-2:] != (3, 3):
+        raise ValueError(
+            'matrix must have shape (3, 3) or (..., 3, 3), '
+            'got {}'.format(m.shape))
+    u, _, vt = np.linalg.svd(m)
+    rotation = np.matmul(u, vt)
+    # A negative determinant means the nearest orthogonal matrix is a
+    # reflection.  The nearest proper rotation is obtained by flipping
+    # the column of U paired with the smallest singular value (the last
+    # one; numpy returns singular values in descending order).
+    det = np.linalg.det(rotation)
+    if m.ndim == 2:
+        if det < 0:
+            u[:, 2] = -u[:, 2]
+            rotation = np.matmul(u, vt)
+    else:
+        negative = det < 0
+        if np.any(negative):
+            u[negative, :, 2] = -u[negative, :, 2]
+            rotation = np.matmul(u, vt)
+    return rotation
+
+
 def matrix2xyzrpy(matrix):
     """Split a 4x4 homogeneous transform into translation and roll-pitch-yaw.
 

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -26,6 +26,7 @@ from skrobot.coordinates.math import matrix2xyzrpy
 from skrobot.coordinates.math import matrix2ypr
 from skrobot.coordinates.math import matrix_relative
 from skrobot.coordinates.math import normalize_vector
+from skrobot.coordinates.math import orthonormalize_rotation_matrix
 from skrobot.coordinates.math import quaternion2matrix
 from skrobot.coordinates.math import quaternion2rpy
 from skrobot.coordinates.math import quaternion_absolute_distance
@@ -1184,6 +1185,67 @@ class TestMath(unittest.TestCase):
         # identity transform leaves the point untouched
         testing.assert_almost_equal(
             transform_point(np.eye(4), [1, 2, 3]), [1, 2, 3])
+
+    def test_orthonormalize_rotation_matrix(self):
+        # an already-valid rotation passes through unchanged
+        rng = np.random.RandomState(7)
+        for _ in range(20):
+            valid = rpy2matrix(*rng.uniform(-np.pi, np.pi, 3))
+            testing.assert_almost_equal(
+                orthonormalize_rotation_matrix(valid), valid)
+
+        # a drifted matrix is projected back onto SO(3), close to the
+        # original rotation
+        for _ in range(50):
+            valid = rpy2matrix(*rng.uniform(-np.pi, np.pi, 3))
+            drifted = valid + rng.uniform(-1e-4, 1e-4, (3, 3))
+            fixed = orthonormalize_rotation_matrix(drifted)
+            testing.assert_almost_equal(fixed.T.dot(fixed), np.eye(3))
+            self.assertAlmostEqual(np.linalg.det(fixed), 1.0)
+            self.assertLess(np.abs(fixed - valid).max(), 1e-3)
+            _check_valid_rotation(fixed)
+
+        # heavy distortion (non-uniform scaling) still yields a proper
+        # rotation
+        distorted = rpy2matrix(0.3, -0.2, 0.9).dot(np.diag([2.0, 0.5, 1.3]))
+        fixed = orthonormalize_rotation_matrix(distorted)
+        testing.assert_almost_equal(fixed.T.dot(fixed), np.eye(3))
+        self.assertAlmostEqual(np.linalg.det(fixed), 1.0)
+
+        # a reflection (det == -1) maps to a proper rotation, not a
+        # reflection
+        reflection = np.diag([1.0, 1.0, -1.0])
+        fixed = orthonormalize_rotation_matrix(reflection)
+        self.assertAlmostEqual(np.linalg.det(fixed), 1.0)
+        testing.assert_almost_equal(fixed.T.dot(fixed), np.eye(3))
+
+        # batch input keeps its shape and fixes each element, including a
+        # mix of proper and reflected matrices
+        batch = np.stack([
+            rpy2matrix(0.1, 0.2, 0.3) + 1e-5,
+            np.diag([1.0, 1.0, -1.0]),
+            np.eye(3),
+        ])
+        fixed = orthonormalize_rotation_matrix(batch)
+        self.assertEqual(fixed.shape, (3, 3, 3))
+        for i in range(3):
+            testing.assert_almost_equal(
+                fixed[i].T.dot(fixed[i]), np.eye(3))
+            self.assertAlmostEqual(np.linalg.det(fixed[i]), 1.0)
+        testing.assert_almost_equal(fixed[2], np.eye(3))
+
+        # multi-dimensional batch (2, 2, 3, 3)
+        nested = batch[:2].reshape(1, 2, 3, 3).repeat(2, axis=0)
+        fixed = orthonormalize_rotation_matrix(nested)
+        self.assertEqual(fixed.shape, (2, 2, 3, 3))
+        for idx in np.ndindex(2, 2):
+            self.assertAlmostEqual(np.linalg.det(fixed[idx]), 1.0)
+
+        # invalid shapes are rejected
+        with self.assertRaises(ValueError):
+            orthonormalize_rotation_matrix(np.eye(4))
+        with self.assertRaises(ValueError):
+            orthonormalize_rotation_matrix([1, 2, 3])
 
     def test_matrix_relative(self):
         rng = np.random.RandomState(3)


### PR DESCRIPTION
This adds `orthonormalize_rotation_matrix`, which projects an approximately-orthogonal matrix back onto SO(3) by solving the orthogonal Procrustes problem via SVD (`U V^T`, with a sign flip on the smallest singular vector so the result always has determinant +1).
Useful for repairing rotation matrices that drifted through long chains of matrix products or came from external CAD/robot APIs, before passing them to functions that validate their input such as `matrix2quaternion` or `Coordinates`.
Supports both single `(3, 3)` and batched `(..., 3, 3)` inputs; tests cover drift repair, non-uniform scaling, reflections, and mixed batches.