### PR TITLE
Add parallel_axis and combine_inertials to utils.inertia

### DIFF
--- a/skrobot/utils/__init__.py
+++ b/skrobot/utils/__init__.py
@@ -19,8 +19,10 @@ from skrobot.utils.blender_mesh import remesh_with_blender
 from skrobot.utils.convex_decomposition import convex_decomposition
 from skrobot.utils.convex_decomposition import is_coacd_available
 
+from skrobot.utils.inertia import combine_inertials
 from skrobot.utils.inertia import link_inertial_from_mesh
 from skrobot.utils.inertia import mesh_mass_properties
+from skrobot.utils.inertia import parallel_axis
 from skrobot.utils.inertia import rescale_inertial_to_mass
 from skrobot.utils.inertia import transform_inertial
 from skrobot.utils.inertia import validate_inertia

--- a/skrobot/utils/inertia.py
+++ b/skrobot/utils/inertia.py
@@ -26,11 +26,25 @@ __all__ = [
     'transform_inertial',
     'link_inertial_from_mesh',
     'rescale_inertial_to_mass',
+    'parallel_axis',
+    'combine_inertials',
     'validate_inertia',
 ]
 
 
 DEFAULT_DENSITY = 1000.0  # kg/m^3 (water) -- generic light part
+
+
+def _as_tensor(inertia):
+    """A 3x3 inertia tensor from either a 3x3 matrix or the 6 components
+    ``(ixx, ixy, ixz, iyy, iyz, izz)``."""
+    inertia = np.asarray(inertia, dtype=np.float64)
+    if inertia.shape == (6,):
+        ixx, ixy, ixz, iyy, iyz, izz = inertia
+        inertia = np.array([[ixx, ixy, ixz],
+                            [ixy, iyy, iyz],
+                            [ixz, iyz, izz]], dtype=np.float64)
+    return inertia
 
 
 def _solid_properties(mesh, density):
@@ -155,12 +169,7 @@ def transform_inertial(mass, com, inertia, visual_xyz, visual_rpy,
     try:
         mass = float(mass)
         com = np.asarray(com, dtype=float)
-        inertia = np.asarray(inertia, dtype=float)
-        if inertia.shape == (6,):
-            ixx, ixy, ixz, iyy, iyz, izz = inertia
-            inertia = np.array([[ixx, ixy, ixz],
-                                [ixy, iyy, iyz],
-                                [ixz, iyz, izz]], dtype=float)
+        inertia = _as_tensor(inertia)
     except (TypeError, ValueError):
         return None
     if not (np.isfinite(mass) and mass > 0 and com.shape == (3,)
@@ -242,6 +251,115 @@ def rescale_inertial_to_mass(info, target_mass):
         'com': list(info['com']),
         'inertia': tuple(float(x) * factor for x in info['inertia']),
         'method': '{}->mass'.format(info.get('method', '?')),
+    }
+
+
+def parallel_axis(mass, inertia, com, reference):
+    """Shift an inertia tensor to be taken about a different point.
+
+    The parallel-axis (Huygens-Steiner) theorem: a tensor taken about the
+    centre of mass gains ``mass * (|d|^2 * I3 - d d^T)`` when moved to a
+    reference point offset by ``d = com - reference``.  This is the piece
+    :func:`transform_inertial` deliberately leaves out -- it maps a tensor
+    into another frame while keeping it about the (moved) centre of mass,
+    whereas this moves the reference point itself.
+
+    Parameters
+    ----------
+    mass : float
+        Mass of the body in kg.
+    inertia : numpy.ndarray or sequence of 6 floats
+        Tensor about ``com``: either the 3x3 matrix or the 6 components
+        ``(ixx, ixy, ixz, iyy, iyz, izz)``.
+    com : sequence of 3 floats
+        Centre of mass, in the frame the tensor is expressed in.
+    reference : sequence of 3 floats
+        Point to take the shifted tensor about, in the same frame.
+
+    Returns
+    -------
+    inertia : numpy.ndarray
+        3x3 tensor about ``reference``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skrobot.utils.inertia import parallel_axis
+    >>> # a 2 kg point-like body 1 m along x picks up m * d^2 about y and z
+    >>> parallel_axis(2.0, np.zeros((3, 3)), [1, 0, 0], [0, 0, 0])
+    array([[0., 0., 0.],
+           [0., 2., 0.],
+           [0., 0., 2.]])
+    """
+    inertia = _as_tensor(inertia)
+    offset = np.asarray(com, dtype=np.float64) \
+        - np.asarray(reference, dtype=np.float64)
+    return inertia + float(mass) * (
+        float(offset.dot(offset)) * np.eye(3) - np.outer(offset, offset))
+
+
+def combine_inertials(*infos):
+    """Lump several rigid bodies into one inertial.
+
+    Every input must already be expressed in the SAME frame (use
+    :func:`transform_inertial` first if they are not).  The combined mass is
+    the sum, the combined centre of mass is the mass-weighted mean, and each
+    tensor is shifted to that combined centre with :func:`parallel_axis`
+    before being summed -- the standard rigid-body composition, and exactly
+    what lumping a fixed-joint child into its parent requires.
+
+    Parameters
+    ----------
+    infos : dict
+        Inertial dicts as produced by :func:`transform_inertial` /
+        :func:`link_inertial_from_mesh`: ``{'mass', 'com', 'inertia'}``, with
+        ``inertia`` as the 6 components or a 3x3 tensor.  Entries that are
+        None or carry a non-positive mass are skipped, so a link without an
+        ``<inertial>`` can be passed straight through.
+
+    Returns
+    -------
+    info : dict or None
+        ``{'mass', 'com', 'inertia', 'method'}`` with ``inertia`` as the 6
+        components about the combined centre of mass, or None when nothing
+        usable was given.  ``method`` joins the inputs' tags with ``'+'``.
+
+    Examples
+    --------
+    >>> from skrobot.utils.inertia import combine_inertials
+    >>> a = {'mass': 1.0, 'com': [0, 0, 0], 'inertia': (0, 0, 0, 0, 0, 0)}
+    >>> b = {'mass': 1.0, 'com': [2, 0, 0], 'inertia': (0, 0, 0, 0, 0, 0)}
+    >>> combined = combine_inertials(a, b)
+    >>> combined['mass'], combined['com']
+    (2.0, [1.0, 0.0, 0.0])
+    """
+    usable = []
+    for info in infos:
+        if not info:
+            continue
+        try:
+            mass = float(info['mass'])
+            com = np.asarray(info['com'], dtype=np.float64)
+            inertia = _as_tensor(info['inertia'])
+        except (TypeError, ValueError, KeyError):
+            continue
+        if not (np.isfinite(mass) and mass > 0 and com.shape == (3,)
+                and np.all(np.isfinite(com)) and np.all(np.isfinite(inertia))):
+            continue
+        usable.append((mass, com, inertia, info.get('method', '?')))
+    if not usable:
+        return None
+    total_mass = sum(item[0] for item in usable)
+    centroid = sum(item[0] * item[1] for item in usable) / total_mass
+    tensor = sum(parallel_axis(mass, inertia, com, centroid)
+                 for mass, com, inertia, _ in usable)
+    return {
+        'mass': total_mass,
+        'com': [float(c) for c in centroid],
+        'inertia': (float(tensor[0, 0]), float(tensor[0, 1]),
+                    float(tensor[0, 2]), float(tensor[1, 1]),
+                    float(tensor[1, 2]), float(tensor[2, 2])),
+        'method': '+'.join(item[3] for item in usable),
     }
 
 

--- a/tests/skrobot_tests/utils_tests/test_inertia.py
+++ b/tests/skrobot_tests/utils_tests/test_inertia.py
@@ -6,11 +6,22 @@ import numpy as np
 import trimesh
 
 from skrobot.coordinates.math import rpy2matrix
+from skrobot.coordinates.math import skew_symmetric_matrix
+from skrobot.utils.inertia import combine_inertials
 from skrobot.utils.inertia import link_inertial_from_mesh
 from skrobot.utils.inertia import mesh_mass_properties
+from skrobot.utils.inertia import parallel_axis
 from skrobot.utils.inertia import rescale_inertial_to_mass
 from skrobot.utils.inertia import transform_inertial
 from skrobot.utils.inertia import validate_inertia
+
+
+def _box_tensor(mass, extents):
+    """Analytic inertia of a solid box about its centre of mass."""
+    a, b, c = extents
+    return np.diag([mass * (b ** 2 + c ** 2) / 12.0,
+                    mass * (a ** 2 + c ** 2) / 12.0,
+                    mass * (a ** 2 + b ** 2) / 12.0])
 
 
 def _box_mesh_file(directory, extents=(0.2, 0.1, 0.05)):
@@ -148,6 +159,132 @@ class TestRescaleAndValidate(unittest.TestCase):
         # not positive definite
         problems = validate_inertia(1.0, (-1.0, 0.0, 0.0, 1.0, 0.0, 1.0))
         self.assertTrue(any('positive definite' in p for p in problems))
+
+
+class TestParallelAxis(unittest.TestCase):
+
+    def test_point_mass_offset(self):
+        # a 2 kg body 1 m along x gains m * d^2 about y and z, nothing about x
+        shifted = parallel_axis(2.0, np.zeros((3, 3)), [1, 0, 0], [0, 0, 0])
+        np.testing.assert_allclose(shifted, np.diag([0.0, 2.0, 2.0]))
+
+    def test_zero_offset_is_identity(self):
+        tensor = np.diag([1.0, 2.0, 3.0])
+        np.testing.assert_allclose(
+            parallel_axis(5.0, tensor, [1, 2, 3], [1, 2, 3]), tensor)
+
+    def test_box_about_corner_matches_textbook(self):
+        # a solid box about one corner is m*(b^2+c^2)/3 (vs /12 about the com)
+        mass, extents = 3.0, (0.2, 0.1, 0.05)
+        a, b, c = extents
+        corner = parallel_axis(mass, _box_tensor(mass, extents),
+                               [0.0, 0.0, 0.0],
+                               [a / 2.0, b / 2.0, c / 2.0])
+        np.testing.assert_allclose(
+            np.diag(corner),
+            [mass * (b ** 2 + c ** 2) / 3.0,
+             mass * (a ** 2 + c ** 2) / 3.0,
+             mass * (a ** 2 + b ** 2) / 3.0], atol=1e-12)
+        # the products of inertia about a corner are -m*x*y etc.
+        self.assertAlmostEqual(corner[0, 1], -mass * (a / 2.0) * (b / 2.0))
+
+    def test_accepts_6_components(self):
+        components = (1.0, 0.1, 0.2, 2.0, 0.3, 3.0)
+        tensor = np.array([[1.0, 0.1, 0.2],
+                           [0.1, 2.0, 0.3],
+                           [0.2, 0.3, 3.0]])
+        np.testing.assert_allclose(
+            parallel_axis(1.5, components, [0, 1, 0], [0, 0, 0]),
+            parallel_axis(1.5, tensor, [0, 1, 0], [0, 0, 0]))
+
+    def test_matches_skew_symmetric_form(self):
+        # the same theorem written as -m [r]x [r]x, as used by
+        # RobotModel.update_mass_properties
+        rng = np.random.RandomState(0)
+        for _ in range(20):
+            mass = float(rng.uniform(0.01, 10.0))
+            offset = rng.uniform(-2.0, 2.0, 3)
+            tensor = rng.uniform(-1.0, 1.0, (3, 3))
+            tensor = tensor + tensor.T
+            cross = skew_symmetric_matrix(offset)
+            np.testing.assert_allclose(
+                parallel_axis(mass, tensor, offset, np.zeros(3)),
+                tensor - mass * cross.dot(cross), atol=1e-12)
+
+
+class TestCombineInertials(unittest.TestCase):
+
+    def test_two_point_masses(self):
+        zero = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        left = {'mass': 1.0, 'com': [-1, 0, 0], 'inertia': zero}
+        right = {'mass': 1.0, 'com': [1, 0, 0], 'inertia': zero}
+        out = combine_inertials(left, right)
+        self.assertEqual(out['mass'], 2.0)
+        np.testing.assert_allclose(out['com'], [0.0, 0.0, 0.0], atol=1e-12)
+        # each mass sits 1 m off the combined centre, on the x axis
+        np.testing.assert_allclose(out['inertia'], (0.0, 0.0, 0.0,
+                                                    2.0, 0.0, 2.0),
+                                   atol=1e-12)
+
+    def test_halves_recombine_into_the_whole_box(self):
+        """Splitting a solid box in two and lumping it back must reproduce the
+        box's own tensor -- the physical invariant this function exists for."""
+        extents = (0.2, 0.1, 0.05)
+        mass = 4.0
+        half = {'mass': mass / 2.0,
+                'inertia': _box_tensor(mass / 2.0,
+                                       (extents[0] / 2.0,) + extents[1:])}
+        out = combine_inertials(
+            dict(half, com=[-extents[0] / 4.0, 0, 0]),
+            dict(half, com=[extents[0] / 4.0, 0, 0]))
+        self.assertAlmostEqual(out['mass'], mass)
+        np.testing.assert_allclose(out['com'], [0.0, 0.0, 0.0], atol=1e-12)
+        whole = _box_tensor(mass, extents)
+        np.testing.assert_allclose(
+            out['inertia'],
+            (whole[0, 0], 0.0, 0.0, whole[1, 1], 0.0, whole[2, 2]),
+            atol=1e-12)
+
+    def test_order_does_not_matter(self):
+        a = {'mass': 1.5, 'com': [0.1, 0.2, 0.3],
+             'inertia': (1.0, 0.0, 0.0, 2.0, 0.0, 3.0), 'method': 'a'}
+        b = {'mass': 0.5, 'com': [-0.4, 0.0, 0.2],
+             'inertia': (0.5, 0.1, 0.0, 0.5, 0.0, 0.5), 'method': 'b'}
+        forward = combine_inertials(a, b)
+        backward = combine_inertials(b, a)
+        np.testing.assert_allclose(forward['inertia'], backward['inertia'],
+                                   atol=1e-12)
+        np.testing.assert_allclose(forward['com'], backward['com'], atol=1e-12)
+
+    def test_skips_unusable_and_reports_method(self):
+        good = {'mass': 2.0, 'com': [0, 0, 0],
+                'inertia': (1.0, 0.0, 0.0, 1.0, 0.0, 1.0), 'method': 'mesh'}
+        massless = {'mass': 0.0, 'com': [1, 1, 1],
+                    'inertia': (1.0, 0.0, 0.0, 1.0, 0.0, 1.0)}
+        out = combine_inertials(good, None, massless, dict(good, method='sw'))
+        self.assertEqual(out['mass'], 4.0)
+        self.assertEqual(out['method'], 'mesh+sw')
+
+    def test_returns_none_when_nothing_usable(self):
+        self.assertIsNone(combine_inertials())
+        self.assertIsNone(combine_inertials(None, {}))
+        self.assertIsNone(combine_inertials(
+            {'mass': -1.0, 'com': [0, 0, 0],
+             'inertia': (1.0, 0.0, 0.0, 1.0, 0.0, 1.0)}))
+
+    def test_composes_with_transform_inertial(self):
+        """The documented workflow: move each body into a common frame with
+        transform_inertial, then lump them."""
+        body = {'mass': 1.0, 'com': [0.1, 0.0, 0.0],
+                'inertia': (0.01, 0.0, 0.0, 0.02, 0.0, 0.03)}
+        moved = transform_inertial(body['mass'], body['com'], body['inertia'],
+                                   [0.0, 0.0, 0.5], [0.0, 0.0, np.pi / 2])
+        out = combine_inertials(body, moved)
+        self.assertAlmostEqual(out['mass'], 2.0)
+        # com of the rotated+translated copy is Rz(90) @ [0.1,0,0] + [0,0,0.5]
+        np.testing.assert_allclose(out['com'],
+                                   [0.05, 0.05, 0.25], atol=1e-12)
+        self.assertEqual(validate_inertia(out['mass'], out['inertia']), [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`transform_inertial` deliberately keeps a tensor about its centre of mass, so the module had no way to move the reference point — the only parallel-axis shift in the package is inlined in `RobotModel.update_mass_properties`.
This adds `parallel_axis` for the Huygens-Steiner shift and `combine_inertials` for lumping several bodies given in a common frame into one (mass sum, mass-weighted centre, each tensor shifted to it and summed), which composes with `transform_inertial` and is what merging a fixed-joint child into its parent requires.
Tested against the textbook box-about-a-corner result and against the equivalent `-m [r]x [r]x` form used in `update_mass_properties`, which could adopt `parallel_axis` in a follow-up.