### PR TITLE
Add canonicalize_urdf for diff-friendly URDF comparison

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ console_scripts.append("urdf-hash=skrobot.apps.urdf_hash:main")
 console_scripts.append("convert-wheel-collision=skrobot.apps.convert_wheel_collision:main")
 console_scripts.append("urdf-tree=skrobot.apps.urdf_tree:main")
 console_scripts.append("convert-urdf-to-mjcf=skrobot.apps.convert_urdf_to_mjcf:main")
+console_scripts.append("canonicalize-urdf=skrobot.apps.canonicalize_urdf:main")
 
 
 setup(

--- a/skrobot/apps/canonicalize_urdf.py
+++ b/skrobot/apps/canonicalize_urdf.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+
+from skrobot.urdf.canonicalize import canonicalize_urdf_file
+
+
+def main():
+    """Rewrite a URDF in canonical, diff-friendly form."""
+    parser = argparse.ArgumentParser(
+        description='Rewrite a URDF in canonical form (links/joints sorted '
+                    'by name, fixed attribute order, uniform number '
+                    'formatting) so two equivalent URDFs diff cleanly.',
+        formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        'urdf_file',
+        type=str,
+        help='Path to the URDF file')
+    parser.add_argument(
+        '-o', '--output',
+        type=str,
+        default=None,
+        help='Output path (default: print to stdout)')
+    parser.add_argument(
+        '--kinematics-only',
+        action='store_true',
+        help='Drop visual/collision/inertial/material/transmission/gazebo '
+             'elements, keeping only the kinematic skeleton')
+
+    args = parser.parse_args()
+
+    try:
+        text = canonicalize_urdf_file(
+            args.urdf_file, output_path=args.output,
+            kinematics_only=args.kinematics_only)
+    except (ValueError, OSError) as e:
+        print("Error: {}".format(e), file=sys.stderr)
+        sys.exit(1)
+    if args.output is None:
+        sys.stdout.write(text)
+
+
+if __name__ == '__main__':
+    main()

--- a/skrobot/urdf/__init__.py
+++ b/skrobot/urdf/__init__.py
@@ -1,4 +1,6 @@
 from skrobot.urdf.aggregate import aggregate_urdf_mesh_files
+from skrobot.urdf.canonicalize import canonicalize_urdf
+from skrobot.urdf.canonicalize import canonicalize_urdf_file
 from skrobot.urdf.extract_sub_urdf import extract_sub_urdf
 from skrobot.urdf.llm_grouping import build_grouping_prompt
 from skrobot.urdf.llm_grouping import compute_jaw_gripper_frame
@@ -50,5 +52,7 @@ __all__ = [
     'compute_jaw_gripper_frame',
     'sanitize_name',
     'sanitize_urdf_names',
+    'canonicalize_urdf',
+    'canonicalize_urdf_file',
     'urdf_to_mjcf',
 ]

--- a/skrobot/urdf/canonicalize.py
+++ b/skrobot/urdf/canonicalize.py
@@ -1,0 +1,208 @@
+"""Rewrite a URDF in a canonical, diff-friendly form.
+
+Two URDFs that describe the same robot rarely diff cleanly: exporters order
+links and joints differently, shuffle attributes, and format numbers with
+different precision (including ``-0`` artifacts).  ``canonicalize_urdf``
+rewrites a URDF so that semantically equal documents become textually equal:
+links and joints are sorted by name, child elements and attributes follow a
+fixed order, and every number is formatted with one rule (``%.10g``, values
+below ``1e-12`` snapped to exact ``0``).  The output is still a valid URDF,
+so ``diff -u`` / ``git diff --no-index`` between two canonicalized files
+shows only meaningful differences.
+
+XML comments and processing instructions are dropped from the canonical
+form.
+"""
+
+import xml.etree.ElementTree as ET
+
+
+__all__ = [
+    'canonicalize_urdf',
+    'canonicalize_urdf_file',
+]
+
+# Fixed child-element order inside <joint> and <link>; unknown tags follow,
+# sorted by tag name, so nothing is silently dropped.
+_JOINT_CHILD_ORDER = ['origin', 'parent', 'child', 'axis', 'limit', 'mimic',
+                      'dynamics', 'calibration', 'safety_controller']
+_LINK_CHILD_ORDER = ['inertial', 'visual', 'collision']
+
+# Elements removed by ``kinematics_only`` (top level and inside <link>).
+_NON_KINEMATIC_TAGS = frozenset(['visual', 'collision', 'inertial',
+                                 'material', 'transmission', 'gazebo'])
+
+# Attributes holding a number or a whitespace-separated number list.
+_NUMERIC_ATTRS = frozenset([
+    'xyz', 'rpy', 'lower', 'upper', 'effort', 'velocity', 'value',
+    'ixx', 'ixy', 'ixz', 'iyy', 'iyz', 'izz', 'multiplier', 'offset',
+    'scale', 'radius', 'length', 'size', 'rgba',
+    'soft_lower_limit', 'soft_upper_limit', 'k_position', 'k_velocity',
+    'damping', 'friction', 'rising', 'falling',
+])
+
+_ZERO_SNAP = 1e-12
+
+
+def _format_number_token(token):
+    """Format one attribute token; non-numeric tokens pass through.
+
+    Parameters
+    ----------
+    token : str
+        One whitespace-separated token from an attribute value.
+
+    Returns
+    -------
+    str
+        ``%.10g`` rendering with ``|value| < 1e-12`` snapped to ``0`` (which
+        also removes ``-0``), or the original token when it is not a number.
+    """
+    try:
+        value = float(token)
+    except ValueError:
+        return token
+    if abs(value) < _ZERO_SNAP:
+        value = 0.0
+    return '%.10g' % value
+
+
+def _canonical_attribute(key, value):
+    if key in _NUMERIC_ATTRS:
+        return ' '.join(_format_number_token(t) for t in value.split())
+    return value
+
+
+def _child_sort_key(order):
+    def key(elem):
+        if elem.tag in order:
+            return (0, order.index(elem.tag), elem.get('name', ''))
+        return (1, 0, elem.tag + '\x00' + elem.get('name', ''))
+    return key
+
+
+def _rebuild(elem, child_order):
+    """Copy ``elem`` with canonical attributes and ordered children."""
+    out = ET.Element(elem.tag)
+    for key in sorted(elem.keys(), key=lambda a: (a != 'name', a)):
+        out.set(key, _canonical_attribute(key, elem.get(key)))
+    for child in sorted(list(elem), key=_child_sort_key(child_order)):
+        out.append(_rebuild(child, []))
+    if elem.text is not None and elem.text.strip():
+        out.text = elem.text.strip()
+    return out
+
+
+def _indent(elem, level=0):
+    pad = '\n' + '  ' * (level + 1)
+    if len(elem):
+        elem.text = pad
+        for child in elem:
+            _indent(child, level + 1)
+            child.tail = pad
+        elem[-1].tail = '\n' + '  ' * level
+    return elem
+
+
+def canonicalize_urdf(urdf_xml, kinematics_only=False):
+    """Return ``urdf_xml`` rewritten in canonical, diff-friendly form.
+
+    Links and joints are sorted by ``name``, child elements and attributes
+    follow a fixed order, and all numbers share one format (``%.10g`` with
+    ``|value| < 1e-12`` snapped to exact ``0``).  The result is a valid URDF
+    and the transform is idempotent.
+
+    Parameters
+    ----------
+    urdf_xml : str
+        URDF document text.
+    kinematics_only : bool, optional
+        When True, drop ``<visual>``, ``<collision>``, ``<inertial>``,
+        ``<material>``, ``<transmission>`` and ``<gazebo>`` elements so only
+        the kinematic skeleton (links, joints, origins, axes, limits, mimic)
+        remains.  Default is False.
+
+    Returns
+    -------
+    str
+        The canonicalized URDF text.
+
+    Raises
+    ------
+    ValueError
+        If ``urdf_xml`` is not parseable XML or its root element is not
+        ``<robot>``.
+
+    Examples
+    --------
+    >>> from skrobot.urdf import canonicalize_urdf
+    >>> a = canonicalize_urdf(open('a.urdf').read())   # doctest: +SKIP
+    >>> b = canonicalize_urdf(open('b.urdf').read())   # doctest: +SKIP
+    >>> a == b                                         # doctest: +SKIP
+    True
+    """
+    try:
+        root = ET.fromstring(urdf_xml)
+    except ET.ParseError as e:
+        raise ValueError('invalid URDF XML: {}'.format(e))
+    if root.tag != 'robot':
+        raise ValueError(
+            "root element is <{}>, expected <robot>".format(root.tag))
+
+    out = ET.Element('robot')
+    if root.get('name') is not None:
+        out.set('name', root.get('name'))
+
+    links = []
+    joints = []
+    others = []
+    for elem in root:
+        if elem.tag == 'link':
+            links.append(elem)
+        elif elem.tag == 'joint':
+            joints.append(elem)
+        else:
+            others.append(elem)
+
+    for elem in sorted(others, key=lambda e: (e.tag, e.get('name', ''))):
+        if kinematics_only and elem.tag in _NON_KINEMATIC_TAGS:
+            continue
+        out.append(_rebuild(elem, []))
+    for elem in sorted(links, key=lambda e: e.get('name', '')):
+        rebuilt = _rebuild(elem, _LINK_CHILD_ORDER)
+        if kinematics_only:
+            for tag in _NON_KINEMATIC_TAGS:
+                for victim in rebuilt.findall(tag):
+                    rebuilt.remove(victim)
+        out.append(rebuilt)
+    for elem in sorted(joints, key=lambda e: e.get('name', '')):
+        out.append(_rebuild(elem, _JOINT_CHILD_ORDER))
+
+    return ET.tostring(_indent(out), encoding='unicode') + '\n'
+
+
+def canonicalize_urdf_file(urdf_path, output_path=None,
+                           kinematics_only=False):
+    """Canonicalize the URDF at ``urdf_path``.
+
+    Parameters
+    ----------
+    urdf_path : str
+        Path of the URDF file to read.
+    output_path : str or None, optional
+        When given, the canonical text is also written there (UTF-8, LF
+        newlines).  Writing to ``urdf_path`` itself is allowed.
+    kinematics_only : bool, optional
+        Forwarded to :func:`canonicalize_urdf`.  Default is False.
+
+    Returns
+    -------
+    str
+        The canonicalized URDF text.
+    """
+    with open(urdf_path, encoding='utf-8') as f:
+        text = canonicalize_urdf(f.read(), kinematics_only=kinematics_only)
+    if output_path is not None:
+        with open(output_path, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(text)
+    return text

--- a/tests/skrobot_tests/urdf_tests/test_canonicalize.py
+++ b/tests/skrobot_tests/urdf_tests/test_canonicalize.py
@@ -1,0 +1,126 @@
+import os
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+from skrobot.urdf import canonicalize_urdf
+from skrobot.urdf import canonicalize_urdf_file
+
+
+URDF_A = """<robot name="r">
+  <joint name="j2" type="revolute">
+    <child link="tip"/>
+    <axis xyz="0 0 -1"/>
+    <parent link="arm"/>
+    <origin xyz="0.10000000001 0 -0" rpy="0 -0 0"/>
+    <limit velocity="1" effort="10" lower="-1" upper="1"/>
+  </joint>
+  <link name="tip"/>
+  <joint name="j1" type="revolute">
+    <parent link="base"/>
+    <child link="arm"/>
+    <axis xyz="1 8.62e-16 0"/>
+    <origin xyz="0 0 0.5" rpy="0 0 0"/>
+    <limit lower="-1" upper="1" effort="10" velocity="1"/>
+  </joint>
+  <link name="arm">
+    <visual>
+      <geometry><box size="0.1 0.1 0.1"/></geometry>
+    </visual>
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>
+  </link>
+  <link name="base"/>
+</robot>
+"""
+
+# Same robot: different element order, attribute order, number spelling.
+URDF_B = """<robot name="r">
+  <link name="base"/>
+  <link name="arm">
+    <inertial>
+      <inertia izz="1" iyz="0" iyy="1" ixz="0" ixy="0" ixx="1"/>
+      <mass value="1.0"/>
+    </inertial>
+    <visual>
+      <geometry><box size="0.1 0.1 0.1"/></geometry>
+    </visual>
+  </link>
+  <link name="tip"/>
+  <joint type="revolute" name="j1">
+    <origin rpy="-0 0 0" xyz="0 0 0.50000000004"/>
+    <parent link="base"/>
+    <child link="arm"/>
+    <axis xyz="1 0 -0"/>
+    <limit effort="10.0" lower="-1.0" upper="1.0" velocity="1.0"/>
+  </joint>
+  <joint type="revolute" name="j2">
+    <origin xyz="0.1 0 0" rpy="0 0 0"/>
+    <parent link="arm"/>
+    <child link="tip"/>
+    <axis xyz="0 0 -1"/>
+    <limit effort="10" lower="-1" upper="1" velocity="1"/>
+  </joint>
+</robot>
+"""
+
+
+class TestCanonicalizeUrdf(unittest.TestCase):
+
+    def test_equivalent_documents_canonicalize_identically(self):
+        self.assertEqual(canonicalize_urdf(URDF_A), canonicalize_urdf(URDF_B))
+
+    def test_idempotent(self):
+        once = canonicalize_urdf(URDF_A)
+        self.assertEqual(once, canonicalize_urdf(once))
+
+    def test_output_is_valid_urdf(self):
+        root = ET.fromstring(canonicalize_urdf(URDF_A))
+        self.assertEqual(root.tag, 'robot')
+        self.assertEqual(len(root.findall('link')), 3)
+        self.assertEqual(len(root.findall('joint')), 2)
+
+    def test_negative_zero_and_noise_snapped(self):
+        text = canonicalize_urdf(URDF_A)
+        self.assertNotIn('-0 ', text)
+        self.assertNotIn('"-0"', text)
+        self.assertNotIn('8.62e-16', text)
+        # axis "1 8.62e-16 0" -> "1 0 0"
+        self.assertIn('<axis xyz="1 0 0" />', text)
+
+    def test_links_and_joints_sorted_by_name(self):
+        root = ET.fromstring(canonicalize_urdf(URDF_A))
+        link_names = [e.get('name') for e in root.findall('link')]
+        joint_names = [e.get('name') for e in root.findall('joint')]
+        self.assertEqual(link_names, sorted(link_names))
+        self.assertEqual(joint_names, sorted(joint_names))
+
+    def test_kinematics_only_strips_geometry(self):
+        text = canonicalize_urdf(URDF_A, kinematics_only=True)
+        self.assertNotIn('<visual', text)
+        self.assertNotIn('<inertial', text)
+        self.assertIn('<axis', text)
+        self.assertIn('<limit', text)
+
+    def test_invalid_input_raises(self):
+        with self.assertRaises(ValueError):
+            canonicalize_urdf('not xml at all <')
+        with self.assertRaises(ValueError):
+            canonicalize_urdf('<not_a_robot/>')
+
+    def test_file_roundtrip(self):
+        tmpdir = tempfile.mkdtemp()
+        in_path = os.path.join(tmpdir, 'in.urdf')
+        out_path = os.path.join(tmpdir, 'out.urdf')
+        with open(in_path, 'w', encoding='utf-8') as f:
+            f.write(URDF_B)
+        text = canonicalize_urdf_file(in_path, output_path=out_path)
+        with open(out_path, encoding='utf-8') as f:
+            self.assertEqual(f.read(), text)
+        self.assertEqual(text, canonicalize_urdf(URDF_A))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds skrobot.urdf.canonicalize_urdf / canonicalize_urdf_file, which rewrite a URDF into a canonical form (links/joints sorted by name, fixed attribute and child-element order, uniform number formatting with sub-1e-12 values snapped to exact 0).
Two URDFs describing the same robot then become textually identical, so plain diff / git diff --no-index shows only meaningful differences; a --kinematics-only mode strips visual/collision/inertial elements to compare just the kinematic skeleton.
A canonicalize-urdf console script exposes the same functionality on the command line, with unit tests covering ordering, zero snapping, idempotence and file round-trip.