### PR TITLE
Add flip_joint_axis, and remap limits when re-rooting reverses a joint

### DIFF
--- a/skrobot/urdf/__init__.py
+++ b/skrobot/urdf/__init__.py
@@ -2,6 +2,8 @@ from skrobot.urdf.aggregate import aggregate_urdf_mesh_files
 from skrobot.urdf.canonicalize import canonicalize_urdf
 from skrobot.urdf.canonicalize import canonicalize_urdf_file
 from skrobot.urdf.extract_sub_urdf import extract_sub_urdf
+from skrobot.urdf.flip_axis import flip_joint_axis
+from skrobot.urdf.flip_axis import flip_joint_axis_file
 from skrobot.urdf.llm_grouping import build_grouping_prompt
 from skrobot.urdf.llm_grouping import compute_jaw_gripper_frame
 from skrobot.urdf.llm_grouping import generate_groups_from_llm
@@ -39,6 +41,8 @@ __all__ = [
     'convert_meshes_to_primitives',
     'get_mesh_dimensions',
     'extract_sub_urdf',
+    'flip_joint_axis',
+    'flip_joint_axis_file',
     'scale_urdf',
     'generate_groups_from_geometry',
     'generate_robot_class_from_geometry',

--- a/skrobot/urdf/flip_axis.py
+++ b/skrobot/urdf/flip_axis.py
@@ -1,0 +1,200 @@
+"""Reverse the positive direction of a URDF joint.
+
+Negating a joint's ``<axis>`` alone leaves the document inconsistent: the
+travel range and any mimic coupling are still expressed in the old sense and
+have to move with it.  :func:`flip_joint_axis` performs the whole edit -- axis,
+limits, the joint's own mimic coefficients and the coefficients of every joint
+that mimics it -- so the mechanism reaches the same poses afterwards and only
+the sign of the commanded value changes.
+"""
+
+import xml.etree.ElementTree as ET
+
+
+__all__ = [
+    'flip_joint_axis',
+    'flip_joint_axis_file',
+]
+
+# attribute pairs holding a lower/upper bound on the joint value, on <limit>
+# and on <safety_controller>
+_BOUND_PAIRS = (('lower', 'upper'),
+                ('soft_lower_limit', 'soft_upper_limit'))
+
+
+def _fmt(value):
+    """Format a flipped number, folding ``-0.0`` back to ``0``."""
+    return '0' if value == 0.0 else '{:.10g}'.format(value)
+
+
+def _negate_attrib(element, name, default=None):
+    """Negate one numeric attribute in place.
+
+    ``default`` is the value URDF gives the attribute when it is absent; pass
+    it for an attribute whose implied value is not its own negation, so the
+    flipped value gets written out explicitly.  Unparsable values are left
+    alone.
+    """
+    raw = element.get(name)
+    if raw is None:
+        if default is None:
+            return
+        raw = default
+    try:
+        element.set(name, _fmt(-float(raw)))
+    except ValueError:
+        pass
+
+
+def _axis_of(joint):
+    """The joint's axis as floats, or None when it has no usable one."""
+    axis = joint.find('axis')
+    if axis is None:
+        return None
+    try:
+        values = [float(v) for v in axis.get('xyz', '').split()]
+    except ValueError:
+        return None
+    if len(values) != 3 or not any(values):
+        return None
+    return values
+
+
+def flip_joint_axis(root, joint_name):
+    """Reverse one joint's positive direction, in place.
+
+    The joint reaches the same physical range afterwards; only the sign of the
+    value that commands it changes.  Four things move together:
+
+    - ``<axis xyz>`` is negated;
+    - ``<limit lower/upper>`` is swapped and negated, so ``[-0.5, 2.0]``
+      becomes ``[-2.0, 0.5]``.  A bound changes side, not just sign: ``q <= U``
+      is ``q' >= -U``, so a one-sided limit moves to the other attribute.  The
+      soft bounds on ``<safety_controller>`` move with it;
+    - this joint's own ``<mimic>`` has both ``multiplier`` and ``offset``
+      negated, since its own value changed sign;
+    - every OTHER joint mimicking this one has its ``multiplier`` negated and
+      its ``offset`` left alone.  Those ``<mimic joint="...">`` tags live in
+      the follower's element, not in this one, which is the part a hand-written
+      flip usually misses: from ``q_f = m * q_d + b`` and ``q_d -> -q_d``, the
+      follower needs ``-m`` to stay in phase.
+
+    The joint's ``<origin>`` is deliberately untouched, so no frame moves, and
+    the operation is its own inverse -- flipping twice restores the original
+    values.
+
+    Parameters
+    ----------
+    root : xml.etree.ElementTree.Element
+        The ``<robot>`` element, modified in place.
+    joint_name : str
+        Name of the joint to reverse.
+
+    Returns
+    -------
+    flipped : bool
+        False when no such joint exists, or when it has no usable axis (a
+        ``fixed`` joint, or one whose axis is the zero vector); nothing is
+        modified in that case.
+
+    Examples
+    --------
+    >>> import xml.etree.ElementTree as ET
+    >>> from skrobot.urdf import flip_joint_axis
+    >>> root = ET.fromstring('''<robot name="r">
+    ...   <joint name="j" type="revolute">
+    ...     <axis xyz="0 0 1"/>
+    ...     <limit lower="-0.5" upper="2.0" effort="1" velocity="1"/>
+    ...   </joint>
+    ... </robot>''')
+    >>> flip_joint_axis(root, 'j')
+    True
+    >>> joint = root.find('joint')
+    >>> joint.find('axis').get('xyz')
+    '0 0 -1'
+    >>> joint.find('limit').get('lower'), joint.find('limit').get('upper')
+    ('-2', '0.5')
+
+    See Also
+    --------
+    skrobot.urdf.change_urdf_root_link : re-roots a URDF, reversing every joint
+        along the path with this function.
+    """
+    joint = None
+    for candidate in root.findall('joint'):
+        if candidate.get('name') == joint_name:
+            joint = candidate
+            break
+    if joint is None:
+        return False
+    axis_values = _axis_of(joint)
+    if axis_values is None:
+        return False
+
+    joint.find('axis').set(
+        'xyz', ' '.join(_fmt(-v) for v in axis_values))
+
+    # q <= U becomes q' >= -U, so a bound does not merely change sign: it
+    # changes side.  A one-sided limit therefore moves to the other attribute
+    # rather than staying put.
+    for element in (joint.find('limit'), joint.find('safety_controller')):
+        if element is None:
+            continue
+        for low_name, high_name in _BOUND_PAIRS:
+            low, high = element.get(low_name), element.get(high_name)
+            if low is None and high is None:
+                continue
+            try:
+                flipped_low = None if high is None else _fmt(-float(high))
+                flipped_high = None if low is None else _fmt(-float(low))
+            except ValueError:
+                continue
+            for name, value in ((low_name, flipped_low),
+                                (high_name, flipped_high)):
+                if value is None:
+                    element.attrib.pop(name, None)
+                else:
+                    element.set(name, value)
+
+    mimic = joint.find('mimic')
+    if mimic is not None:
+        # multiplier defaults to 1 and offset to 0 when absent; the implied
+        # multiplier has to be written out, since -1 is not the default
+        _negate_attrib(mimic, 'multiplier', default='1')
+        _negate_attrib(mimic, 'offset')
+
+    for follower in root.findall('joint'):
+        if follower is joint:
+            continue
+        follower_mimic = follower.find('mimic')
+        if follower_mimic is not None \
+                and follower_mimic.get('joint') == joint_name:
+            _negate_attrib(follower_mimic, 'multiplier', default='1')
+    return True
+
+
+def flip_joint_axis_file(input_path, joint_name, output_path=None):
+    """Apply :func:`flip_joint_axis` to a URDF file.
+
+    Parameters
+    ----------
+    input_path : str
+        URDF to read.
+    joint_name : str
+        Name of the joint to reverse.
+    output_path : str or None
+        Where to write.  Defaults to ``input_path``, editing it in place.
+
+    Returns
+    -------
+    flipped : bool
+        Whether the joint was reversed.  The output is written either way when
+        ``output_path`` names a different file, so it can be used as a copy.
+    """
+    tree = ET.parse(input_path)
+    flipped = flip_joint_axis(tree.getroot(), joint_name)
+    if not flipped and output_path in (None, input_path):
+        return False
+    tree.write(output_path or input_path,
+               encoding='utf-8', xml_declaration=True)
+    return flipped

--- a/skrobot/urdf/xml_root_link_changer.py
+++ b/skrobot/urdf/xml_root_link_changer.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy.spatial.transform import Rotation as R
 
 from skrobot.coordinates.math import invert_yaw_pitch_roll
+from skrobot.urdf.flip_axis import flip_joint_axis
 
 
 class URDFXMLRootLinkChanger:
@@ -345,12 +346,10 @@ class URDFXMLRootLinkChanger:
         origin.set('xyz', ' '.join(map(str, new_xyz)))
         origin.set('rpy', ' '.join(map(str, new_rpy)))
 
-        # Invert axis direction
-        axis = joint.find('axis')
-        if axis is not None:
-            axis_xyz_str = axis.get('xyz', '0 0 0')
-            inv_axis_xyz = [-float(x) for x in axis_xyz_str.split()]
-            axis.set('xyz', ' '.join(map(str, inv_axis_xyz)))
+        # Reverse the joint's sense.  The axis is not the only thing that has
+        # to move: an asymmetric <limit> and any mimic coupling are expressed
+        # in the old sense too, so they are remapped with it.
+        flip_joint_axis(self.root, joint.get('name'))
 
         # The joint's old parent link frame is relocated onto this joint's
         # frame; re-express everything attached to that link (visuals,

--- a/tests/skrobot_tests/urdf_tests/test_flip_axis.py
+++ b/tests/skrobot_tests/urdf_tests/test_flip_axis.py
@@ -1,0 +1,215 @@
+import os
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+from skrobot.urdf import change_urdf_root_link
+from skrobot.urdf import flip_joint_axis
+from skrobot.urdf import flip_joint_axis_file
+
+
+_URDF = """<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/>
+  <link name="mid"/>
+  <link name="tip"/>
+  <joint name="drive" type="revolute">
+    <origin xyz="0 0 0.1" rpy="0 0 0"/>
+    <parent link="base"/><child link="mid"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-0.5" upper="2.0" effort="10" velocity="1"/>
+  </joint>
+  <joint name="follow" type="revolute">
+    <origin xyz="0 0 0.2" rpy="0 0 0"/>
+    <parent link="mid"/><child link="tip"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.0" upper="1.0" effort="10" velocity="1"/>
+    <mimic joint="drive" multiplier="2.0" offset="0.25"/>
+  </joint>
+</robot>"""
+
+
+def _joint(root, name):
+    return next(j for j in root.findall('joint') if j.get('name') == name)
+
+
+class TestFlipJointAxis(unittest.TestCase):
+
+    def test_axis_and_limits_move_together(self):
+        root = ET.fromstring(_URDF)
+        self.assertTrue(flip_joint_axis(root, 'drive'))
+        drive = _joint(root, 'drive')
+        self.assertEqual(drive.find('axis').get('xyz'), '0 0 -1')
+        # the reachable range is preserved, expressed in the new sense
+        self.assertEqual(drive.find('limit').get('lower'), '-2')
+        self.assertEqual(drive.find('limit').get('upper'), '0.5')
+
+    def test_origin_is_untouched(self):
+        root = ET.fromstring(_URDF)
+        before = _joint(root, 'drive').find('origin').attrib.copy()
+        flip_joint_axis(root, 'drive')
+        self.assertEqual(_joint(root, 'drive').find('origin').attrib, before)
+
+    def test_followers_of_the_flipped_joint_keep_phase(self):
+        """A joint mimicking the flipped one needs -multiplier, same offset."""
+        root = ET.fromstring(_URDF)
+        flip_joint_axis(root, 'drive')
+        mimic = _joint(root, 'follow').find('mimic')
+        self.assertEqual(mimic.get('multiplier'), '-2')
+        self.assertEqual(mimic.get('offset'), '0.25')
+        # the follower's own axis and limits are its own business
+        self.assertEqual(_joint(root, 'follow').find('axis').get('xyz'),
+                         '0 1 0')
+
+    def test_flipping_a_follower_negates_both_its_coefficients(self):
+        root = ET.fromstring(_URDF)
+        flip_joint_axis(root, 'follow')
+        mimic = _joint(root, 'follow').find('mimic')
+        self.assertEqual(mimic.get('multiplier'), '-2')
+        self.assertEqual(mimic.get('offset'), '-0.25')
+        # the driver it points at is unaffected
+        self.assertEqual(_joint(root, 'drive').find('axis').get('xyz'),
+                         '0 0 1')
+
+    def test_flip_is_its_own_inverse(self):
+        root = ET.fromstring(_URDF)
+        before = ET.tostring(root)
+        flip_joint_axis(root, 'drive')
+        self.assertNotEqual(ET.tostring(root), before)
+        flip_joint_axis(root, 'drive')
+        after = ET.fromstring(ET.tostring(root))
+        original = ET.fromstring(_URDF)
+        for name in ('drive', 'follow'):
+            for tag in ('axis', 'limit', 'mimic'):
+                got, want = _joint(after, name).find(tag), \
+                    _joint(original, name).find(tag)
+                if want is None:
+                    continue
+                for key, value in want.attrib.items():
+                    where = '{}/{}/{}'.format(name, tag, key)
+                    try:
+                        numbers = [float(v) for v in value.split()]
+                    except ValueError:
+                        self.assertEqual(got.get(key), value, msg=where)
+                        continue
+                    self.assertEqual(len(got.get(key).split()), len(numbers),
+                                     msg=where)
+                    for a, b in zip(got.get(key).split(), numbers):
+                        self.assertAlmostEqual(float(a), b, msg=where)
+
+    def test_one_sided_limit_changes_side_not_just_sign(self):
+        """``q <= 0.4`` is ``q' >= -0.4``: the bound moves to the other
+        attribute.  Keeping it as an upper bound would silently relocate the
+        reachable range instead of mirroring it."""
+        root = ET.fromstring("""<robot name="r">
+          <joint name="j" type="prismatic"><axis xyz="1 0 0"/>
+            <limit upper="0.4" effort="1" velocity="1"/></joint>
+        </robot>""")
+        self.assertTrue(flip_joint_axis(root, 'j'))
+        limit = root.find('joint').find('limit')
+        self.assertEqual(limit.get('lower'), '-0.4')
+        self.assertIsNone(limit.get('upper'))
+        # and it is still self-inverse
+        flip_joint_axis(root, 'j')
+        limit = root.find('joint').find('limit')
+        self.assertEqual(limit.get('upper'), '0.4')
+        self.assertIsNone(limit.get('lower'))
+
+    def test_safety_controller_soft_limits_move_with_the_limit(self):
+        root = ET.fromstring("""<robot name="r">
+          <joint name="j" type="revolute"><axis xyz="0 0 1"/>
+            <limit lower="-0.5" upper="2.0" effort="1" velocity="1"/>
+            <safety_controller k_velocity="1" soft_lower_limit="-0.4"
+              soft_upper_limit="1.9"/></joint>
+        </robot>""")
+        self.assertTrue(flip_joint_axis(root, 'j'))
+        safety = root.find('joint').find('safety_controller')
+        self.assertEqual(safety.get('soft_lower_limit'), '-1.9')
+        self.assertEqual(safety.get('soft_upper_limit'), '0.4')
+        # unrelated attributes are untouched
+        self.assertEqual(safety.get('k_velocity'), '1')
+
+    def test_implicit_mimic_multiplier_is_written_out(self):
+        """``<mimic>`` without a multiplier means 1.0; after the driver flips
+        the follower needs -1, which has to become explicit."""
+        root = ET.fromstring("""<robot name="r">
+          <joint name="drive" type="revolute"><axis xyz="0 0 1"/></joint>
+          <joint name="follow" type="revolute"><axis xyz="0 0 1"/>
+            <mimic joint="drive"/></joint>
+        </robot>""")
+        self.assertTrue(flip_joint_axis(root, 'drive'))
+        mimic = _joint(root, 'follow').find('mimic')
+        self.assertEqual(mimic.get('multiplier'), '-1')
+
+    def test_flipping_a_follower_with_implicit_multiplier(self):
+        root = ET.fromstring("""<robot name="r">
+          <joint name="drive" type="revolute"><axis xyz="0 0 1"/></joint>
+          <joint name="follow" type="revolute"><axis xyz="0 0 1"/>
+            <mimic joint="drive" offset="0.25"/></joint>
+        </robot>""")
+        self.assertTrue(flip_joint_axis(root, 'follow'))
+        mimic = _joint(root, 'follow').find('mimic')
+        self.assertEqual(mimic.get('multiplier'), '-1')
+        self.assertEqual(mimic.get('offset'), '-0.25')
+
+    def test_returns_false_without_a_usable_axis(self):
+        root = ET.fromstring("""<robot name="r">
+          <joint name="fixed_j" type="fixed"/>
+          <joint name="zero_j" type="revolute"><axis xyz="0 0 0"/></joint>
+        </robot>""")
+        self.assertFalse(flip_joint_axis(root, 'fixed_j'))
+        self.assertFalse(flip_joint_axis(root, 'zero_j'))
+        self.assertFalse(flip_joint_axis(root, 'no_such_joint'))
+
+    def test_continuous_joint_without_limit(self):
+        root = ET.fromstring("""<robot name="r">
+          <joint name="spin" type="continuous"><axis xyz="0 0 1"/></joint>
+        </robot>""")
+        self.assertTrue(flip_joint_axis(root, 'spin'))
+        self.assertEqual(root.find('joint').find('axis').get('xyz'), '0 0 -1')
+
+
+class TestFlipJointAxisFile(unittest.TestCase):
+
+    def test_in_place_edit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'r.urdf')
+            with open(path, 'w') as f:
+                f.write(_URDF)
+            self.assertTrue(flip_joint_axis_file(path, 'drive'))
+            root = ET.parse(path).getroot()
+            self.assertEqual(_joint(root, 'drive').find('axis').get('xyz'),
+                             '0 0 -1')
+
+    def test_missing_joint_leaves_the_file_alone(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'r.urdf')
+            with open(path, 'w') as f:
+                f.write(_URDF)
+            self.assertFalse(flip_joint_axis_file(path, 'nope'))
+            with open(path) as f:
+                self.assertEqual(f.read(), _URDF)
+
+
+class TestRootLinkChangeRemapsLimits(unittest.TestCase):
+    """Re-rooting reverses the joints along the path; an asymmetric limit has
+    to be remapped with the axis or the robot's reachable range moves."""
+
+    def test_asymmetric_limits_follow_the_reversed_axis(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, 'in.urdf')
+            dst = os.path.join(tmp, 'out.urdf')
+            with open(src, 'w') as f:
+                f.write(_URDF)
+            change_urdf_root_link(src, 'mid', dst)
+
+            drive = _joint(ET.parse(dst).getroot(), 'drive')
+            axis = [float(v) for v in drive.find('axis').get('xyz').split()]
+            self.assertEqual(axis, [0.0, 0.0, -1.0])
+            limit = drive.find('limit')
+            self.assertAlmostEqual(float(limit.get('lower')), -2.0)
+            self.assertAlmostEqual(float(limit.get('upper')), 0.5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Reversing a joint means more than negating its <axis>.  The travel range and any mimic coupling are expressed in the old sense and have to move with it, and a bound changes side rather than sign: q <= U is q' >= -U, so a one-sided <limit> moves to the other attribute.  The soft bounds on <safety_controller> move the same way, a <mimic> without a multiplier means 1.0 and so has to have -1 written out explicitly, and every OTHER joint mimicking this one needs its multiplier negated -- those <mimic joint="..."> tags live in the follower's element, not in this one, which is the part a hand-written flip usually misses.

flip_joint_axis(root, joint_name) performs the whole edit in place, leaving the <origin> untouched so no frame moves; flipping twice restores the original values.  flip_joint_axis_file applies it to a file.

This also fixes a bug: change_urdf_root_link reverses every joint along the path to the new root and was negating only the axis, so re-rooting a robot with an asymmetric limit silently relocated its reachable range instead of mirroring it -- [-0.5, 2.0] stayed put where it should have become [-2.0, 0.5].  That path now goes through flip_joint_axis.