### PR TITLE
Bake each element's origin into its own copy of the mesh

### DIFF
--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -38,7 +38,6 @@ except ImportError:
     rospkg = None
 
 
-mesh_filenames_cache = {}
 logger = getLogger(__name__)
 
 # Whether the one-time "install DracoPy" hint has already been emitted.
@@ -146,6 +145,48 @@ def force_visual_mesh_origin_to_zero():
     _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero'] = True
     yield
     _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero'] = False
+
+
+def bake_origin_into_meshes(geometry, origin):
+    """Bake ``origin`` into the vertices of a geometry's meshes.
+
+    Used by :func:`force_visual_mesh_origin_to_zero`, which zeroes an
+    element's ``<origin>`` and moves that offset into the geometry itself.
+
+    The meshes are copied before being transformed, because one
+    :class:`~trimesh.base.Trimesh` may be shared by several elements: the
+    same file referenced by a ``<visual>`` and a ``<collision>``, or by two
+    links, and under :func:`enable_mesh_cache` every such load returns the
+    one cached list. Transforming in place would bake one element's origin
+    into another element's geometry, or bake both origins into a single
+    mesh.
+
+    Parameters
+    ----------
+    geometry : :class:`.Geometry`
+        Geometry whose meshes are baked. Only a ``<mesh>`` geometry is
+        touched; a primitive carries no vertices to bake into and is left
+        alone. Its ``mesh.meshes`` is replaced with the transformed copies.
+    origin : (4, 4) float
+        Pose to bake into the vertices. Treated as identity within
+        ``1e-8``, in which case nothing is copied or transformed.
+    """
+    if geometry.mesh is None or np.allclose(origin, np.eye(4)):
+        # No vertices to bake into, or an offset small enough that baking it
+        # would only cost a copy of possibly shared meshes.
+        return
+    baked_meshes = []
+    for mesh in geometry.mesh.meshes:
+        baked_mesh = mesh.copy()
+        baked_mesh.apply_transform(origin)
+        # copy() deep-copies the material, including its texture image; the
+        # material is not what the transform changes, so hand the copy back
+        # the original rather than a per-element duplicate of the image
+        visual, original = baked_mesh.visual, mesh.visual
+        if hasattr(visual, 'material') and hasattr(original, 'material'):
+            visual.material = original.material
+        baked_meshes.append(baked_mesh)
+    geometry.mesh.meshes = baked_meshes
 
 
 @contextlib.contextmanager
@@ -2108,16 +2149,8 @@ class Collision(URDFType):
         self.name = name
         self.origin = origin
         if _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero']:
-            if self.geometry.mesh is not None and \
-                self.geometry.mesh.filename not in mesh_filenames_cache:
-                mesh_filenames_cache[self.geometry.mesh.filename] = True
-                if self.geometry.mesh is not None:
-                    new_mesh = []
-                    for mesh in self.geometry.meshes:
-                        mesh.apply_transform(self.origin)
-                        new_mesh.append(mesh)
-                    self.geometry.mesh.meshes = new_mesh
-                    del new_mesh
+            if self.geometry.mesh is not None:
+                bake_origin_into_meshes(self.geometry, self.origin)
             # force the origin to be zero
             self.origin = np.eye(4)
 
@@ -2213,16 +2246,8 @@ class Visual(URDFType):
         self.material = material
 
         if _CONFIGURABLE_VALUES['force_visual_mesh_origin_to_zero']:
-            if self.geometry.mesh is not None and \
-                self.geometry.mesh.filename not in mesh_filenames_cache:
-                mesh_filenames_cache[self.geometry.mesh.filename] = True
-                if self.geometry.mesh is not None:
-                    new_mesh = []
-                    for mesh in self.geometry.meshes:
-                        mesh.apply_transform(self.origin)
-                        new_mesh.append(mesh)
-                    self.geometry.mesh.meshes = new_mesh
-                    del new_mesh
+            if self.geometry.mesh is not None:
+                bake_origin_into_meshes(self.geometry, self.origin)
             # force the origin to be zero
             self.origin = np.eye(4)
 

--- a/tests/skrobot_tests/utils_tests/test_urdf.py
+++ b/tests/skrobot_tests/utils_tests/test_urdf.py
@@ -391,3 +391,139 @@ class TestConfigureOrigin(unittest.TestCase):
             urdf_utils.configure_origin(np.zeros(5))
         with pytest.raises(TypeError):
             urdf_utils.configure_origin('not-a-matrix')
+
+
+class TestForceVisualMeshOriginToZero(unittest.TestCase):
+    """Every element must get its own origin baked into its own vertices.
+
+    ``force_visual_mesh_origin_to_zero`` zeroes an element's ``<origin>``
+    and moves the offset into the mesh vertices. One mesh file is commonly
+    referenced by several elements with different origins -- a ``<visual>``
+    and a ``<collision>`` of one link, or two links sharing a part. Baking
+    only the first origin seen for a filename, or transforming a shared
+    Trimesh in place, misplaces every other element's geometry.
+    """
+
+    URDF_TEMPLATE = """<?xml version="1.0"?>
+<robot name="shared_mesh">
+  <link name="base_link">
+    <visual>
+      <origin xyz="1 0 0" rpy="0 0 0"/>
+      <geometry><mesh filename="box.stl"/></geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 2 0" rpy="0 0 0"/>
+      <geometry><mesh filename="box.stl"/></geometry>
+    </collision>
+  </link>
+  <link name="second_link">
+    <visual>
+      <origin xyz="0 0 3" rpy="0 0 0"/>
+      <geometry><mesh filename="box.stl"/></geometry>
+    </visual>
+  </link>
+  <joint name="fixed_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="second_link"/>
+  </joint>
+</robot>
+"""
+
+    def setUp(self):
+        import trimesh
+
+        self._tmp = tempfile.mkdtemp()
+        box = trimesh.creation.box(extents=[0.2, 0.2, 0.2])
+        box.export(os.path.join(self._tmp, 'box.stl'))
+        self._urdf_path = os.path.join(self._tmp, 'robot.urdf')
+        with open(self._urdf_path, 'w') as f:
+            f.write(self.URDF_TEMPLATE)
+        urdf_utils._MESH_CACHE.clear()
+
+    def tearDown(self):
+        import shutil
+
+        urdf_utils._MESH_CACHE.clear()
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _load(self):
+        with urdf_utils.force_visual_mesh_origin_to_zero():
+            return urdf_utils.URDF.load(self._urdf_path)
+
+    def _assert_baked(self, robot):
+        elements = {}
+        for link in robot.links:
+            for visual in link.visuals:
+                elements['visual/' + link.name] = visual
+            for collision in link.collisions:
+                elements['collision/' + link.name] = collision
+        expected = {'visual/base_link': [1.0, 0.0, 0.0],
+                    'collision/base_link': [0.0, 2.0, 0.0],
+                    'visual/second_link': [0.0, 0.0, 3.0]}
+        self.assertEqual(set(elements), set(expected))
+        for key, center in expected.items():
+            element = elements[key]
+            # The origin is zeroed, so the offset has to live in the vertices.
+            np.testing.assert_allclose(element.origin, np.eye(4), atol=1e-9)
+            vertices = np.vstack(
+                [m.vertices for m in element.geometry.meshes])
+            np.testing.assert_allclose(
+                vertices.mean(axis=0), center, atol=1e-6,
+                err_msg='{} geometry is not centered at {}'.format(
+                    key, center))
+
+    def test_each_element_keeps_its_own_origin(self):
+        self._assert_baked(self._load())
+
+    def test_reloading_the_same_urdf_bakes_again(self):
+        # No module-level state may make a later load skip the baking.
+        self._load()
+        self._assert_baked(self._load())
+
+    def test_shared_trimesh_objects_are_not_transformed_in_place(self):
+        # enable_mesh_cache hands the very same Trimesh objects to every
+        # element referencing the file.
+        with urdf_utils.enable_mesh_cache():
+            self._assert_baked(self._load())
+
+
+class TestBakeOriginIntoMeshes(unittest.TestCase):
+    """The helper behind ``force_visual_mesh_origin_to_zero``."""
+
+    def _geometry(self):
+        import trimesh
+        mesh = urdf_utils.Mesh(filename='box.stl',
+                               meshes=[trimesh.creation.box(
+                                   extents=(0.2, 0.2, 0.2))])
+        return urdf_utils.Geometry(mesh=mesh)
+
+    def test_an_identity_origin_leaves_the_meshes_shared(self):
+        """An identity origin must not even copy: under a mesh cache the
+        objects are shared, and copying them costs memory for nothing."""
+        geometry = self._geometry()
+        before = geometry.mesh.meshes[0]
+        urdf_utils.bake_origin_into_meshes(geometry, np.eye(4))
+        self.assertIs(geometry.mesh.meshes[0], before)
+
+    def test_a_real_origin_copies_and_transforms(self):
+        geometry = self._geometry()
+        before = geometry.mesh.meshes[0]
+        origin = np.eye(4)
+        origin[:3, 3] = [1.0, 2.0, 3.0]
+        urdf_utils.bake_origin_into_meshes(geometry, origin)
+        baked = geometry.mesh.meshes[0]
+        self.assertIsNot(baked, before)
+        np.testing.assert_allclose(
+            baked.bounding_box.centroid, [1.0, 2.0, 3.0], atol=1e-9)
+        # the original is left where it was, for whoever else holds it
+        np.testing.assert_allclose(
+            before.bounding_box.centroid, [0.0, 0.0, 0.0], atol=1e-9)
+
+    def test_a_primitive_geometry_is_left_alone(self):
+        """A ``<box>`` has no vertices to bake into; the helper must not
+        reach for a mesh that is not there."""
+        geometry = urdf_utils.Geometry(box=urdf_utils.Box(size=[1, 1, 1]))
+        origin = np.eye(4)
+        origin[:3, 3] = [1.0, 0.0, 0.0]
+        urdf_utils.bake_origin_into_meshes(geometry, origin)
+        self.assertIsNone(geometry.mesh)


### PR DESCRIPTION
force_visual_mesh_origin_to_zero bakes an element's <origin> into its mesh vertices and zeroes the origin.  A module-global cache keyed on the mesh FILENAME decided whether that had already been done, which was wrong in two ways.  A file referenced by two elements with different origins had only the first origin baked, and the second element got an identity origin over geometry carrying the other element's offset.  The cache was also never cleared, so a second URDF.load in the same process skipped baking entirely and collapsed the whole model onto the mesh origin -- any viewer or batch converter loading two URDFs that share a mesh filename hit that.

Each element now copies the meshes before transforming them, which is what makes "every element owns its baked geometry" true whether or not the loader hands back shared objects: under enable_mesh_cache it returns the same Trimesh objects to every element, so a (filename, origin) key would still have applied several origins to one mesh.  The cache is therefore removed rather than re-keyed.

An identity origin skips the copy, a geometry with no <mesh> is left alone -- a primitive has no vertices to bake into -- and the copy keeps pointing at the original material, since the transform does not touch it and deep-copying a texture per element is expensive.