### PR TITLE
Extract moving_links, and say why sweep_limits probes

### DIFF
--- a/skrobot/collision/__init__.py
+++ b/skrobot/collision/__init__.py
@@ -57,6 +57,7 @@ from skrobot.collision.robot_collision import RobotCollisionChecker
 from skrobot.collision.self_collision import is_fcl_available
 from skrobot.collision.self_collision import link_meshes
 from skrobot.collision.self_collision import link_visual_mesh
+from skrobot.collision.self_collision import moving_links
 from skrobot.collision.self_collision import SelfCollision
 from skrobot.collision.self_collision import sweep_limits
 
@@ -86,6 +87,7 @@ __all__ = [
     'SelfCollision',
     'sweep_limits',
     'link_meshes',
+    'moving_links',
     'link_visual_mesh',
     'is_fcl_available',
 ]

--- a/skrobot/collision/self_collision.py
+++ b/skrobot/collision/self_collision.py
@@ -278,6 +278,47 @@ def _prismatic_joints(robot):
     return [j for j in robot.joint_list if isinstance(j, LinearJoint)]
 
 
+def moving_links(joint, links, probe):
+    """Which links actually move when ``joint`` moves, found by moving it.
+
+    Walking the link tree needs care -- ``Link.child_links`` is one level, so
+    it has to recurse -- but even a correct recursive descent from
+    ``joint.child_link`` can be wrong: a mimic follower is driven through a
+    hook rather than an edge, so it can sit outside the joint's subtree
+    entirely and take its own children with it.
+
+    Under-reporting is what hurts a collision sweep.  A link left out is
+    frozen at its home pose, so a collision it would have caused is never
+    seen and the limit comes back too wide.  One probe is enough because each
+    moved subtree is rigid, and comparing full transforms rather than
+    positions catches a link that only rotates, on the axis.
+
+    Parameters
+    ----------
+    joint : skrobot.model.Joint
+        The joint to probe.  Its angle is restored before returning.
+    links : dict
+        ``{name: Link}`` to consider.
+    probe : float
+        How far to move the joint, in its native unit (radians for a
+        rotational joint, metres for a linear one).
+
+    Returns
+    -------
+    moved : set of str
+        Names of the links whose world transform changed.
+    """
+    home = {name: link.worldcoords().T() for name, link in links.items()}
+    previous = float(joint.joint_angle())
+    joint.joint_angle(probe)
+    try:
+        return {name for name, link in links.items()
+                if not np.allclose(link.worldcoords().T(), home[name],
+                                   atol=1e-7)}
+    finally:
+        joint.joint_angle(previous)
+
+
 def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
                  step_mm=5.0, max_mm=300.0, margin_mm=2.0,
                  margin_m=REST_MARGIN, only=None, progress=None, refine=True,
@@ -366,19 +407,7 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
     hull_objs, hull_g2n, hull_set_T = _world(sc_hull)
 
     def _moving_set(J, probe):
-        # Which links ACTUALLY move when only J moves?  Determined by probing
-        # (the skrobot parent/child tree-walk under-reports the subtree for
-        # this model -- it returned just the immediate child while 18 links
-        # really move).  The subtree is rigid, so one probe reveals all of it;
-        # the full transform comparison catches on-axis rotation too.  ``probe``
-        # is in the joint's native unit (radians / metres).
-        home = {n: sc._link[n].worldcoords().T() for n in sc.names}
-        J.joint_angle(probe)
-        moved = {n for n in sc.names
-                 if not np.allclose(sc._link[n].worldcoords().T(),
-                                    home[n], atol=1e-7)}
-        J.joint_angle(0.0)
-        return moved
+        return moving_links(J, sc._link, probe)
 
     out = {}
     try:

--- a/tests/skrobot_tests/collision_tests/test_self_collision.py
+++ b/tests/skrobot_tests/collision_tests/test_self_collision.py
@@ -3,8 +3,11 @@ import os
 import tempfile
 import unittest
 
+import numpy as np
+
 from skrobot.collision import is_fcl_available
 from skrobot.collision import link_meshes
+from skrobot.collision import moving_links
 from skrobot.collision import SelfCollision
 from skrobot.collision import sweep_limits
 
@@ -109,6 +112,101 @@ class TestSweepLimits(unittest.TestCase):
                            parts={'pillar': [meshes['pillar']]})
         with self.assertRaises(ValueError):
             sweep_limits(robot, meshes, sc=sc)
+
+
+_MIMIC_URDF = """<?xml version="1.0"?>
+<robot name="mimic_pair">
+  <link name="base_link"/>
+  <link name="driver"/>
+  <link name="driver_tip"/>
+  <link name="follower"/>
+  <link name="follower_tip"/>
+  <joint name="drive" type="revolute">
+    <origin xyz="0 0 0.1" rpy="0 0 0"/>
+    <parent link="base_link"/><child link="driver"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2" upper="2" effort="1" velocity="1"/>
+  </joint>
+  <joint name="drive_fix" type="fixed">
+    <origin xyz="0 0 0.2" rpy="0 0 0"/>
+    <parent link="driver"/><child link="driver_tip"/>
+  </joint>
+  <joint name="follow" type="revolute">
+    <origin xyz="0.3 0 0" rpy="0 0 0"/>
+    <parent link="base_link"/><child link="follower"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2" upper="2" effort="1" velocity="1"/>
+    <mimic joint="drive" multiplier="1"/>
+  </joint>
+  <joint name="follow_fix" type="fixed">
+    <origin xyz="0 0 0.1" rpy="0 0 0"/>
+    <parent link="follower"/><child link="follower_tip"/>
+  </joint>
+</robot>"""
+
+
+class TestMovingLinks(unittest.TestCase):
+    """``moving_links`` must not be replaceable by a link-tree walk.
+
+    A mimic follower is driven by a hook, not by an edge, so moving the driver
+    moves the follower and everything below it -- none of which appears below
+    the driver in the parent/child tree.  A sweep that decided which links move
+    by descending that tree would freeze them at home and miss any collision
+    they cause.
+    """
+
+    def _model(self):
+        from skrobot.models.urdf import RobotModelFromURDF
+        with tempfile.NamedTemporaryFile('w', suffix='.urdf',
+                                         delete=False) as f:
+            f.write(_MIMIC_URDF)
+            path = f.name
+        try:
+            return RobotModelFromURDF(urdf_file=path)
+        finally:
+            os.unlink(path)
+
+    def _descend(self, link, found=None):
+        found = set() if found is None else found
+        found.add(link.name)
+        for child in link.child_links:
+            self._descend(child, found)
+        return found
+
+    def test_reports_the_mimic_subtree_a_tree_walk_cannot_see(self):
+        robot = self._model()
+        drive = next(j for j in robot.joint_list if j.name == 'drive')
+        links = {link.name: link for link in robot.link_list}
+
+        moved = moving_links(drive, links, 0.4)
+        self.assertEqual(moved,
+                         {'driver', 'driver_tip', 'follower', 'follower_tip'})
+        # not merely incomplete: a recursive descent CANNOT reach them, so
+        # swapping the probe for a tree walk would silently under-report
+        self.assertEqual(moved - self._descend(drive.child_link),
+                         {'follower', 'follower_tip'})
+
+    def test_restores_the_joint_it_probed(self):
+        robot = self._model()
+        drive = next(j for j in robot.joint_list if j.name == 'drive')
+        links = {link.name: link for link in robot.link_list}
+        drive.joint_angle(0.2)
+        moving_links(drive, links, 0.4)
+        self.assertAlmostEqual(float(drive.joint_angle()), 0.2)
+
+    def test_a_link_only_rotating_on_the_axis_still_counts(self):
+        """Comparing positions instead of full transforms would miss it."""
+        robot = self._model()
+        drive = next(j for j in robot.joint_list if j.name == 'drive')
+        links = {link.name: link for link in robot.link_list}
+        # 'driver' sits on the rotation axis: its origin does not translate
+        before = links['driver'].worldcoords().T()[:3, 3].copy()
+        moved = moving_links(drive, links, 0.4)
+        drive.joint_angle(0.4)
+        after = links['driver'].worldcoords().T()[:3, 3]
+        drive.joint_angle(0.0)
+        np.testing.assert_allclose(after, before, atol=1e-12)
+        self.assertIn('driver', moved)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
sweep_limits decides which links move with a joint by moving it and comparing transforms.  The note explaining that said the parent/child tree-walk "under-reports the subtree", which reads as a defect in Link.child_links -- it is one level by design, and a recursive descent is correct for an ordinary chain.  Twice now that wording has sent a reader to the wrong conclusion.

What no descent can see is a mimic follower: it is driven through a hook rather than an edge, so it can sit outside the swept joint's subtree entirely and take its own children with it.  Under-reporting is the half that hurts -- a link left out is frozen at its home pose, so the collision it would have caused is never seen and the limit comes back too wide.

Lifting the probe out of the closure as moving_links lets a test assert that, instead of the comment merely asserting it in prose: swapping the probe for a tree walk now fails.  The helper also restores the angle it found rather than assuming zero.