### PR TITLE
Add normalize_link_origins to re-centre link frames on their geometry

### DIFF
--- a/skrobot/urdf/__init__.py
+++ b/skrobot/urdf/__init__.py
@@ -4,6 +4,9 @@ from skrobot.urdf.canonicalize import canonicalize_urdf_file
 from skrobot.urdf.extract_sub_urdf import extract_sub_urdf
 from skrobot.urdf.flip_axis import flip_joint_axis
 from skrobot.urdf.flip_axis import flip_joint_axis_file
+from skrobot.urdf.link_origins import geometry_centroid
+from skrobot.urdf.link_origins import normalize_link_origins
+from skrobot.urdf.link_origins import normalize_link_origins_file
 from skrobot.urdf.llm_grouping import build_grouping_prompt
 from skrobot.urdf.llm_grouping import compute_jaw_gripper_frame
 from skrobot.urdf.llm_grouping import generate_groups_from_llm
@@ -58,5 +61,8 @@ __all__ = [
     'sanitize_urdf_names',
     'canonicalize_urdf',
     'canonicalize_urdf_file',
+    'geometry_centroid',
+    'normalize_link_origins',
+    'normalize_link_origins_file',
     'urdf_to_mjcf',
 ]

--- a/skrobot/urdf/link_origins.py
+++ b/skrobot/urdf/link_origins.py
@@ -1,0 +1,426 @@
+"""Re-centre link frames onto the geometry they carry.
+
+CAD exporters routinely place a link's frame far away from its parts: a
+sub-assembly inherits the CAD origin of the whole machine, so its frame can
+float a metre from anything visible.  The model still renders correctly --
+every ``<visual>`` carries the compensating ``<origin>`` -- but the TF frame
+is useless to look at in RViz and the numbers in the file are hard to read.
+
+:func:`normalize_link_origins` moves such a frame onto its geometry.  For a
+shift ``d`` (the geometry centroid expressed in the link frame) the parent
+joint's origin becomes ``F @ T(+d)``, which slides the link frame onto the
+geometry, and everything expressed in that frame -- child joints,
+``<inertial>``, ``<visual>``, ``<collision>`` -- has its origin turned into
+``T(-d) @ F``.  The two cancel, so the link frame is the only thing that
+moves: every piece of geometry, every mass and every other link stays
+exactly where it was, in every joint configuration.
+
+Only links whose parent joint is ``fixed`` are re-centred, and the root link
+is never touched.  See :func:`normalize_link_origins` for why.
+"""
+
+from logging import getLogger
+import os
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+from skrobot.coordinates.math import rpy2matrix
+
+
+logger = getLogger(__name__)
+
+
+__all__ = [
+    'geometry_centroid',
+    'normalize_link_origins',
+    'normalize_link_origins_file',
+]
+
+
+def _origin_translation(elem):
+    """Translation of ``elem``'s ``<origin>`` child; zeros when absent."""
+    origin = elem.find('origin')
+    if origin is None or 'xyz' not in origin.attrib:
+        return np.zeros(3)
+    return np.array([float(v) for v in origin.get('xyz').split()],
+                    dtype=np.float64)
+
+
+def _origin_rotation(elem):
+    """Rotation of ``elem``'s ``<origin>`` child; identity when absent."""
+    origin = elem.find('origin')
+    if origin is None or 'rpy' not in origin.attrib:
+        return np.eye(3)
+    roll, pitch, yaw = [float(v) for v in origin.get('rpy').split()]
+    return rpy2matrix(roll, pitch, yaw)
+
+
+def _format_xyz(xyz):
+    """Format a translation for an ``xyz`` attribute, round-trip exact."""
+    tokens = []
+    for value in xyz:
+        value = float(value)
+        if value == 0.0:      # also turns -0.0 into 0
+            value = 0.0
+        tokens.append(repr(value))
+    return ' '.join(tokens)
+
+
+def _set_origin_translation(elem, xyz):
+    """Write ``elem``'s ``<origin>`` translation, in place.
+
+    Only the ``xyz`` attribute is rewritten: every transform applied here is
+    a pure translation, so the ``rpy`` attribute keeps its exact original
+    text and contributes no round-trip error.
+    """
+    origin = elem.find('origin')
+    if origin is None:
+        origin = ET.SubElement(elem, 'origin')
+        origin.set('rpy', '0 0 0')
+    origin.set('xyz', _format_xyz(xyz))
+
+
+def geometry_centroid(geometry, base_path):
+    """Centroid of one URDF ``<geometry>`` element, in the geometry's frame.
+
+    This is the default measurement used by :func:`normalize_link_origins`.
+    A ``<mesh>`` is loaded through :func:`skrobot.utils.urdf.load_meshes`
+    (``package://`` URIs are resolved relative to ``base_path``) and its
+    area-weighted centroid is returned, scaled by the mesh ``scale``
+    attribute.  ``<box>``, ``<sphere>`` and ``<cylinder>`` are centred on
+    their own frame by definition, so they measure as zero.
+
+    Parameters
+    ----------
+    geometry : xml.etree.ElementTree.Element
+        A ``<geometry>`` element.
+    base_path : str
+        Directory the URDF lives in, used to resolve relative and
+        ``package://`` mesh paths.
+
+    Returns
+    -------
+    centroid : numpy.ndarray or None
+        ``(3,)`` centroid in the geometry's own frame, or None when the
+        geometry holds no shape this function understands or its mesh
+        cannot be loaded.
+    """
+    # Imported here so callers that supply their own ``centroid_fn`` -- and
+    # the rest of this module, which is pure XML -- never pull in the mesh
+    # loading stack.
+    from skrobot.utils.urdf import get_filename
+    from skrobot.utils.urdf import load_meshes
+
+    for tag in ('box', 'sphere', 'cylinder'):
+        if geometry.find(tag) is not None:
+            return np.zeros(3)
+
+    mesh = geometry.find('mesh')
+    if mesh is None or mesh.get('filename') is None:
+        return None
+    filename = get_filename(base_path, mesh.get('filename'))
+    if filename is None:
+        return None
+    try:
+        meshes = load_meshes(filename)
+    except Exception as e:
+        logger.warning('could not load %s: %s', filename, e)
+        return None
+    if not meshes:
+        return None
+
+    # Area-weighted mean of the sub-mesh centroids, so a multi-body mesh is
+    # measured as the single body it visually is.
+    weights = np.array([float(m.area) for m in meshes], dtype=np.float64)
+    centroids = np.array([np.asarray(m.centroid, dtype=np.float64)
+                          for m in meshes])
+    if weights.sum() > 0.0:
+        centroid = (centroids * weights[:, None]).sum(axis=0) / weights.sum()
+    else:
+        centroid = centroids.mean(axis=0)
+
+    scale = mesh.get('scale')
+    if scale is not None:
+        # the spec asks for three values, but a single uniform one is common
+        values = np.array([float(v) for v in scale.split()],
+                          dtype=np.float64)
+        centroid = centroid * (values if values.size == 3 else values[0])
+    return centroid
+
+
+def _external_frames(root, link_name):
+    """Elements outside the link that place something in ITS frame.
+
+    A ``<gazebo reference="L">`` sensor pose and a top-level ``<sensor>``
+    parented to ``L`` are expressed in ``L``'s frame, so moving that frame
+    moves them -- and nothing here rewrites them.  ``<transmission>`` is not
+    listed: it references joints, which carry no frame of their own.
+
+    Parameters
+    ----------
+    root : xml.etree.ElementTree.Element
+        The ``<robot>`` element.
+    link_name : str
+        Link whose frame is about to move.
+
+    Returns
+    -------
+    tags : list of str
+        Tag names found, empty when the frame is safe to move.
+    """
+    found = []
+    for gazebo in root.findall('gazebo'):
+        if gazebo.get('reference') == link_name and len(gazebo):
+            found.append('<gazebo>')
+            break
+    for sensor in root.findall('sensor'):
+        parent = sensor.find('parent')
+        if parent is not None and parent.get('link') == link_name:
+            found.append('<sensor>')
+            break
+    return found
+
+
+def _translated_origins(elements, offsets):
+    """Pre-compute every ``(element, new xyz)`` pair for one link's move.
+
+    Parsing all of them before writing any keeps a malformed origin -- a
+    xacro ``${...}`` substitution, say -- from leaving the tree half
+    corrected, with the geometry moved and the joint not.
+
+    Parameters
+    ----------
+    elements : list
+        Elements whose ``<origin>`` moves.
+    offsets : list
+        Translation to add to each, in the same order.
+
+    Returns
+    -------
+    updates : list of tuple
+        ``(element, (3,) array)`` pairs to apply.
+
+    Raises
+    ------
+    ValueError
+        If any origin holds a value that is not a number.
+    """
+    updates = []
+    for element, offset in zip(elements, offsets):
+        updates.append((element, _origin_translation(element) + offset))
+    return updates
+
+
+def normalize_link_origins(root, base_path=None, centroid_fn=None,
+                           link_names=None, tolerance=1e-6):
+    """Re-centre fixed links' frames onto their geometry, in place.
+
+    Each eligible link's frame is moved by ``d``, the centroid of its
+    ``<visual>`` geometry expressed in that frame.  The shift is absorbed
+    exactly: the parent joint's origin becomes ``F @ T(+d)`` and the
+    origins of the child joints, the ``<inertial>``, the ``<visual>`` and
+    the ``<collision>`` elements become ``T(-d) @ F``.  The re-centred
+    frame is therefore the only thing that moves -- every other frame in
+    the model keeps its world pose, in every joint configuration.
+
+    A link is eligible only when its parent joint is of type ``fixed``.  A
+    movable joint's ``<origin>`` places its axis of motion, so moving the
+    child frame would move that axis and the model would no longer agree
+    with itself away from the zero configuration.  The root link is skipped
+    for the same reason in reverse: it has no parent joint to absorb
+    ``T(+d)``, so re-centring it would move the whole robot in the world.
+
+    Parameters
+    ----------
+    root : xml.etree.ElementTree.Element
+        Root ``<robot>`` element; modified in place.
+    base_path : str or None, optional
+        Directory the URDF lives in, used by the default measurement to
+        resolve relative and ``package://`` mesh paths.  Required unless
+        ``centroid_fn`` is given.
+    centroid_fn : callable or None, optional
+        ``centroid_fn(geometry) -> (3,) array or None``, measuring the
+        centroid of a ``<geometry>`` element **in the geometry's own
+        frame** (the ``<visual>`` origin is applied by this function, not
+        by the callable).  Returning None makes that geometry unmeasurable
+        and it is left out of the average.  Defaults to
+        :func:`geometry_centroid` bound to ``base_path``.
+    link_names : iterable of str or None, optional
+        Restrict the operation to these links.  Default is every link.
+    tolerance : float, optional
+        Links whose centroid is within this Euclidean distance of their
+        frame are left untouched.  Default is ``1e-6`` metres: measuring a
+        centroid off a binary STL carries several nanometres of float32
+        error, so a tighter threshold makes re-centring depend on which
+        export of the same CAD it was handed.
+
+    Returns
+    -------
+    shifts : dict
+        ``{link_name: (3,) numpy.ndarray}`` for the links that moved, each
+        value the shift ``d`` in the link's original frame.  Links that
+        were skipped or already centred do not appear.
+
+    Raises
+    ------
+    ValueError
+        If neither ``base_path`` nor ``centroid_fn`` is given.
+
+    Notes
+    -----
+    Frames declared by extensions that reference a link -- ``<gazebo>``
+    bodies, ``<sensor>`` elements, ``<transmission>`` blocks -- are not
+    rewritten, so a URDF relying on those should be re-centred with care.
+
+    Examples
+    --------
+    >>> import xml.etree.ElementTree as ET
+    >>> from skrobot.urdf import normalize_link_origins
+    >>> root = ET.parse('robot.urdf').getroot()      # doctest: +SKIP
+    >>> normalize_link_origins(root, base_path='.')  # doctest: +SKIP
+    {'gripper_base': array([0.  , 0.  , 0.42])}
+    """
+    measure = centroid_fn
+    if measure is None:
+        if base_path is None:
+            raise ValueError(
+                'either base_path or centroid_fn must be given')
+
+        def measure(geometry):
+            return geometry_centroid(geometry, base_path)
+
+    parent_joint = {}
+    child_joints = {}
+    ambiguous = set()
+    for joint in root.findall('joint'):
+        child = joint.find('child')
+        parent = joint.find('parent')
+        if child is None or parent is None:
+            continue
+        child_name = child.get('link')
+        if child_name in parent_joint:
+            # a URDF is a tree; with two parents there is no single frame to
+            # absorb the shift, and correcting one branch moves the other
+            ambiguous.add(child_name)
+        parent_joint[child_name] = joint
+        child_joints.setdefault(parent.get('link'), []).append(joint)
+
+    seen = set()
+    for link in root.findall('link'):
+        name = link.get('name')
+        if name in seen:
+            # both elements would be processed, translating the shared parent
+            # joint twice
+            ambiguous.add(name)
+        seen.add(name)
+
+    if link_names is not None:
+        link_names = set(link_names)
+
+    shifts = {}
+    for link in root.findall('link'):
+        name = link.get('name')
+        if link_names is not None and name not in link_names:
+            continue
+        joint = parent_joint.get(name)
+        if joint is None or joint.get('type') != 'fixed':
+            continue
+        if name in ambiguous:
+            logger.warning(
+                'link %s is declared or parented more than once; leaving its '
+                'frame alone', name)
+            continue
+        attached = _external_frames(root, name)
+        if attached:
+            logger.warning(
+                'link %s carries %s, which name a frame this function does '
+                'not rewrite; leaving it alone', name, ', '.join(attached))
+            continue
+
+        centroids = []
+        for visual in link.findall('visual'):
+            geometry = visual.find('geometry')
+            if geometry is None:
+                continue
+            centroid = measure(geometry)
+            if centroid is None:
+                continue
+            centroid = np.asarray(centroid, dtype=np.float64)
+            centroids.append(_origin_rotation(visual).dot(centroid)
+                             + _origin_translation(visual))
+        if not centroids:
+            logger.debug('link %s has no measurable visual geometry', name)
+            continue
+        shift = np.mean(centroids, axis=0)
+        if np.linalg.norm(shift) <= tolerance:
+            continue
+
+        # F' = F @ T(+d) on the parent side; T(-d) @ F on everything the
+        # link frame carries.  Both are pure translations, so only the xyz
+        # attributes move and the rpy attributes stay byte for byte.
+        elements = [joint]
+        offsets = [_origin_rotation(joint).dot(shift)]
+        for child_joint in child_joints.get(name, []):
+            elements.append(child_joint)
+            offsets.append(-shift)
+        for tag in ('inertial', 'visual', 'collision'):
+            for elem in link.findall(tag):
+                elements.append(elem)
+                offsets.append(-shift)
+        try:
+            updates = _translated_origins(elements, offsets)
+        except ValueError as e:
+            # every origin is read before any is written, so a link with an
+            # unparsable one is skipped whole rather than half moved
+            logger.warning('link %s has an origin this cannot move (%s); '
+                           'leaving its frame alone', name, e)
+            continue
+        for element, xyz in updates:
+            _set_origin_translation(element, xyz)
+        shifts[name] = shift
+    return shifts
+
+
+def normalize_link_origins_file(input_file, output_file=None, **kwargs):
+    """Re-centre fixed links' frames in a URDF file.
+
+    Parameters
+    ----------
+    input_file : str
+        Path of the URDF file to read.  Its directory is used as
+        ``base_path`` when resolving mesh paths.
+    output_file : str or None, optional
+        When given, the rewritten URDF is written there.  Writing back to
+        ``input_file`` is allowed.
+    **kwargs
+        Forwarded to :func:`normalize_link_origins` (``centroid_fn``,
+        ``link_names``, ``tolerance``).  ``base_path`` defaults to the
+        directory of ``input_file``.
+
+    Returns
+    -------
+    shifts : dict
+        ``{link_name: (3,) numpy.ndarray}``, as returned by
+        :func:`normalize_link_origins`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``input_file`` does not exist.
+    """
+    if not os.path.exists(input_file):
+        raise FileNotFoundError(
+            'URDF file not found: {}'.format(input_file))
+
+    ET.register_namespace('xacro', 'http://ros.org/wiki/xacro')
+    tree = ET.parse(input_file)
+    kwargs.setdefault(
+        'base_path', os.path.dirname(os.path.abspath(input_file)))
+    shifts = normalize_link_origins(tree.getroot(), **kwargs)
+    if output_file is not None and shifts:
+        # only rewrite when something moved: ElementTree drops comments and
+        # reflows the markup, so writing a no-op still costs the file its
+        # licence header and any per-link provenance
+        tree.write(output_file, encoding='utf-8', xml_declaration=True)
+    return shifts

--- a/tests/skrobot_tests/urdf_tests/test_link_origins.py
+++ b/tests/skrobot_tests/urdf_tests/test_link_origins.py
@@ -1,0 +1,635 @@
+import os
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+from skrobot.coordinates.math import rotation_matrix
+from skrobot.coordinates.math import rpy2matrix
+from skrobot.urdf import normalize_link_origins
+from skrobot.urdf import normalize_link_origins_file
+
+
+def _origin_matrix(elem):
+    """4x4 transform of ``elem``'s ``<origin>``, identity when absent."""
+    matrix = np.eye(4)
+    if elem is None:
+        return matrix
+    origin = elem.find('origin')
+    if origin is None:
+        return matrix
+    if 'xyz' in origin.attrib:
+        matrix[:3, 3] = [float(v) for v in origin.get('xyz').split()]
+    if 'rpy' in origin.attrib:
+        roll, pitch, yaw = [float(v) for v in origin.get('rpy').split()]
+        matrix[:3, :3] = rpy2matrix(roll, pitch, yaw)
+    return matrix
+
+
+def _joint_motion(joint, value):
+    """4x4 transform a joint applies at configuration ``value``."""
+    matrix = np.eye(4)
+    axis_elem = joint.find('axis')
+    if axis_elem is None:
+        axis = np.array([1.0, 0.0, 0.0])
+    else:
+        axis = np.array([float(v) for v in axis_elem.get('xyz').split()])
+    axis = axis / np.linalg.norm(axis)
+    joint_type = joint.get('type')
+    if joint_type in ('revolute', 'continuous'):
+        matrix[:3, :3] = rotation_matrix(value, axis)
+    elif joint_type == 'prismatic':
+        matrix[:3, 3] = axis * value
+    return matrix
+
+
+def world_poses(root, joint_values=None):
+    """World pose of every frame in a URDF at a given configuration.
+
+    Independent forward kinematics used as the reference: link frames plus
+    every ``<inertial>`` / ``<visual>`` / ``<collision>`` frame, keyed by
+    ``'<link>/<tag>/<index>'``.
+    """
+    joint_values = joint_values or {}
+    links = {link.get('name'): link for link in root.findall('link')}
+    children = {}
+    has_parent = set()
+    for joint in root.findall('joint'):
+        parent = joint.find('parent').get('link')
+        children.setdefault(parent, []).append(joint)
+        has_parent.add(joint.find('child').get('link'))
+
+    poses = {}
+    stack = [(name, np.eye(4)) for name in links if name not in has_parent]
+    while stack:
+        name, matrix = stack.pop()
+        poses[name] = matrix
+        for joint in children.get(name, []):
+            value = joint_values.get(joint.get('name'), 0.0)
+            stack.append((
+                joint.find('child').get('link'),
+                matrix.dot(_origin_matrix(joint)).dot(
+                    _joint_motion(joint, value))))
+    for name, link in links.items():
+        for tag in ('inertial', 'visual', 'collision'):
+            for i, elem in enumerate(link.findall(tag)):
+                poses['{}/{}/{}'.format(name, tag, i)] = \
+                    poses[name].dot(_origin_matrix(elem))
+    return poses
+
+
+def max_pose_difference(before, after):
+    """Largest absolute entry-wise difference between two pose dicts."""
+    assert set(before) == set(after)
+    return max(float(np.max(np.abs(before[k] - after[k]))) for k in before)
+
+
+def expected_poses(before, shifts):
+    """The poses a correct re-centring must produce.
+
+    Every frame stays exactly where it was, except the re-centred link
+    frames themselves, which move to ``pose @ T(d)`` -- that displacement
+    is the whole point of the operation.
+    """
+    expected = dict(before)
+    for name, shift in shifts.items():
+        matrix = np.eye(4)
+        matrix[:3, 3] = shift
+        expected[name] = before[name].dot(matrix)
+    return expected
+
+
+def mesh_centroids(mapping):
+    """A ``centroid_fn`` answering from ``{mesh filename: centroid}``."""
+    def centroid_fn(geometry):
+        mesh = geometry.find('mesh')
+        if mesh is None:
+            return None
+        value = mapping.get(mesh.get('filename'))
+        if value is None:
+            return None
+        return np.array(value, dtype=np.float64)
+    return centroid_fn
+
+
+BRANCHING = """<robot name="branching">
+  <link name="base">
+    <visual>
+      <origin xyz="0.02 0 0.03" rpy="0 0 0"/>
+      <geometry><mesh filename="base.stl"/></geometry>
+    </visual>
+  </link>
+  <joint name="base_to_mid" type="fixed">
+    <parent link="base"/>
+    <child link="mid"/>
+    <origin xyz="0.1 0.2 0.3" rpy="0.3 -0.2 0.5"/>
+  </joint>
+  <link name="mid">
+    <inertial>
+      <mass value="2.5"/>
+      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.3"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.9 -0.4 1.2" rpy="0.1 0.2 -0.3"/>
+      <geometry><mesh filename="mid.stl"/></geometry>
+    </visual>
+    <collision>
+      <origin xyz="0.9 -0.4 1.2" rpy="0.1 0.2 -0.3"/>
+      <geometry><mesh filename="mid.stl"/></geometry>
+    </collision>
+  </link>
+  <joint name="mid_to_hinge" type="revolute">
+    <parent link="mid"/>
+    <child link="hinge"/>
+    <origin xyz="1.0 -0.5 1.1" rpy="0 0.4 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-2" upper="2" effort="10" velocity="1"/>
+  </joint>
+  <link name="hinge">
+    <visual>
+      <geometry><mesh filename="hinge.stl"/></geometry>
+    </visual>
+  </link>
+  <joint name="mid_to_slider" type="prismatic">
+    <parent link="mid"/>
+    <child link="slider"/>
+    <origin xyz="0.8 -0.3 1.3" rpy="-0.2 0 0.1"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-1" upper="1" effort="10" velocity="1"/>
+  </joint>
+  <link name="slider"/>
+  <joint name="mid_to_pad" type="fixed">
+    <parent link="mid"/>
+    <child link="pad"/>
+    <origin xyz="0.95 -0.45 1.25" rpy="0 0 0.7"/>
+  </joint>
+  <link name="pad">
+    <visual>
+      <geometry><mesh filename="pad.stl"/></geometry>
+    </visual>
+  </link>
+</robot>
+"""
+
+CONFIGURATION = {'mid_to_hinge': 0.73, 'mid_to_slider': -0.41}
+
+
+class TestNormalizeLinkOrigins(unittest.TestCase):
+
+    def _round_trip(self, urdf, centroids, joint_values=None,
+                    **kwargs):
+        """Normalize ``urdf`` and return ``(root, shifts, max_difference)``.
+
+        ``max_difference`` compares the forward kinematics of the whole
+        model, every frame included, against :func:`expected_poses`: it is
+        the amount by which something moved that should not have.
+        """
+        root = ET.fromstring(urdf)
+        joint_values = joint_values or {}
+        before = world_poses(root, joint_values)
+        shifts = normalize_link_origins(
+            root, centroid_fn=mesh_centroids(centroids), **kwargs)
+        after = world_poses(root, joint_values)
+        # nothing but the re-centred link frames may have moved
+        for name in set(before) - set(shifts):
+            np.testing.assert_allclose(
+                before[name], after[name], atol=1e-12,
+                err_msg='{} moved'.format(name))
+        return root, shifts, max_pose_difference(
+            expected_poses(before, shifts), after)
+
+    def test_link_with_parent_and_several_children(self):
+        centroids = {
+            'base.stl': [0.0, 0.0, 0.0],
+            'mid.stl': [0.05, -0.02, 0.01],
+            'hinge.stl': [0.0, 0.0, 0.0],
+            'pad.stl': [0.0, 0.0, 0.0],
+        }
+        root, shifts, difference = self._round_trip(
+            BRANCHING, centroids, CONFIGURATION)
+
+        # 'mid' is the only fixed link whose geometry is off its frame.
+        self.assertEqual(set(shifts), {'mid'})
+        expected = rpy2matrix(0.1, 0.2, -0.3).dot(
+            np.array(centroids['mid.stl'])) + np.array([0.9, -0.4, 1.2])
+        np.testing.assert_allclose(shifts['mid'], expected, atol=1e-15)
+        self.assertLess(difference, 1e-12)
+
+        # the frame really did move onto the geometry
+        visual = root.find(".//link[@name='mid']/visual")
+        residual = rpy2matrix(0.1, 0.2, -0.3).dot(
+            np.array(centroids['mid.stl'])) \
+            + np.array([float(v) for v
+                        in visual.find('origin').get('xyz').split()])
+        self.assertLess(np.linalg.norm(residual), 1e-14)
+
+        # a pure translation never touches rpy
+        joint = root.find(".//joint[@name='base_to_mid']/origin")
+        self.assertEqual(joint.get('rpy'), '0.3 -0.2 0.5')
+        self.assertEqual(visual.find('origin').get('rpy'), '0.1 0.2 -0.3')
+
+    def test_link_with_parent_and_several_children_many_configurations(self):
+        centroids = {
+            'base.stl': [0.0, 0.0, 0.0],
+            'mid.stl': [0.05, -0.02, 0.01],
+            'hinge.stl': [0.0, 0.0, 0.0],
+            'pad.stl': [0.0, 0.0, 0.0],
+        }
+        worst = 0.0
+        for hinge, slider in [(0.0, 0.0), (1.4, 0.9), (-2.0, -1.0)]:
+            _, _, difference = self._round_trip(
+                BRANCHING, centroids,
+                {'mid_to_hinge': hinge, 'mid_to_slider': slider})
+            worst = max(worst, difference)
+        self.assertLess(worst, 1e-12)
+
+    def test_root_link_is_left_alone(self):
+        urdf = """<robot name="rooted">
+  <link name="base">
+    <visual>
+      <origin xyz="1.5 -0.5 0.25" rpy="0 0 0"/>
+      <geometry><mesh filename="base.stl"/></geometry>
+    </visual>
+  </link>
+  <joint name="base_to_tip" type="fixed">
+    <parent link="base"/>
+    <child link="tip"/>
+    <origin xyz="0.1 0 0" rpy="0 0 0"/>
+  </joint>
+  <link name="tip"/>
+</robot>
+"""
+        # The root has no parent joint to absorb T(+d), so re-centring it
+        # would move the whole robot in the world.
+        root, shifts, difference = self._round_trip(
+            urdf, {'base.stl': [0.0, 0.0, 0.0]})
+        self.assertEqual(shifts, {})
+        self.assertEqual(difference, 0.0)
+        origin = root.find(".//link[@name='base']/visual/origin")
+        self.assertEqual(origin.get('xyz'), '1.5 -0.5 0.25')
+
+    def test_inertial_origin_already_non_zero(self):
+        urdf = """<robot name="inertial">
+  <link name="base"/>
+  <joint name="base_to_body" type="fixed">
+    <parent link="base"/>
+    <child link="body"/>
+    <origin xyz="0 0 0.5" rpy="0 0 1.2"/>
+  </joint>
+  <link name="body">
+    <inertial>
+      <origin xyz="0.7 -0.25 0.4" rpy="0.15 -0.35 0.55"/>
+      <mass value="3"/>
+      <inertia ixx="0.1" ixy="0.01" ixz="0.02" iyy="0.2" iyz="0.03"
+               izz="0.3"/>
+    </inertial>
+    <visual>
+      <origin xyz="0.75 -0.2 0.45" rpy="0 0 0"/>
+      <geometry><mesh filename="body.stl"/></geometry>
+    </visual>
+  </link>
+</robot>
+"""
+        root, shifts, difference = self._round_trip(
+            urdf, {'body.stl': [-0.05, 0.0, 0.02]})
+        np.testing.assert_allclose(
+            shifts['body'], [0.7, -0.2, 0.47], atol=1e-15)
+        self.assertLess(difference, 1e-12)
+
+        inertial = root.find(".//link[@name='body']/inertial/origin")
+        np.testing.assert_allclose(
+            [float(v) for v in inertial.get('xyz').split()],
+            [0.0, -0.05, -0.07], atol=1e-15)
+        # the inertia tensor is expressed in the inertial frame, whose
+        # orientation is untouched, so it must not be rewritten
+        self.assertEqual(inertial.get('rpy'), '0.15 -0.35 0.55')
+        inertia = root.find(".//link[@name='body']/inertial/inertia")
+        self.assertEqual(inertia.get('ixy'), '0.01')
+
+    def test_already_centred_geometry_is_a_noop(self):
+        urdf = """<robot name="centred">
+  <link name="base"/>
+  <joint name="base_to_body" type="fixed">
+    <parent link="base"/>
+    <child link="body"/>
+    <origin xyz="0 0 0.5" rpy="0 0 0"/>
+  </joint>
+  <link name="body">
+    <visual>
+      <geometry><mesh filename="body.stl"/></geometry>
+    </visual>
+  </link>
+</robot>
+"""
+        root = ET.fromstring(urdf)
+        original = ET.tostring(root)
+        shifts = normalize_link_origins(
+            root, centroid_fn=mesh_centroids({'body.stl': [0.0, 0.0, 0.0]}))
+        self.assertEqual(shifts, {})
+        self.assertEqual(ET.tostring(root), original)
+
+    def test_shift_within_tolerance_is_a_noop(self):
+        urdf = """<robot name="nearly">
+  <link name="base"/>
+  <joint name="base_to_body" type="fixed">
+    <parent link="base"/>
+    <child link="body"/>
+    <origin xyz="0 0 0.5" rpy="0 0 0"/>
+  </joint>
+  <link name="body">
+    <visual>
+      <geometry><mesh filename="body.stl"/></geometry>
+    </visual>
+  </link>
+</robot>
+"""
+        root = ET.fromstring(urdf)
+        original = ET.tostring(root)
+        shifts = normalize_link_origins(
+            root,
+            centroid_fn=mesh_centroids({'body.stl': [1e-11, 0.0, 0.0]}))
+        self.assertEqual(shifts, {})
+        self.assertEqual(ET.tostring(root), original)
+
+    def test_several_visuals_use_their_common_centroid(self):
+        urdf = """<robot name="multi">
+  <link name="base"/>
+  <joint name="base_to_body" type="fixed">
+    <parent link="base"/>
+    <child link="body"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+  <link name="body">
+    <visual>
+      <origin xyz="0.6 0 0" rpy="0 0 0"/>
+      <geometry><mesh filename="left.stl"/></geometry>
+    </visual>
+    <visual>
+      <origin xyz="0 0.4 0" rpy="0 0 0"/>
+      <geometry><mesh filename="right.stl"/></geometry>
+    </visual>
+    <visual>
+      <origin xyz="0 0 0.2" rpy="0 0 0"/>
+      <geometry><mesh filename="top.stl"/></geometry>
+    </visual>
+  </link>
+</robot>
+"""
+        centroids = {'left.stl': [0.0, 0.0, 0.0],
+                     'right.stl': [0.0, 0.0, 0.0],
+                     'top.stl': [0.0, 0.0, 0.0]}
+        _, shifts, difference = self._round_trip(urdf, centroids)
+        np.testing.assert_allclose(
+            shifts['body'], [0.2, 0.4 / 3.0, 0.2 / 3.0], atol=1e-15)
+        # the common centroid is none of the three visual origins
+        for xyz in ([0.6, 0, 0], [0, 0.4, 0], [0, 0, 0.2]):
+            self.assertGreater(
+                np.linalg.norm(shifts['body'] - np.array(xyz)), 0.1)
+        self.assertLess(difference, 1e-12)
+
+    def test_movable_parent_joint_is_skipped(self):
+        urdf = """<robot name="movable">
+  <link name="base"/>
+  <joint name="base_to_body" type="revolute">
+    <parent link="base"/>
+    <child link="body"/>
+    <origin xyz="0 0 0.5" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1" upper="1" effort="1" velocity="1"/>
+  </joint>
+  <link name="body">
+    <visual>
+      <origin xyz="0.9 0 0" rpy="0 0 0"/>
+      <geometry><mesh filename="body.stl"/></geometry>
+    </visual>
+  </link>
+</robot>
+"""
+        # Moving a movable link's frame would move its axis of motion, so
+        # the model would only agree with itself at the zero configuration.
+        root = ET.fromstring(urdf)
+        shifts = normalize_link_origins(
+            root, centroid_fn=mesh_centroids({'body.stl': [0.0, 0.0, 0.0]}))
+        self.assertEqual(shifts, {})
+
+    def test_link_names_restricts_the_operation(self):
+        centroids = {
+            'base.stl': [0.0, 0.0, 0.0],
+            'mid.stl': [0.05, -0.02, 0.01],
+            'hinge.stl': [0.0, 0.0, 0.0],
+            'pad.stl': [0.3, 0.0, 0.0],
+        }
+        _, shifts, difference = self._round_trip(
+            BRANCHING, centroids, CONFIGURATION)
+        self.assertEqual(set(shifts), {'mid', 'pad'})
+        self.assertLess(difference, 1e-12)
+
+        _, shifts, difference = self._round_trip(
+            BRANCHING, centroids, CONFIGURATION, link_names=['pad'])
+        self.assertEqual(set(shifts), {'pad'})
+        self.assertLess(difference, 1e-12)
+
+    def test_unmeasurable_geometry_leaves_the_link_alone(self):
+        root = ET.fromstring(BRANCHING)
+        original = ET.tostring(root)
+        shifts = normalize_link_origins(root, centroid_fn=lambda g: None)
+        self.assertEqual(shifts, {})
+        self.assertEqual(ET.tostring(root), original)
+
+    def test_base_path_or_centroid_fn_is_required(self):
+        root = ET.fromstring(BRANCHING)
+        with self.assertRaises(ValueError):
+            normalize_link_origins(root)
+
+
+class TestNormalizeLinkOriginsFile(unittest.TestCase):
+
+    URDF = """<robot name="primitives">
+  <link name="base"/>
+  <joint name="base_to_body" type="fixed">
+    <parent link="base"/>
+    <child link="body"/>
+    <origin xyz="0 0 0.5" rpy="0 0 0.9"/>
+  </joint>
+  <link name="body">
+    <visual>
+      <origin xyz="1.2 -0.6 0.4" rpy="0 0 0"/>
+      <geometry><box size="0.1 0.2 0.3"/></geometry>
+    </visual>
+    <collision>
+      <origin xyz="1.2 -0.6 0.4" rpy="0 0 0"/>
+      <geometry><box size="0.1 0.2 0.3"/></geometry>
+    </collision>
+  </link>
+  <joint name="body_to_tip" type="fixed">
+    <parent link="body"/>
+    <child link="tip"/>
+    <origin xyz="1.3 -0.6 0.4" rpy="0 0 0"/>
+  </joint>
+  <link name="tip"/>
+</robot>
+"""
+
+    def test_primitive_geometry_and_file_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_file = os.path.join(tmpdir, 'robot.urdf')
+            output_file = os.path.join(tmpdir, 'centred.urdf')
+            with open(input_file, 'w') as f:
+                f.write(self.URDF)
+
+            before = world_poses(ET.fromstring(self.URDF))
+            shifts = normalize_link_origins_file(input_file, output_file)
+            after = world_poses(ET.parse(output_file).getroot())
+
+        # a box is centred on its own frame, so the shift is the visual origin
+        np.testing.assert_allclose(
+            shifts['body'], [1.2, -0.6, 0.4], atol=1e-15)
+        self.assertLess(
+            max_pose_difference(expected_poses(before, shifts), after), 1e-12)
+
+    def test_missing_file(self):
+        with self.assertRaises(FileNotFoundError):
+            normalize_link_origins_file('/no/such/robot.urdf')
+
+
+class TestGeometryCentroid(unittest.TestCase):
+
+    def test_mesh_on_disk(self):
+        try:
+            import trimesh
+        except ImportError:
+            self.skipTest('trimesh is not available')
+
+        urdf = """<robot name="meshed">
+  <link name="base"/>
+  <joint name="base_to_body" type="fixed">
+    <parent link="base"/>
+    <child link="body"/>
+    <origin xyz="0 0 0.5" rpy="0 0 0"/>
+  </joint>
+  <link name="body">
+    <visual>
+      <geometry><mesh filename="body.stl" scale="2 2 2"/></geometry>
+    </visual>
+  </link>
+</robot>
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            box = trimesh.creation.box(extents=(0.1, 0.1, 0.1))
+            box.apply_translation([0.4, -0.15, 0.05])
+            box.export(os.path.join(tmpdir, 'body.stl'))
+            input_file = os.path.join(tmpdir, 'robot.urdf')
+            with open(input_file, 'w') as f:
+                f.write(urdf)
+
+            before = world_poses(ET.fromstring(urdf))
+            root = ET.parse(input_file).getroot()
+            shifts = normalize_link_origins(root, base_path=tmpdir)
+            after = world_poses(root)
+
+        # the mesh scale multiplies the measured centroid
+        np.testing.assert_allclose(
+            shifts['body'], [0.8, -0.3, 0.1], atol=1e-6)
+        self.assertLess(
+            max_pose_difference(expected_poses(before, shifts), after), 1e-12)
+
+
+class TestFramesThisCannotMove(unittest.TestCase):
+    """A frame is only moved when everything expressed in it moves with it.
+
+    Anything referencing the link from outside -- a Gazebo sensor pose, a
+    top-level ``<sensor>`` -- is stated in that link's frame and is not
+    rewritten here, so re-centring would silently displace it.  Likewise a
+    malformed origin, or a link the document declares or parents twice.
+    """
+
+    _URDF = """<robot name="r">
+      <link name="base"/>
+      <link name="head">
+        <visual><origin xyz="0.4 0 0.1"/>
+          <geometry><box size="0.1 0.1 0.1"/></geometry></visual>
+      </link>
+      <joint name="j" type="fixed"><origin xyz="0 0 1"/>
+        <parent link="base"/><child link="head"/></joint>
+      {}</robot>"""
+
+    def _run(self, extra=''):
+        root = ET.fromstring(self._URDF.format(extra))
+        shifts = normalize_link_origins(
+            root, centroid_fn=lambda geometry: np.zeros(3))
+        return root, shifts
+
+    def test_a_plain_link_is_still_recentred(self):
+        _root, shifts = self._run()
+        np.testing.assert_allclose(shifts['head'], [0.4, 0.0, 0.1])
+
+    def test_a_gazebo_sensor_on_the_link_stops_it(self):
+        _root, shifts = self._run(
+            '<gazebo reference="head"><sensor name="cam">'
+            '<pose>0.5 0 0.12 0 0 0</pose></sensor></gazebo>')
+        self.assertEqual(shifts, {})
+
+    def test_a_sensor_parented_to_the_link_stops_it(self):
+        _root, shifts = self._run(
+            '<sensor name="s"><parent link="head"/>'
+            '<origin xyz="0.45 0 0.15"/></sensor>')
+        self.assertEqual(shifts, {})
+
+    def test_an_empty_gazebo_tag_does_not_stop_it(self):
+        """``<gazebo reference="L"/>`` carrying only material settings names
+        no frame, so it must not block a re-centre."""
+        _root, shifts = self._run('<gazebo reference="head"/>')
+        np.testing.assert_allclose(shifts['head'], [0.4, 0.0, 0.1])
+
+    def test_an_unparsable_origin_leaves_the_tree_untouched(self):
+        root, shifts = self._run(
+            '<link name="tip"/><joint name="k" type="fixed">'
+            '<origin xyz="${tip} 0 0"/>'
+            '<parent link="head"/><child link="tip"/></joint>')
+        self.assertEqual(shifts, {})
+        # the parent joint must not have been moved before the failure
+        joint = next(j for j in root.findall('joint')
+                     if j.get('name') == 'j')
+        self.assertEqual(joint.find('origin').get('xyz'), '0 0 1')
+
+    def test_a_link_declared_twice_is_left_alone(self):
+        _root, shifts = self._run('<link name="head"/>')
+        self.assertEqual(shifts, {})
+
+    def test_a_link_with_two_parent_joints_is_left_alone(self):
+        _root, shifts = self._run(
+            '<joint name="j2" type="fixed"><origin xyz="1 0 0"/>'
+            '<parent link="base"/><child link="head"/></joint>')
+        self.assertEqual(shifts, {})
+
+
+class TestToleranceIsAboveMeasurementNoise(unittest.TestCase):
+
+    def _shift_for(self, centroid, **kwargs):
+        root = ET.fromstring("""<robot name="r">
+          <link name="base"/>
+          <link name="c"><visual><geometry><box size="1 1 1"/></geometry>
+            </visual></link>
+          <joint name="j" type="fixed"><parent link="base"/>
+            <child link="c"/></joint></robot>""")
+        return normalize_link_origins(
+            root, centroid_fn=lambda geometry: np.asarray(centroid, float),
+            **kwargs)
+
+    def test_a_nanometre_is_noise_and_is_ignored(self):
+        """Measuring a centroid off a binary STL carries several nanometres
+        of float32 error, so a nanometre shift must not churn the file."""
+        self.assertEqual(self._shift_for([1e-9, 0.0, 0.0]), {})
+        self.assertEqual(self._shift_for([1e-9 / np.sqrt(3)] * 3), {})
+
+    def test_a_millimetre_is_real_and_is_applied(self):
+        shifts = self._shift_for([1e-3, 0.0, 0.0])
+        np.testing.assert_allclose(shifts['c'], [1e-3, 0.0, 0.0])
+
+    def test_the_threshold_is_configurable(self):
+        self.assertEqual(self._shift_for([1e-3, 0.0, 0.0], tolerance=1.0), {})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
CAD exporters routinely place a link's frame far from its parts: a sub-assembly inherits the CAD origin of the whole machine, so its frame can float a metre from anything visible.  The model renders correctly -- every <visual> carries the compensating <origin> -- but the TF frame is useless to look at and the numbers in the file are hard to read.

normalize_link_origins moves such a frame onto its geometry.  For a shift d the parent joint's origin becomes F @ T(+d) and everything expressed in that frame -- child joints, <inertial>, <visual>, <collision> -- becomes T(-d) @ F.  The two cancel, so the frame is the only thing that moves: every piece of geometry, every mass and every other link stays where it was, in every joint configuration.

Only links whose parent joint is fixed are eligible.  A movable joint's origin places its axis of motion, so moving the child frame would move that axis; the root link is skipped for the mirror of that reason, having no parent joint to absorb the shift.

A link is also left alone, with a warning, whenever the move could not be completed honestly: when a <gazebo reference> or a top-level <sensor> states a pose in that link's frame, since nothing here rewrites those; when an origin holds a value that is not a number, so a xacro substitution cannot leave the tree half corrected; and when the document declares or parents the link more than once.  The default tolerance is 1e-6 m, above the few nanometres of float32 error that measuring a centroid off a binary STL carries, so re-centring does not depend on which export it was handed.