### PR TITLE
Add convex_decomposition_cached: a disk cache for CoACD results

### DIFF
--- a/skrobot/utils/__init__.py
+++ b/skrobot/utils/__init__.py
@@ -17,6 +17,7 @@ from skrobot.utils.visualization import get_ik_visualization_enabled
 from skrobot.utils.blender_mesh import remesh_with_blender
 
 from skrobot.utils.convex_decomposition import convex_decomposition
+from skrobot.utils.convex_decomposition import convex_decomposition_cached
 from skrobot.utils.convex_decomposition import is_coacd_available
 
 from skrobot.utils.inertia import combine_inertials

--- a/skrobot/utils/convex_decomposition.py
+++ b/skrobot/utils/convex_decomposition.py
@@ -1,6 +1,13 @@
 """Approximate convex decomposition of meshes using CoACD."""
 
+import hashlib
+import json
 from logging import getLogger
+import os
+import shutil
+import tempfile
+import threading
+import zipfile
 
 import numpy as np
 
@@ -14,6 +21,8 @@ __all__ = [
     'COACD_PRESETS',
     'is_coacd_available',
     'convex_decomposition',
+    'convex_decomposition_cached',
+    'clear_convex_decomposition_cache',
 ]
 
 
@@ -123,3 +132,429 @@ def convex_decomposition(mesh, quality='balanced', **params):
         parts.append(part)
     logger.debug('CoACD decomposed mesh into %d convex part(s)', len(parts))
     return parts
+
+
+# ------------------------------------------------------------------ disk cache
+# CoACD costs seconds to tens of seconds per mesh, and a robot description
+# typically decomposes the same part many times (several links sharing one
+# servo mesh, a re-export of an unchanged model, a test suite).  The results
+# are a pure function of the mesh content and the CoACD parameters, so they can
+# be cached on disk and reused indefinitely -- a cache hit costs a hash and a
+# few file reads, and never touches CoACD.
+
+# Bump when the on-disk layout or the meaning of a cache entry changes, so that
+# entries written by an older skrobot are ignored instead of misread.
+_CACHE_VERSION = 1
+
+# formats whose geometry lives in files the named one only references, so
+# hashing that file alone cannot notice the geometry changing
+_EXTERNAL_GEOMETRY_FORMATS = frozenset(('.gltf', '.obj', '.dae', '.mtl'))
+
+# Name of the manifest written *last* inside a cache entry: its presence is what
+# makes an entry valid, so a build interrupted halfway is simply a miss.
+_MANIFEST_NAME = 'parts.json'
+
+# Errors that mean "this cache entry is unusable" (missing, truncated, written
+# by a crashed process, hand-edited, ...) rather than a programming mistake.
+# EOFError is in here for a specific reason: a rename that was not preceded by
+# an fsync can leave a zero-length file behind after a crash, and numpy raises
+# EOFError -- not OSError -- on one.  Reading a cache must never be able to
+# fail a call that would have succeeded without it.
+_CACHE_READ_ERRORS = (OSError, EOFError, ValueError, KeyError, TypeError,
+                      IndexError, zipfile.BadZipFile)
+
+# One lock per cache key.  Several links commonly share a single source mesh;
+# without this they would all miss, all run CoACD, and all write the same files
+# at once (on Windows, a file-in-use error).  Locking per key -- rather than
+# globally -- keeps decompositions of *different* meshes parallel.
+_cache_locks = {}
+_cache_locks_guard = threading.Lock()
+
+
+def _cache_key_lock(key):
+    """Return the process-wide :class:`threading.Lock` for a cache key.
+
+    Parameters
+    ----------
+    key : str
+        Cache key, as returned by ``_cache_key``.
+
+    Returns
+    -------
+    lock : threading.Lock
+        The lock guarding builds of that key, created on first use.
+    """
+    with _cache_locks_guard:
+        lock = _cache_locks.get(key)
+        if lock is None:
+            lock = _cache_locks[key] = threading.Lock()
+        return lock
+
+
+def _default_cache_dir():
+    """Return the default directory holding cached decompositions.
+
+    Returns
+    -------
+    cache_dir : str
+        ``<skrobot cache dir>/convex_decomposition``.  The skrobot cache dir
+        honours the ``SKROBOT_CACHE_DIR`` environment variable, so this is
+        resolved on every call rather than at import time.
+    """
+    from skrobot.data import get_cache_dir
+    return os.path.join(get_cache_dir(), 'convex_decomposition')
+
+
+def _file_digest(path):
+    """Return the SHA-1 hex digest of a file's bytes.
+
+    Parameters
+    ----------
+    path : str
+        Path of the file to hash.
+
+    Returns
+    -------
+    digest : str
+        Hex digest of the file content.
+    """
+    h = hashlib.sha1()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1 << 20), b''):
+            h.update(chunk)
+    if os.path.splitext(path)[1].lower() in _EXTERNAL_GEOMETRY_FORMATS:
+        # the named file does not hold the geometry: a .gltf points at sibling
+        # .bin buffers, an .obj may point at other files.  Editing only what it
+        # references would leave this digest unchanged, so fold in the sibling
+        # directory's shape as well -- coarse, but it moves when they do.
+        directory = os.path.dirname(os.path.abspath(path))
+        try:
+            for name in sorted(os.listdir(directory)):
+                sibling = os.path.join(directory, name)
+                if sibling == os.path.abspath(path) or not os.path.isfile(
+                        sibling):
+                    continue
+                stat = os.stat(sibling)
+                h.update('{}:{}:{}'.format(
+                    name, stat.st_size, stat.st_mtime_ns).encode())
+        except OSError:
+            pass
+    return h.hexdigest()
+
+
+def _mesh_digest(mesh):
+    """Return the SHA-1 hex digest of a mesh's vertices and faces.
+
+    Parameters
+    ----------
+    mesh : trimesh.Trimesh
+        Mesh to hash.
+
+    Returns
+    -------
+    digest : str
+        Hex digest of the exact vertex and face arrays.  This is a content
+        hash, not a geometric one: a translated or rotated copy hashes
+        differently, which is what the cache needs since the decomposition is
+        expressed in the mesh frame.
+    """
+    vertices = np.ascontiguousarray(mesh.vertices, dtype=np.float64)
+    faces = np.ascontiguousarray(mesh.faces, dtype=np.int64)
+    h = hashlib.sha1()
+    h.update(json.dumps([list(vertices.shape), list(faces.shape)]).encode())
+    h.update(vertices.tobytes())
+    h.update(faces.tobytes())
+    return h.hexdigest()
+
+
+def _cache_key(source_kind, digest, run_params):
+    """Return the cache key for one decomposition.
+
+    Parameters
+    ----------
+    source_kind : str
+        ``'path'`` or ``'mesh'``; keeps the two hashing domains separate.
+    digest : str
+        Content digest of the source mesh.
+    run_params : dict
+        The effective CoACD parameters (preset merged with overrides).
+
+    Returns
+    -------
+    key : str
+        16 hex characters -- short enough to keep the cache paths well clear
+        of the Windows path length limit, wide enough (64 bits) that an
+        accidental collision is not a practical concern.
+    """
+    h = hashlib.sha1(digest.encode())
+    h.update(json.dumps([source_kind, run_params, _CACHE_VERSION],
+                        sort_keys=True, default=repr).encode())
+    return h.hexdigest()[:16]
+
+
+def _atomic_write(path, write):
+    """Write a file atomically by writing a temporary file and renaming it.
+
+    Parameters
+    ----------
+    path : str
+        Final path of the file.
+    write : callable
+        Called with the open binary file object of the temporary file.
+    """
+    tmp = '{}.{}.{}.tmp'.format(path, os.getpid(), threading.get_ident())
+    try:
+        with open(tmp, 'wb') as f:
+            write(f)
+            # flush to disk before the rename: a rename that overtakes its own
+            # data leaves a zero-length file behind after a crash
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _read_cache_entry(part_dir):
+    """Read the convex parts stored in a cache entry.
+
+    Parameters
+    ----------
+    part_dir : str
+        Directory of the cache entry.
+
+    Returns
+    -------
+    parts : list of trimesh.Trimesh or None
+        The cached parts, or None if the entry is absent, incomplete or
+        unreadable -- in which case the caller rebuilds it.
+    """
+    trimesh = _lazy_trimesh()
+    try:
+        with open(os.path.join(part_dir, _MANIFEST_NAME)) as f:
+            manifest = json.load(f)
+        if manifest['version'] != _CACHE_VERSION:
+            return None
+        names = manifest['parts']
+        parts = []
+        for name in names:
+            # a manifest is data, not a path list to trust: a name carrying a
+            # separator would read a file outside the entry
+            if os.path.basename(name) != name:
+                return None
+            with np.load(os.path.join(part_dir, name)) as data:
+                vertices = data['vertices']
+                faces = data['faces']
+            parts.append(trimesh.Trimesh(vertices=vertices, faces=faces,
+                                         process=False))
+        return parts
+    except _CACHE_READ_ERRORS:
+        return None
+
+
+def _write_cache_entry(part_dir, quality, run_params, parts):
+    """Store convex parts in a cache entry.
+
+    The manifest is written last, so an interrupted or partially written entry
+    reads back as a miss rather than as a truncated result.
+
+    Parameters
+    ----------
+    part_dir : str
+        Directory of the cache entry; created if needed.
+    quality : str
+        Preset name the parts were computed with (recorded for inspection).
+    run_params : dict
+        Effective CoACD parameters (recorded for inspection).
+    parts : list of trimesh.Trimesh
+        The parts to store.
+    """
+    parent = os.path.dirname(part_dir)
+    os.makedirs(parent, exist_ok=True)
+    staging = tempfile.mkdtemp(prefix=os.path.basename(part_dir) + '.',
+                               suffix='.tmp', dir=parent)
+    try:
+        names = []
+        for i, part in enumerate(parts):
+            name = 'part_{}.npz'.format(i)
+            vertices = np.ascontiguousarray(part.vertices, dtype=np.float64)
+            faces = np.ascontiguousarray(part.faces, dtype=np.int64)
+            _atomic_write(
+                os.path.join(staging, name),
+                lambda f, v=vertices, t=faces: np.savez(f, vertices=v,
+                                                        faces=t))
+            names.append(name)
+        manifest = {'version': _CACHE_VERSION, 'quality': quality,
+                    'params': run_params, 'parts': names}
+        _atomic_write(
+            os.path.join(staging, _MANIFEST_NAME),
+            lambda f: f.write(json.dumps(manifest, sort_keys=True,
+                                         default=repr).encode()))
+        # An entry is published as one directory, never file by file: CoACD is
+        # not deterministic -- two runs on the same mesh return the same parts
+        # in a different order -- so interleaving two builds in a shared
+        # directory yields an entry that reads back as valid while covering
+        # less of the mesh than either run did.
+        try:
+            os.rename(staging, part_dir)
+            return
+        except OSError:
+            pass
+        if _read_cache_entry(part_dir) is not None:
+            # somebody published a whole entry first; theirs is as good as ours
+            shutil.rmtree(staging, ignore_errors=True)
+            return
+        # what is there is unreadable (corrupt, stale version, half-deleted):
+        # move it aside and take its place
+        discard = staging + '.discard'
+        try:
+            os.rename(part_dir, discard)
+            os.rename(staging, part_dir)
+        except OSError:
+            shutil.rmtree(staging, ignore_errors=True)
+        finally:
+            shutil.rmtree(discard, ignore_errors=True)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def convex_decomposition_cached(mesh, quality='balanced', cache_dir=None,
+                                **params):
+    """Decompose a mesh into convex parts, reusing a decomposition on disk.
+
+    Same result as :func:`convex_decomposition`, but the parts are persisted
+    under ``cache_dir`` and keyed by the mesh content and the effective CoACD
+    parameters.  CoACD costs seconds to tens of seconds per mesh, so repeated
+    decompositions -- several links sharing one part mesh, a re-export of an
+    unchanged model, a test run -- become instant.  A cache hit only reads the
+    stored parts back: the ``coacd`` package need not even be installed.
+
+    Concurrent calls for the same key are serialised with a per-key lock, so a
+    mesh shared by many links is decomposed once even from several threads.
+    Distinct meshes still decompose in parallel.
+
+    Parameters
+    ----------
+    mesh : trimesh.Trimesh or str or os.PathLike
+        Input mesh, or the path of a mesh file.  A path is hashed by its bytes
+        and only loaded on a cache miss, so a hit costs no mesh parsing at all.
+    quality : str, optional
+        Preset name, one of ``COACD_PRESETS`` keys ('balanced' or 'fine').
+    cache_dir : str or os.PathLike or None, optional
+        Directory holding the cache.  Defaults to ``convex_decomposition``
+        inside the skrobot cache directory (``~/.skrobot``, or
+        ``SKROBOT_CACHE_DIR`` if set).
+    **params
+        Explicit CoACD parameters overriding the preset, forwarded to
+        :func:`convex_decomposition`.  The key is built from the *effective*
+        parameters, so two calls that would run CoACD identically share one
+        entry whatever preset name they name it by.
+
+    Returns
+    -------
+    parts : list of trimesh.Trimesh
+        The convex parts covering the input mesh, exactly as
+        :func:`convex_decomposition` returns them.
+
+    Raises
+    ------
+    RuntimeError
+        If the result is not cached and the optional ``coacd`` package is not
+        installed.
+    ValueError
+        If ``quality`` is not a known preset name.
+
+    Notes
+    -----
+    A cache entry that is missing, incomplete or unreadable (an interrupted
+    build, a hand-edited manifest, a stale format) is treated as a miss and
+    rebuilt.  If the cache cannot be written -- a read-only directory, say --
+    the freshly computed parts are still returned and a warning is logged.
+
+    Examples
+    --------
+    >>> import trimesh
+    >>> from skrobot.utils.convex_decomposition import (
+    ...     convex_decomposition_cached)
+    >>> mesh = trimesh.creation.annulus(r_min=0.5, r_max=1.0, height=0.3)
+    >>> parts = convex_decomposition_cached(mesh)   # runs CoACD
+    >>> parts = convex_decomposition_cached(mesh)   # read back from disk
+    """
+    if quality not in COACD_PRESETS:
+        raise ValueError(
+            'unsupported quality: {!r} (expected one of {})'.format(
+                quality, sorted(COACD_PRESETS)))
+    run_params = dict(COACD_PRESETS[quality])
+    run_params.update(params)
+
+    if isinstance(mesh, (str, os.PathLike)):
+        source_path = os.fspath(mesh)
+        key = _cache_key('path', _file_digest(source_path), run_params)
+    else:
+        source_path = None
+        key = _cache_key('mesh', _mesh_digest(mesh), run_params)
+
+    if cache_dir is None:
+        cache_dir = _default_cache_dir()
+    part_dir = os.path.join(os.fspath(cache_dir), key)
+
+    parts = _read_cache_entry(part_dir)
+    if parts is not None:
+        logger.debug('convex decomposition cache hit (%s)', key)
+        return parts
+
+    # Hold the per-key lock across the re-check and the build: another thread
+    # may have finished this very key while we were reading the miss.
+    with _cache_key_lock(key):
+        parts = _read_cache_entry(part_dir)
+        if parts is not None:
+            logger.debug('convex decomposition cache hit (%s)', key)
+            return parts
+        if source_path is not None:
+            mesh = _lazy_trimesh().load(source_path, force='mesh')
+        parts = convex_decomposition(mesh, quality=quality, **params)
+        try:
+            _write_cache_entry(part_dir, quality, run_params, parts)
+        except OSError as e:
+            logger.warning('could not cache convex decomposition in %s: %s',
+                           part_dir, e)
+        return parts
+
+
+def clear_convex_decomposition_cache(cache_dir=None):
+    """Delete cached convex decompositions.
+
+    Nothing evicts entries on its own: every re-export of a mesh and every
+    change of parameters mints a fresh key, and the superseded entries stay on
+    disk.  Call this to reclaim the space.
+
+    Parameters
+    ----------
+    cache_dir : str or None, optional
+        Directory to clear.  Defaults to the same location
+        :func:`convex_decomposition_cached` writes to.
+
+    Returns
+    -------
+    removed : int
+        How many cache entries were deleted.
+    """
+    cache_dir = cache_dir or _default_cache_dir()
+    removed = 0
+    try:
+        names = sorted(os.listdir(cache_dir))
+    except OSError:
+        return 0
+    for name in names:
+        entry = os.path.join(cache_dir, name)
+        if not os.path.isdir(entry):
+            continue
+        shutil.rmtree(entry, ignore_errors=True)
+        if not os.path.exists(entry):
+            removed += 1
+    return removed

--- a/tests/skrobot_tests/utils_tests/test_convex_decomposition_cached.py
+++ b/tests/skrobot_tests/utils_tests/test_convex_decomposition_cached.py
@@ -1,0 +1,331 @@
+import importlib
+import json
+import os
+import shutil
+import tempfile
+import threading
+import unittest
+
+import numpy as np
+import trimesh
+
+from skrobot.utils.convex_decomposition import convex_decomposition_cached
+
+
+# ``skrobot.utils.convex_decomposition`` names the function, not the module,
+# so reach the module itself to swap the (slow, optional) decomposer out.
+cd_module = importlib.import_module('skrobot.utils.convex_decomposition')
+
+
+class _CountingDecomposer(object):
+    """Stand-in for ``convex_decomposition`` that counts its own calls.
+
+    CoACD is an optional dependency and is slow even when installed, so the
+    cache tests patch it out: what they check is that the expensive callable
+    runs exactly as often as the cache says it should.
+    """
+
+    def __init__(self, delay=0.0):
+        self.calls = 0
+        self.seen = []
+        self.delay = delay
+        self._lock = threading.Lock()
+
+    def __call__(self, mesh, quality='balanced', **params):
+        if self.delay:
+            import time
+            time.sleep(self.delay)
+        with self._lock:
+            self.calls += 1
+            self.seen.append((quality, dict(params)))
+        # two parts, so the manifest genuinely holds a list
+        box = trimesh.creation.box(extents=(1.0, 1.0, 1.0))
+        return [box.convex_hull,
+                trimesh.creation.box(extents=(0.5, 0.5, 2.0)).convex_hull]
+
+
+def _explode(*args, **kwargs):
+    raise AssertionError('the decomposer must not run on a cache hit')
+
+
+def _explode_load(*args, **kwargs):
+    raise AssertionError('the source mesh must not be loaded on a cache hit')
+
+
+class TestConvexDecompositionCached(unittest.TestCase):
+
+    def setUp(self):
+        self.cache_dir = tempfile.mkdtemp(prefix='skrobot_coacd_cache_')
+        self.mesh = trimesh.creation.annulus(
+            r_min=0.5, r_max=1.0, height=0.3)
+        self._original = cd_module.convex_decomposition
+
+    def tearDown(self):
+        cd_module.convex_decomposition = self._original
+        shutil.rmtree(self.cache_dir, ignore_errors=True)
+
+    def _patch(self, decomposer):
+        cd_module.convex_decomposition = decomposer
+
+    def _entries(self):
+        return sorted(os.listdir(self.cache_dir))
+
+    def test_miss_then_hit_runs_decomposer_once(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        first = convex_decomposition_cached(
+            self.mesh, cache_dir=self.cache_dir)
+        self.assertEqual(decomposer.calls, 1)
+        self.assertEqual(len(self._entries()), 1)
+
+        # a hit must not need the decomposer at all -- that is the point
+        self._patch(_explode)
+        second = convex_decomposition_cached(
+            self.mesh, cache_dir=self.cache_dir)
+        self.assertEqual(len(second), len(first))
+        for a, b in zip(first, second):
+            np.testing.assert_allclose(a.vertices, b.vertices)
+            np.testing.assert_array_equal(a.faces, b.faces)
+            self.assertTrue(b.is_watertight)
+
+    def test_hit_works_with_the_real_decomposer_in_place(self):
+        # the cache is what makes CoACD optional at call time: with the entry
+        # warm, the real code path is never reached, so an environment without
+        # the ``coacd`` package still gets its parts
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        convex_decomposition_cached(self.mesh, cache_dir=self.cache_dir)
+        cd_module.convex_decomposition = self._original
+        parts = convex_decomposition_cached(
+            self.mesh, cache_dir=self.cache_dir)
+        self.assertEqual(len(parts), 2)
+
+    def test_quality_changes_the_key(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        convex_decomposition_cached(
+            self.mesh, quality='balanced', cache_dir=self.cache_dir)
+        convex_decomposition_cached(
+            self.mesh, quality='fine', cache_dir=self.cache_dir)
+        self.assertEqual(decomposer.calls, 2)
+        self.assertEqual(len(self._entries()), 2)
+        # ... and each preset still caches on its own
+        self._patch(_explode)
+        convex_decomposition_cached(
+            self.mesh, quality='balanced', cache_dir=self.cache_dir)
+        convex_decomposition_cached(
+            self.mesh, quality='fine', cache_dir=self.cache_dir)
+
+    def test_explicit_params_change_the_key(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        convex_decomposition_cached(self.mesh, cache_dir=self.cache_dir)
+        convex_decomposition_cached(
+            self.mesh, cache_dir=self.cache_dir, threshold=0.42)
+        self.assertEqual(decomposer.calls, 2)
+        self.assertEqual(len(self._entries()), 2)
+
+    def test_params_matching_the_preset_hit_the_same_entry(self):
+        # the key is built from the effective parameters, so naming a preset
+        # value explicitly must not miss
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        convex_decomposition_cached(self.mesh, cache_dir=self.cache_dir)
+        preset = dict(cd_module.COACD_PRESETS['balanced'])
+        convex_decomposition_cached(
+            self.mesh, cache_dir=self.cache_dir, **preset)
+        self.assertEqual(decomposer.calls, 1)
+        self.assertEqual(len(self._entries()), 1)
+
+    def test_different_mesh_changes_the_key(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        convex_decomposition_cached(self.mesh, cache_dir=self.cache_dir)
+        other = trimesh.creation.box(extents=(1.0, 2.0, 3.0))
+        convex_decomposition_cached(other, cache_dir=self.cache_dir)
+        self.assertEqual(decomposer.calls, 2)
+        self.assertEqual(len(self._entries()), 2)
+
+    def test_corrupt_manifest_is_rebuilt(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        expected = convex_decomposition_cached(
+            self.mesh, cache_dir=self.cache_dir)
+        entry = os.path.join(self.cache_dir, self._entries()[0])
+        with open(os.path.join(entry, 'parts.json'), 'w') as f:
+            f.write('{not json at all')
+
+        parts = convex_decomposition_cached(
+            self.mesh, cache_dir=self.cache_dir)
+        self.assertEqual(decomposer.calls, 2)
+        self.assertEqual(len(parts), len(expected))
+        # the rebuild repaired the entry
+        self._patch(_explode)
+        convex_decomposition_cached(self.mesh, cache_dir=self.cache_dir)
+
+    def test_manifest_of_a_foreign_version_is_rebuilt(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        convex_decomposition_cached(self.mesh, cache_dir=self.cache_dir)
+        entry = os.path.join(self.cache_dir, self._entries()[0])
+        manifest_path = os.path.join(entry, 'parts.json')
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+        manifest['version'] = cd_module._CACHE_VERSION + 99
+        with open(manifest_path, 'w') as f:
+            json.dump(manifest, f)
+
+        convex_decomposition_cached(self.mesh, cache_dir=self.cache_dir)
+        self.assertEqual(decomposer.calls, 2)
+
+    def test_missing_part_file_is_rebuilt(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        convex_decomposition_cached(self.mesh, cache_dir=self.cache_dir)
+        entry = os.path.join(self.cache_dir, self._entries()[0])
+        os.remove(os.path.join(entry, 'part_1.npz'))
+
+        parts = convex_decomposition_cached(
+            self.mesh, cache_dir=self.cache_dir)
+        self.assertEqual(decomposer.calls, 2)
+        self.assertEqual(len(parts), 2)
+
+    def test_truncated_part_file_is_rebuilt(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        convex_decomposition_cached(self.mesh, cache_dir=self.cache_dir)
+        entry = os.path.join(self.cache_dir, self._entries()[0])
+        with open(os.path.join(entry, 'part_0.npz'), 'wb') as f:
+            f.write(b'PK\x03\x04 truncated')
+
+        parts = convex_decomposition_cached(
+            self.mesh, cache_dir=self.cache_dir)
+        self.assertEqual(decomposer.calls, 2)
+        self.assertEqual(len(parts), 2)
+
+    def test_mesh_path_is_accepted_and_hit_skips_loading_the_mesh(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        tmp_dir = tempfile.mkdtemp(prefix='skrobot_coacd_src_')
+        original_load = trimesh.load
+        try:
+            path = os.path.join(tmp_dir, 'mesh.stl')
+            self.mesh.export(path)
+            convex_decomposition_cached(path, cache_dir=self.cache_dir)
+            self.assertEqual(decomposer.calls, 1)
+            # a path is keyed on its bytes, so a hit costs one file read and
+            # neither parses the mesh nor runs the decomposer
+            self._patch(_explode)
+            trimesh.load = _explode_load
+            parts = convex_decomposition_cached(
+                path, cache_dir=self.cache_dir)
+            self.assertEqual(len(parts), 2)
+        finally:
+            trimesh.load = original_load
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def test_mesh_path_and_loaded_mesh_are_hashed_separately(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        tmp_dir = tempfile.mkdtemp(prefix='skrobot_coacd_src_')
+        try:
+            path = os.path.join(tmp_dir, 'mesh.stl')
+            self.mesh.export(path)
+            convex_decomposition_cached(path, cache_dir=self.cache_dir)
+            convex_decomposition_cached(
+                trimesh.load(path, force='mesh'), cache_dir=self.cache_dir)
+            self.assertEqual(decomposer.calls, 2)
+            self.assertEqual(len(self._entries()), 2)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def test_unknown_quality_raises_and_writes_nothing(self):
+        self._patch(_explode)
+        with self.assertRaises(ValueError):
+            convex_decomposition_cached(
+                self.mesh, quality='ultra', cache_dir=self.cache_dir)
+        self.assertEqual(self._entries(), [])
+
+    def test_default_cache_dir_follows_skrobot_cache_dir(self):
+        decomposer = _CountingDecomposer()
+        self._patch(decomposer)
+        original = os.environ.get('SKROBOT_CACHE_DIR')
+        os.environ['SKROBOT_CACHE_DIR'] = self.cache_dir
+        try:
+            convex_decomposition_cached(self.mesh)
+            expected = cd_module._default_cache_dir()
+        finally:
+            if original is None:
+                del os.environ['SKROBOT_CACHE_DIR']
+            else:
+                os.environ['SKROBOT_CACHE_DIR'] = original
+        self.assertTrue(expected.startswith(self.cache_dir))
+        self.assertEqual(decomposer.calls, 1)
+        self.assertEqual(len(os.listdir(expected)), 1)
+
+    def test_concurrent_calls_decompose_once_and_agree(self):
+        decomposer = _CountingDecomposer(delay=0.05)
+        self._patch(decomposer)
+        results = {}
+        errors = []
+
+        def worker(i):
+            try:
+                results[i] = convex_decomposition_cached(
+                    self.mesh, cache_dir=self.cache_dir)
+            except Exception as e:  # pragma: no cover - reported below
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,))
+                   for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+        self.assertEqual(decomposer.calls, 1)
+        self.assertEqual(len(results), 8)
+        self.assertEqual(len(self._entries()), 1)
+        reference = results[0]
+        for parts in results.values():
+            self.assertEqual(len(parts), len(reference))
+            for a, b in zip(reference, parts):
+                np.testing.assert_allclose(a.vertices, b.vertices)
+                np.testing.assert_array_equal(a.faces, b.faces)
+
+        # the entry the threads left behind is intact and complete
+        entry = os.path.join(self.cache_dir, self._entries()[0])
+        self.assertEqual(
+            sorted(os.listdir(entry)),
+            ['part_0.npz', 'part_1.npz', 'parts.json'])
+        self._patch(_explode)
+        convex_decomposition_cached(self.mesh, cache_dir=self.cache_dir)
+
+    def test_concurrent_calls_on_distinct_meshes_build_distinct_entries(self):
+        decomposer = _CountingDecomposer(delay=0.01)
+        self._patch(decomposer)
+        meshes = [trimesh.creation.box(extents=(1.0, 1.0, 1.0 + 0.1 * i))
+                  for i in range(6)]
+        errors = []
+
+        def worker(mesh):
+            try:
+                convex_decomposition_cached(mesh, cache_dir=self.cache_dir)
+            except Exception as e:  # pragma: no cover - reported below
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(m,))
+                   for m in meshes for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+        self.assertEqual(decomposer.calls, len(meshes))
+        self.assertEqual(len(self._entries()), len(meshes))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
CoACD costs seconds to tens of seconds per mesh, and a robot description decomposes the same part many times -- several links sharing one servo mesh, a re-export of an unchanged model, a test suite.  The result is a pure function of the mesh content and the parameters, so this module's own docstring already asks callers to cache it; every caller reinvents that.

convex_decomposition_cached keys on a SHA-1 of the mesh content (raw float64 vertex and int64 face bytes) or of the file's bytes, plus the effective CoACD parameters and a cache-format version.  A hit costs a hash and a few file reads and never touches CoACD -- measured on a real decomposition: 29.6 s cold, 0.05 s warm, parts bit-identical.  Parts are stored as npz rather than STL so the round trip is exact; STL is float32, which would return subtly different geometry from a cold run.

An entry is published by renaming a staging directory into place, never file by file.  CoACD is not deterministic -- two runs on the same mesh return the same parts in a different order -- so interleaving two builds in a shared directory could produce an entry that reads back as valid while covering a quarter less of the mesh, and the per-key threading lock does nothing across processes.

Reading a cache must never fail a call that would have worked without one: numpy raises EOFError, not OSError, on a zero-length file, which is what a rename that overtook its own data leaves behind, so writes now fsync and that error means "rebuild".  Part names from the manifest are checked to stay inside their entry.  Formats that keep their geometry in files they only reference -- a .gltf and its .bin buffers -- fold their siblings into the digest, since hashing the named file alone made editing the geometry a silent stale hit.  Nothing evicts entries, so
clear_convex_decomposition_cache reclaims them.