### PR TITLE
Add merge_fixed_links to collapse a URDF's fixed joints

### DIFF
--- a/skrobot/urdf/__init__.py
+++ b/skrobot/urdf/__init__.py
@@ -11,6 +11,8 @@ from skrobot.urdf.llm_grouping import build_grouping_prompt
 from skrobot.urdf.llm_grouping import compute_jaw_gripper_frame
 from skrobot.urdf.llm_grouping import generate_groups_from_llm
 from skrobot.urdf.llm_grouping import parse_grouping_response
+from skrobot.urdf.merge_fixed_links import merge_fixed_links
+from skrobot.urdf.merge_fixed_links import merge_fixed_links_file
 from skrobot.urdf.modularize_urdf import find_root_link
 from skrobot.urdf.modularize_urdf import transform_urdf_to_macro
 from skrobot.urdf.primitives_converter import convert_meshes_to_primitives
@@ -46,6 +48,8 @@ __all__ = [
     'extract_sub_urdf',
     'flip_joint_axis',
     'flip_joint_axis_file',
+    'merge_fixed_links',
+    'merge_fixed_links_file',
     'scale_urdf',
     'generate_groups_from_geometry',
     'generate_robot_class_from_geometry',

--- a/skrobot/urdf/merge_fixed_links.py
+++ b/skrobot/urdf/merge_fixed_links.py
@@ -1,0 +1,305 @@
+"""Collapse a URDF's fixed joints so each rigid body is one link.
+
+CAD exporters emit one link per part, joined by fixed joints, so a robot that
+moves in six degrees of freedom can arrive as a hundred links.  Simulators pay
+for every one of them and the kinematic tree is unreadable.
+
+:func:`merge_fixed_links` folds each fixed-joint child into its parent: the
+child's visual and collision geometry moves over with its origin pre-composed
+by the joint transform, the two inertials are combined about the merged centre
+of mass, joints hanging off the child are re-parented, and the joint and link
+are removed.  It iterates to a fixpoint, so a chain of fixed joints collapses
+onto the nearest movable (or root) link.
+
+Links carrying no geometry are treated as coordinate frames and kept by
+default: they are usually TF frames -- tool centre points, sensor mounts,
+connector markers -- that something downstream looks up by name.
+"""
+
+from logging import getLogger
+import xml.etree.ElementTree as ET
+
+from skrobot.coordinates.math import matrix2xyzrpy
+from skrobot.utils.inertia import combine_inertials
+from skrobot.utils.inertia import transform_inertial
+from skrobot.utils.urdf import parse_origin
+
+
+logger = getLogger(__name__)
+
+
+__all__ = [
+    'merge_fixed_links',
+    'merge_fixed_links_file',
+]
+
+_INERTIA_KEYS = ('ixx', 'ixy', 'ixz', 'iyy', 'iyz', 'izz')
+
+
+def _fmt(value):
+    """Format a number for a URDF attribute, folding ``-0.0`` to ``0``."""
+    value = float(value)
+    return '0' if value == 0.0 else '{:.10g}'.format(value)
+
+
+def _set_origin(element, matrix):
+    """Write ``element``'s ``<origin>`` child from a 4x4 matrix."""
+    xyz, rpy = matrix2xyzrpy(matrix)
+    origin = element.find('origin')
+    if origin is None:
+        origin = ET.SubElement(element, 'origin')
+    origin.set('xyz', ' '.join(_fmt(v) for v in xyz))
+    origin.set('rpy', ' '.join(_fmt(v) for v in rpy))
+
+
+def _has_geometry(link):
+    """Whether a link carries geometry, as opposed to being a bare frame."""
+    return link.find('visual') is not None or link.find('collision') is not None
+
+
+def _vector(element, attribute):
+    """A 3-vector attribute, defaulting to zeros when absent or empty."""
+    raw = (element.get(attribute) if element is not None else None) or '0 0 0'
+    return [float(v) for v in raw.split()]
+
+
+def _read_inertial(link):
+    """A link's ``<inertial>`` as an inertial dict in the LINK frame.
+
+    None when the block is missing or its mass is not positive.  The inertial
+    ``<origin>`` is applied here, so the tensor comes back in link axes about
+    the centre of mass -- what :func:`~skrobot.utils.inertia.combine_inertials`
+    expects.
+    """
+    inertial = link.find('inertial')
+    if inertial is None:
+        return None
+    tensor = inertial.find('inertia')
+    if tensor is None:
+        return None
+    mass_element = inertial.find('mass')
+    mass = float(mass_element.get('value', '0')) \
+        if mass_element is not None else 0.0
+    components = tuple(float(tensor.get(k, '0')) for k in _INERTIA_KEYS)
+    origin = inertial.find('origin')
+    return transform_inertial(mass, [0.0, 0.0, 0.0], components,
+                              _vector(origin, 'xyz'), _vector(origin, 'rpy'))
+
+
+def _write_inertial(link, info):
+    """Replace ``link``'s ``<inertial>`` with ``info``.
+
+    Written with ``rpy="0 0 0"``: the tensor is already in link axes about
+    ``com``, so the origin only has to carry the centre of mass.
+    """
+    old = link.find('inertial')
+    if old is not None:
+        link.remove(old)
+    inertial = ET.SubElement(link, 'inertial')
+    origin = ET.SubElement(inertial, 'origin')
+    origin.set('xyz', ' '.join(_fmt(v) for v in info['com']))
+    origin.set('rpy', '0 0 0')
+    ET.SubElement(inertial, 'mass').set('value', _fmt(info['mass']))
+    tensor = ET.SubElement(inertial, 'inertia')
+    for key, value in zip(_INERTIA_KEYS, info['inertia']):
+        tensor.set(key, _fmt(value))
+
+
+def _merge_inertials(parent, child, transform):
+    """Lump the child's inertial into the parent's.
+
+    ``transform`` is the 4x4 parent-from-child transform.  No-op when the child
+    has no usable inertial; seeds the parent when the parent had none.
+    """
+    info = _read_inertial(child)
+    if info is None:
+        return
+    xyz, rpy = matrix2xyzrpy(transform)
+    info = transform_inertial(info['mass'], info['com'], info['inertia'],
+                              xyz, rpy)
+    combined = combine_inertials(_read_inertial(parent), info)
+    if combined is not None:
+        _write_inertial(parent, combined)
+
+
+def merge_fixed_links(root, keep_frames=True, force_merge=None, only=None):
+    """Collapse fixed joints so each rigid body is a single link, in place.
+
+    Iterates to a fixpoint, so a chain of fixed joints collapses onto the
+    nearest movable or root link.  Movable joints, and the frames they are
+    expressed in, are preserved exactly: every merge pre-composes the fixed
+    transform into the origins it moves.
+
+    Parameters
+    ----------
+    root : xml.etree.ElementTree.Element
+        The ``<robot>`` element, modified in place.
+    keep_frames : bool
+        Keep links that carry no geometry of their own, which are usually TF
+        frames something downstream looks up by name.  They are then neither
+        merged away nor used as a merge target -- a frame that absorbed
+        geometry could be lumped onward itself, silently dropping the frame.
+        Set False to collapse them too.
+    force_merge : iterable of str or None
+        Child links to merge even though they carry no geometry, so that a
+        mass-only link's ``<inertial>`` still reaches its parent.  Such a child
+        may fold into a frame parent even under ``keep_frames``, since it adds
+        only mass, never geometry, and the parent stays a frame.
+    only : iterable of str or None
+        Restrict merging to these child links, leaving every other fixed child
+        in place.  Implies ``force_merge`` for the same names when
+        ``force_merge`` is not given, so a mass-only link folds without also
+        collapsing the rest of the fixed structure.
+
+    Returns
+    -------
+    merged : int
+        How many links were folded away.
+
+    Examples
+    --------
+    >>> import xml.etree.ElementTree as ET
+    >>> from skrobot.urdf import merge_fixed_links
+    >>> root = ET.fromstring('''<robot name="r">
+    ...   <link name="base">
+    ...     <visual><geometry><box size="1 1 1"/></geometry></visual>
+    ...   </link>
+    ...   <link name="bolt">
+    ...     <visual><geometry><box size="0.1 0.1 0.1"/></geometry></visual>
+    ...   </link>
+    ...   <joint name="j" type="fixed">
+    ...     <origin xyz="1 0 0"/>
+    ...     <parent link="base"/><child link="bolt"/>
+    ...   </joint>
+    ... </robot>''')
+    >>> merge_fixed_links(root)
+    1
+    >>> [link.get('name') for link in root.findall('link')]
+    ['base']
+    >>> root.find('link').findall('visual')[1].find('origin').get('xyz')
+    '1 0 0'
+    """
+    if only is not None and not force_merge:
+        # naming a child in `only` is the request to fold it; an explicitly
+        # empty force_merge should not quietly cancel that
+        force_merge = only
+    force_merge = set(force_merge or ())
+    only = None if only is None else set(only)
+
+    # a link reached by more than one joint cannot be folded: merging it into
+    # one parent would leave the other joint pointing at a link that is gone
+    incoming = {}
+    for joint in root.findall('joint'):
+        child_ref = joint.find('child')
+        if child_ref is not None:
+            name = child_ref.get('link')
+            incoming[name] = incoming.get(name, 0) + 1
+    multi_parent = {name for name, count in incoming.items() if count > 1}
+    # snapshot before merging: a link that receives geometry mid-run must not
+    # then count as a frame, nor stop being one
+    frames = set()
+    if keep_frames:
+        frames = {link.get('name') for link in root.findall('link')
+                  if not _has_geometry(link)} - force_merge
+
+    merged = 0
+    while True:
+        links = {link.get('name'): link for link in root.findall('link')}
+        joints = root.findall('joint')
+        target = None
+        for joint in joints:
+            if joint.get('type') != 'fixed':
+                continue
+            parent_ref, child_ref = joint.find('parent'), joint.find('child')
+            if parent_ref is None or child_ref is None:
+                continue
+            parent_name = parent_ref.get('link')
+            child_name = child_ref.get('link')
+            if parent_name == child_name:
+                # a self-loop is not a joint between two bodies; folding it
+                # would delete the one link it names
+                logger.warning('joint %s has %s as both parent and child; '
+                               'skipping it', joint.get('name'), child_name)
+                continue
+            if child_name in multi_parent:
+                logger.warning('link %s is the child of more than one joint; '
+                               'skipping it', child_name)
+                continue
+            if only is not None and child_name not in only:
+                continue
+            parent = links.get(parent_name)
+            child = links.get(child_name)
+            if parent is None or child is None:
+                continue
+            # geometry is what makes a child mergeable while frames are being
+            # kept, unless it was named in force_merge to carry its mass over
+            if keep_frames and not (_has_geometry(child)
+                                    or child_name in force_merge):
+                continue
+            if child_name in frames:
+                continue
+            if parent_name in frames and not (child_name in force_merge
+                                              and not _has_geometry(child)):
+                continue
+            target = (joint, parent, child, parent_name, child_name)
+            break
+        if target is None:
+            return merged
+        joint, parent, child, parent_name, child_name = target
+        transform = parse_origin(joint)
+
+        for geometry in list(child):
+            if geometry.tag not in ('visual', 'collision'):
+                continue
+            _set_origin(geometry, transform.dot(parse_origin(geometry)))
+            child.remove(geometry)
+            parent.append(geometry)
+
+        _merge_inertials(parent, child, transform)
+
+        for other in joints:
+            other_parent = other.find('parent')
+            if other_parent is not None \
+                    and other_parent.get('link') == child_name:
+                other_parent.set('link', parent_name)
+                _set_origin(other, transform.dot(parse_origin(other)))
+
+        root.remove(joint)
+        root.remove(child)
+        merged += 1
+
+
+def merge_fixed_links_file(input_path, output_path=None, keep_frames=True,
+                           force_merge=None, only=None):
+    """Apply :func:`merge_fixed_links` to a URDF file.
+
+    Comments survive the round trip, so per-link provenance written by an
+    exporter is not lost.
+
+    Parameters
+    ----------
+    input_path : str
+        URDF to read.
+    output_path : str or None
+        Where to write.  Defaults to ``input_path``, editing it in place.
+    keep_frames, force_merge, only
+        Forwarded to :func:`merge_fixed_links`.
+
+    Returns
+    -------
+    merged : int
+        How many links were folded away.
+    """
+    parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
+    with open(input_path, encoding='utf-8') as f:
+        root = ET.fromstring(f.read(), parser=parser)
+    merged = merge_fixed_links(root, keep_frames=keep_frames,
+                               force_merge=force_merge, only=only)
+    text = ET.tostring(root, encoding='unicode')
+    if not text.startswith('<?xml'):
+        text = '<?xml version="1.0"?>\n' + text
+    if not text.endswith('\n'):
+        text += '\n'
+    with open(output_path or input_path, 'w', encoding='utf-8') as f:
+        f.write(text)
+    return merged

--- a/tests/skrobot_tests/urdf_tests/test_merge_fixed_links.py
+++ b/tests/skrobot_tests/urdf_tests/test_merge_fixed_links.py
@@ -1,0 +1,283 @@
+import os
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+from skrobot.urdf import merge_fixed_links
+from skrobot.urdf import merge_fixed_links_file
+
+
+_URDF = """<?xml version="1.0"?>
+<robot name="t">
+  <link name="base">
+    <visual><origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry><box size="1 1 1"/></geometry></visual>
+    <inertial><origin xyz="0 0 0" rpy="0 0 0"/><mass value="2"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/></inertial>
+  </link>
+  <joint name="fix_c" type="fixed">
+    <origin xyz="1 0 0" rpy="0 0 0"/>
+    <parent link="base"/><child link="c"/>
+  </joint>
+  <link name="c">
+    <visual><origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry><box size="0.5 0.5 0.5"/></geometry></visual>
+    <inertial><origin xyz="0 0 0" rpy="0 0 0"/><mass value="3"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="2" iyz="0" izz="2"/></inertial>
+  </link>
+  <joint name="mov" type="revolute">
+    <origin xyz="0 1 0" rpy="0 0 0"/>
+    <parent link="c"/><child link="g"/>
+    <axis xyz="0 0 1"/><limit lower="-1" upper="1" effort="1" velocity="1"/>
+  </joint>
+  <link name="g"><visual><geometry><box size="0.2 0.2 0.2"/></geometry></visual></link>
+  <joint name="fix_frame" type="fixed">
+    <origin xyz="0 0 1" rpy="0 0 0"/>
+    <parent link="base"/><child link="frame"/>
+  </joint>
+  <link name="frame"/>
+</robot>"""
+
+
+def _names(root, tag):
+    return [e.get('name') for e in root.findall(tag)]
+
+
+def _floats(text):
+    return [float(v) for v in text.split()]
+
+
+class TestMergeFixedLinks(unittest.TestCase):
+
+    def test_geometry_moves_with_a_composed_origin(self):
+        root = ET.fromstring(_URDF)
+        self.assertEqual(merge_fixed_links(root), 1)
+        self.assertEqual(_names(root, 'link'), ['base', 'g', 'frame'])
+        base = root.find('link')
+        visuals = base.findall('visual')
+        self.assertEqual(len(visuals), 2)
+        # the merged child's visual carries the fixed joint's translation
+        self.assertEqual(_floats(visuals[1].find('origin').get('xyz')),
+                         [1.0, 0.0, 0.0])
+
+    def test_movable_joint_is_reparented_and_its_frame_preserved(self):
+        root = ET.fromstring(_URDF)
+        merge_fixed_links(root)
+        mov = next(j for j in root.findall('joint') if j.get('name') == 'mov')
+        self.assertEqual(mov.find('parent').get('link'), 'base')
+        # 'mov' hung 1 m along +y off c, which sat 1 m along +x off base
+        self.assertEqual(_floats(mov.find('origin').get('xyz')),
+                         [1.0, 1.0, 0.0])
+
+    def test_inertials_combine_about_the_merged_centre_of_mass(self):
+        root = ET.fromstring(_URDF)
+        merge_fixed_links(root)
+        inertial = root.find('link').find('inertial')
+        self.assertAlmostEqual(
+            float(inertial.find('mass').get('value')), 5.0)
+        # 2 kg at the origin and 3 kg at x=1 balance at x=0.6
+        self.assertAlmostEqual(
+            _floats(inertial.find('origin').get('xyz'))[0], 0.6)
+        tensor = inertial.find('inertia')
+        # parallel axis about x is unchanged; y and z each gain m*d^2
+        self.assertAlmostEqual(float(tensor.get('ixx')), 3.0)
+        self.assertAlmostEqual(float(tensor.get('iyy')),
+                               1 + 2 * 0.36 + 2 + 3 * 0.16)
+
+    def test_geometryless_frames_are_kept_by_default(self):
+        root = ET.fromstring(_URDF)
+        merge_fixed_links(root)
+        self.assertIn('frame', _names(root, 'link'))
+        self.assertIn('fix_frame', _names(root, 'joint'))
+
+    def test_keep_frames_false_collapses_them(self):
+        root = ET.fromstring(_URDF)
+        merged = merge_fixed_links(root, keep_frames=False)
+        self.assertEqual(merged, 2)
+        self.assertNotIn('frame', _names(root, 'link'))
+
+    def test_a_chain_of_fixed_joints_collapses_to_a_fixpoint(self):
+        root = ET.fromstring("""<robot name="chain">
+          <link name="a"><visual><geometry><box size="1 1 1"/></geometry></visual></link>
+          <link name="b"><visual><geometry><box size="1 1 1"/></geometry></visual></link>
+          <link name="c"><visual><geometry><box size="1 1 1"/></geometry></visual></link>
+          <joint name="j1" type="fixed"><origin xyz="1 0 0"/>
+            <parent link="a"/><child link="b"/></joint>
+          <joint name="j2" type="fixed"><origin xyz="0 2 0"/>
+            <parent link="b"/><child link="c"/></joint>
+        </robot>""")
+        self.assertEqual(merge_fixed_links(root), 2)
+        self.assertEqual(_names(root, 'link'), ['a'])
+        # c's geometry ends up at the composition of both joint origins
+        origins = [_floats(v.find('origin').get('xyz'))
+                   for v in root.find('link').findall('visual')[1:]]
+        self.assertIn([1.0, 0.0, 0.0], origins)
+        self.assertIn([1.0, 2.0, 0.0], origins)
+
+    def test_rotation_is_applied_to_the_child_tensor(self):
+        """A yaw of 90 degrees swaps the child's ixx and iyy before they are
+        combined, so a dropped or transposed rotation is visible."""
+        root = ET.fromstring("""<robot name="rot">
+          <link name="base"><visual><geometry><box size="1 1 1"/></geometry></visual>
+            <inertial><origin xyz="0 0 0" rpy="0 0 0"/><mass value="2"/>
+              <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/></inertial></link>
+          <link name="pcb"><visual><geometry><box size="1 1 1"/></geometry></visual>
+            <inertial><origin xyz="0 0 0" rpy="0 0 0"/><mass value="3"/>
+              <inertia ixx="2" ixy="0" ixz="0" iyy="5" iyz="0" izz="7"/></inertial></link>
+          <joint name="j" type="fixed"><origin xyz="1 0 0" rpy="0 0 1.5707963267948966"/>
+            <parent link="base"/><child link="pcb"/></joint>
+        </robot>""")
+        merge_fixed_links(root)
+        tensor = root.find('link').find('inertial').find('inertia')
+        # Rz(90) maps diag(2,5,7) to diag(5,2,7); then parallel axis about x=0.6
+        self.assertAlmostEqual(float(tensor.get('ixx')), 6.0, places=6)
+        self.assertAlmostEqual(float(tensor.get('iyy')), 4.2, places=6)
+        self.assertAlmostEqual(float(tensor.get('izz')), 9.2, places=6)
+
+    def test_force_merge_folds_a_massonly_link(self):
+        root = ET.fromstring("""<robot name="m">
+          <link name="base"><visual><geometry><box size="1 1 1"/></geometry></visual>
+            <inertial><origin xyz="0 0 0"/><mass value="1"/>
+              <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/></inertial></link>
+          <link name="weight">
+            <inertial><origin xyz="0 0 0"/><mass value="4"/>
+              <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/></inertial></link>
+          <joint name="j" type="fixed"><origin xyz="0 0 0"/>
+            <parent link="base"/><child link="weight"/></joint>
+        </robot>""")
+        # without force_merge it is a frame and stays
+        untouched = ET.fromstring(ET.tostring(root))
+        self.assertEqual(merge_fixed_links(untouched), 0)
+        self.assertEqual(merge_fixed_links(root, force_merge={'weight'}), 1)
+        self.assertAlmostEqual(
+            float(root.find('link').find('inertial').find('mass').get('value')),
+            5.0)
+
+    def test_only_restricts_folding_to_the_named_child(self):
+        root = ET.fromstring(_URDF)
+        self.assertEqual(merge_fixed_links(root, only={'nothing'}), 0)
+        self.assertEqual(_names(root, 'link'), ['base', 'c', 'g', 'frame'])
+
+    def test_a_link_without_inertial_is_handled(self):
+        root = ET.fromstring("""<robot name="n">
+          <link name="a"><visual><geometry><box size="1 1 1"/></geometry></visual></link>
+          <link name="b"><visual><geometry><box size="1 1 1"/></geometry></visual></link>
+          <joint name="j" type="fixed"><origin xyz="1 0 0"/>
+            <parent link="a"/><child link="b"/></joint>
+        </robot>""")
+        self.assertEqual(merge_fixed_links(root), 1)
+        self.assertIsNone(root.find('link').find('inertial'))
+
+    def test_world_poses_are_unchanged(self):
+        """The point of the transform: every link that survives keeps the pose
+        it had, so nothing downstream moves."""
+        def poses(robot):
+            placement = {}
+            edges = [(j.find('parent').get('link'), j.find('child').get('link'),
+                      parse(j)) for j in robot.findall('joint')]
+            names = [ln.get('name') for ln in robot.findall('link')]
+            for name in names:
+                matrix, current = np.eye(4), name
+                while True:
+                    step = next((e for e in edges if e[1] == current), None)
+                    if step is None:
+                        break
+                    matrix, current = step[2].dot(matrix), step[0]
+                placement[name] = matrix
+            return placement
+
+        from skrobot.utils.urdf import parse_origin as parse
+        root = ET.fromstring(_URDF)
+        before = poses(ET.fromstring(_URDF))
+        merge_fixed_links(root)
+        after = poses(root)
+        for name, matrix in after.items():
+            np.testing.assert_allclose(matrix, before[name], atol=1e-12,
+                                       err_msg=name)
+
+
+class TestMalformedTopology(unittest.TestCase):
+    """A merge that would leave the tree inconsistent must not happen."""
+
+    def test_a_self_loop_does_not_delete_its_link(self):
+        root = ET.fromstring("""<robot name="r">
+          <link name="a"><visual><geometry><box size="1 1 1"/></geometry>
+            </visual></link>
+          <joint name="loop" type="fixed"><origin xyz="1 1 1"/>
+            <parent link="a"/><child link="a"/></joint>
+        </robot>""")
+        self.assertEqual(merge_fixed_links(root), 0)
+        self.assertEqual(_names(root, 'link'), ['a'])
+
+    def test_a_link_with_two_parents_is_left_alone(self):
+        """Folding it into one parent would leave the other joint pointing
+        at a link that no longer exists."""
+        root = ET.fromstring("""<robot name="r">
+          <link name="a"><visual><geometry><box size="1 1 1"/></geometry>
+            </visual></link>
+          <link name="b"><visual><geometry><box size="1 1 1"/></geometry>
+            </visual></link>
+          <link name="c"><visual><geometry><box size="1 1 1"/></geometry>
+            </visual></link>
+          <joint name="j1" type="fixed"><origin xyz="1 0 0"/>
+            <parent link="a"/><child link="c"/></joint>
+          <joint name="j2" type="fixed"><origin xyz="0 9 0"/>
+            <parent link="b"/><child link="c"/></joint>
+        </robot>""")
+        self.assertEqual(merge_fixed_links(root), 0)
+        self.assertEqual(_names(root, 'link'), ['a', 'b', 'c'])
+        children = {j.find('child').get('link')
+                    for j in root.findall('joint')}
+        self.assertTrue(children <= set(_names(root, 'link')))
+
+    def test_only_still_folds_with_an_empty_force_merge(self):
+        """Naming a child in ``only`` is the request to fold it; passing an
+        empty ``force_merge`` (a common default) must not cancel that."""
+        urdf = """<robot name="m">
+          <link name="base"><visual><geometry><box size="1 1 1"/></geometry>
+            </visual></link>
+          <link name="weight"><inertial><origin xyz="0 0 0"/>
+            <mass value="4"/>
+            <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+            </inertial></link>
+          <joint name="j" type="fixed"><origin xyz="0 0 0"/>
+            <parent link="base"/><child link="weight"/></joint>
+        </robot>"""
+        root = ET.fromstring(urdf)
+        self.assertEqual(merge_fixed_links(root, only={'weight'},
+                                           force_merge=[]), 1)
+        self.assertEqual(_names(root, 'link'), ['base'])
+
+
+class TestMergeFixedLinksFile(unittest.TestCase):
+
+    def test_round_trip_keeps_comments(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'r.urdf')
+            with open(path, 'w') as f:
+                f.write(_URDF.replace('<link name="base">',
+                                      '<!-- provenance --><link name="base">'))
+            self.assertEqual(merge_fixed_links_file(path), 1)
+            with open(path) as f:
+                text = f.read()
+            self.assertIn('<!-- provenance -->', text)
+            self.assertTrue(text.startswith('<?xml'))
+
+    def test_writes_to_a_separate_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, 'in.urdf')
+            dst = os.path.join(tmp, 'out.urdf')
+            with open(src, 'w') as f:
+                f.write(_URDF)
+            merge_fixed_links_file(src, dst)
+            with open(src) as f:
+                self.assertIn('name="c"', f.read())
+            self.assertEqual(
+                _names(ET.parse(dst).getroot(), 'link'),
+                ['base', 'g', 'frame'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A CAD exporter emits one link per part joined by fixed joints, so a robot that moves in six degrees of freedom can arrive as a hundred links. Simulators pay for every one of them and the kinematic tree is unreadable.

merge_fixed_links folds each fixed-joint child into its parent: the child's visual and collision geometry moves over with its origin pre-composed by the joint transform, the two inertials are combined about the merged centre of mass, joints hanging off the child are re-parented, and it iterates to a fixpoint so a chain collapses onto the nearest movable link.  Every merge pre-composes the fixed transform into the origins it moves, so world poses are preserved exactly.

Links carrying no geometry are kept by default: they are usually TF frames that something downstream looks up by name.  keep_frames=False collapses them too, force_merge folds a named mass-only link so its weight still reaches the parent, and only= restricts merging to named children.

A merge that would leave the tree inconsistent is skipped with a warning rather than performed: a self-loop names one link as both parent and child, so folding it would delete the only link it names, and a link reached by two joints would leave the second pointing at a link that is gone.