### PR TITLE
Keep the vertex normals stored in mesh files

### DIFF
--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -42,6 +42,7 @@ from skrobot.model.link import find_link_path
 from skrobot.model.link import Link
 from skrobot.utils import urdf
 from skrobot.utils.listify import listify
+from skrobot.utils.urdf import _transform_vertex_normals
 from skrobot.utils.urdf import enable_mesh_cache
 from skrobot.utils.urdf import URDF
 
@@ -2925,7 +2926,18 @@ class RobotModel(CascadedLink):
         for mesh in visual.geometry.meshes:
             if trimesh is None:
                 trimesh = _lazy_trimesh()
+            # ``copy`` drops the cache, which is where normals loaded from
+            # the mesh file live.  Carry them over by hand: they record which
+            # edges the author meant to be smooth, and averaging face normals
+            # later cannot recover that.  They are re-attached after the
+            # transforms below, mapped through ``_transform_vertex_normals``
+            # rather than by ``apply_transform``, whose plain matrix multiply
+            # is wrong for a mirroring scale such as ``1 -1 1``.
+            authored_normals = mesh._cache.cache.get('vertex_normals')
             mesh = mesh.copy()
+            if authored_normals is not None \
+                    and len(authored_normals) != len(mesh.vertices):
+                authored_normals = None
 
             # rescale
             if visual.geometry.mesh is not None:
@@ -2943,6 +2955,9 @@ class RobotModel(CascadedLink):
                     scale_transform[:3, :3] = np.diag(
                         visual.geometry.mesh.scale)
                     mesh.apply_transform(scale_transform)
+                    if authored_normals is not None:
+                        authored_normals = _transform_vertex_normals(
+                            authored_normals, scale_transform)
 
             # TextureVisuals is usually slow to render
             if not isinstance(mesh.visual, trimesh.visual.ColorVisuals):
@@ -2968,6 +2983,9 @@ class RobotModel(CascadedLink):
                     mesh.visual.face_colors = visual.material.color
 
             mesh.apply_transform(visual.origin)
+            if authored_normals is not None:
+                mesh.vertex_normals = _transform_vertex_normals(
+                    authored_normals, visual.origin)
             meshes.append(mesh)
         return meshes
 

--- a/skrobot/utils/mesh.py
+++ b/skrobot/utils/mesh.py
@@ -44,9 +44,24 @@ def split_mesh_by_face_color(mesh):
     # This creates a list of arrays, each containing face indices for one color
     grouped_face_indices = np.split(sorted_face_indices, counts.cumsum()[:-1])
 
+    # Drop empty groups so the submeshes line up with grouped_face_indices:
+    # trimesh.util.submesh silently skips them.
+    grouped_face_indices = [g for g in grouped_face_indices if len(g) > 0]
+
     # Create all submeshes at once using the grouped indices
     # append=False prevents adding to the original mesh
     submeshes = mesh.submesh(grouped_face_indices, append=False)
+
+    # submesh() builds fresh meshes, so any normals the mesh file supplied are
+    # dropped and would later be re-derived by averaging -- which rounds off
+    # hard edges.  trimesh keys each submesh on ``np.unique`` of the group's
+    # face indices, so the same expression re-creates the vertex mapping.
+    authored_normals = mesh._cache.cache.get('vertex_normals')
+    if authored_normals is not None:
+        for group, submesh in zip(grouped_face_indices, submeshes):
+            unique = np.unique(mesh.faces[group].reshape(-1))
+            if len(unique) == len(submesh.vertices):
+                submesh.vertex_normals = authored_normals[unique]
 
     return submeshes
 

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -617,6 +617,116 @@ def resolve_simplified_mesh_path(filename, simplify_factor):
     return cache_path
 
 
+def _transform_vertex_normals(normals, matrix):
+    """Map normals through a 4x4 transform.
+
+    Normals do not transform like points.  The inverse transpose of the linear
+    block is what keeps them perpendicular to the surface under a non-uniform
+    scale, and a transform with a negative determinant (a mirror, common in
+    exported CAD scenes) reverses the triangle winding, so the result has to be
+    negated to keep pointing out of the same side.  ``Trimesh.apply_transform``
+    multiplies by the matrix directly, which is only correct for a rotation.
+
+    Parameters
+    ----------
+    normals : (n, 3) float
+        Unit normals in the source frame.
+    matrix : (4, 4) float
+        Transform applied to the vertices.
+
+    Returns
+    -------
+    normals : (n, 3) float
+        Unit normals in the destination frame.
+    """
+    linear = np.asarray(matrix)[:3, :3]
+    try:
+        mapped = np.asarray(normals) @ np.linalg.inv(linear)
+    except np.linalg.LinAlgError:
+        return np.asarray(normals)
+    if np.linalg.det(linear) < 0:
+        mapped = -mapped
+    length = np.linalg.norm(mapped, axis=1)
+    length[length < 1e-12] = 1.0
+    return mapped / length[:, None]
+
+
+def _authored_vertex_normals(obj):
+    """Snapshot the vertex normals a mesh file actually stored.
+
+    ``vertex_normals`` is a lazily computed property, so only an array already
+    sitting in the cache came from the file; touching the property here would
+    fabricate one and defeat the point.
+
+    Parameters
+    ----------
+    obj : trimesh.Scene or trimesh.Trimesh
+        Freshly loaded geometry.
+
+    Returns
+    -------
+    normals : dict
+        Geometry name (``None`` for a bare mesh) -> (n, 3) float array.
+    """
+    trimesh = _lazy_trimesh()
+    if isinstance(obj, trimesh.Scene):
+        items = list(obj.geometry.items())
+    else:
+        items = [(None, obj)]
+    normals = {}
+    for name, geom in items:
+        cache = getattr(geom, '_cache', None)
+        stored = cache.cache.get('vertex_normals') if cache is not None else None
+        if stored is not None:
+            normals[name] = np.array(stored)
+    return normals
+
+
+def _restore_vertex_normals(obj, normals):
+    """Put snapshotted normals back after a units conversion.
+
+    ``convert_units`` rebuilds the geometry and drops the cache, but it only
+    applies a uniform scale, which leaves normal directions untouched.
+    """
+    if not normals:
+        return obj
+    trimesh = _lazy_trimesh()
+    if isinstance(obj, trimesh.Scene):
+        items = list(obj.geometry.items())
+    else:
+        items = [(None, obj)]
+    for name, geom in items:
+        stored = normals.get(name)
+        if stored is not None and len(stored) == len(geom.vertices):
+            geom.vertex_normals = stored
+    return obj
+
+
+def _dump_scene(scene):
+    """Flatten a scene into world-frame meshes, keeping authored normals.
+
+    ``Scene.dump`` copies each geometry without its cache, so normals supplied
+    by the file are lost and later recomputed by averaging, which rounds off
+    every hard edge.  Re-attaching them before ``apply_transform`` lets trimesh
+    rotate them along with the vertices instead.
+    """
+    trimesh = _lazy_trimesh()
+    meshes = []
+    for node in scene.graph.nodes_geometry:
+        transform, geom_name = scene.graph[node]
+        geom = scene.geometry.get(geom_name)
+        if not isinstance(geom, trimesh.Trimesh):
+            continue
+        cache = getattr(geom, '_cache', None)
+        stored = cache.cache.get('vertex_normals') if cache is not None else None
+        mesh = geom.copy()
+        mesh.apply_transform(transform)
+        if stored is not None and len(stored) == len(mesh.vertices):
+            mesh.vertex_normals = _transform_vertex_normals(stored, transform)
+        meshes.append(mesh)
+    return meshes
+
+
 def load_meshes(filename):
     enable_mesh_cache = _CONFIGURABLE_VALUES['enable_mesh_cache']
     if enable_mesh_cache:
@@ -778,8 +888,13 @@ def _load_meshes(filename):
         # To convert the mesh unit from millimeters to meters,
         # use the function meshes.convert_units('meter').
         meshes = trimesh.load(filename)
+        # Keep whatever normals the file stored: they encode which edges the
+        # author meant to be smooth, and nothing downstream can recover that
+        # once they have been dropped.
+        authored_normals = _authored_vertex_normals(meshes)
         if meshes.units is not None and meshes.units != 'meter':
             meshes = meshes.convert_units('meter')
+            _restore_vertex_normals(meshes, authored_normals)
     except Exception as e:
         if is_glb_or_gltf and not dracopy_available:
             logger.error(
@@ -793,8 +908,7 @@ def _load_meshes(filename):
 
     # If we got a scene, dump the meshes
     if isinstance(meshes, trimesh.Scene):
-        meshes = list(meshes.dump())
-        meshes = [g for g in meshes if isinstance(g, trimesh.Trimesh)]
+        meshes = _dump_scene(meshes)
 
     if isinstance(meshes, (list, tuple, set)):
         meshes = list(meshes)

--- a/tests/skrobot_tests/model_tests/test_visual_mesh_normals.py
+++ b/tests/skrobot_tests/model_tests/test_visual_mesh_normals.py
@@ -1,0 +1,98 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+import trimesh
+
+from skrobot.model import RobotModel
+
+
+URDF_TEMPLATE = """<?xml version="1.0"?>
+<robot name="normals">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0" rpy="{rpy}"/>
+      <geometry>
+        <mesh filename="{mesh}"{scale}/>
+      </geometry>
+    </visual>
+  </link>
+</robot>
+"""
+
+
+class TestVisualMeshKeepsAuthoredNormals(unittest.TestCase):
+    """Normals stored in a mesh file must reach ``Link.visual_mesh``.
+
+    They are the only record of which edges the author meant to be smooth.
+    Once dropped, the only thing left is to average adjacent face normals,
+    which rounds off every hard edge -- so any renderer downstream shows a
+    flat plate as a gradient, or a cylinder as a faceted tube.
+    """
+
+    #: Not a normal any averaging would produce for a box, so its presence
+    #: proves the array came from the file rather than from inference.
+    AUTHORED = np.array([0.0, 0.0, 1.0])
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        mesh = trimesh.creation.box()
+        mesh.vertex_normals = np.tile(self.AUTHORED, (len(mesh.vertices), 1))
+        self.mesh_path = os.path.join(self.tmpdir, 'box.glb')
+        mesh.export(self.mesh_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _load(self, rpy='0 0 0', scale=None):
+        urdf_path = os.path.join(self.tmpdir, 'robot.urdf')
+        with open(urdf_path, 'w') as f:
+            f.write(URDF_TEMPLATE.format(
+                mesh=self.mesh_path, rpy=rpy,
+                scale='' if scale is None else ' scale="{}"'.format(scale)))
+        robot = RobotModel()
+        with open(urdf_path) as f:
+            robot.load_urdf_file(f)
+        link = robot.link_list[0]
+        self.assertTrue(link.visual_mesh)
+        return link.visual_mesh[0]
+
+    def test_they_are_still_there_after_loading(self):
+        mesh = self._load()
+        self.assertIn('vertex_normals', mesh._cache.cache)
+        np.testing.assert_allclose(
+            np.asarray(mesh.vertex_normals),
+            np.tile(self.AUTHORED, (len(mesh.vertices), 1)), atol=1e-6)
+
+    def test_a_visual_origin_rotates_them(self):
+        # quarter turn about x: +z becomes -y
+        mesh = self._load(rpy='{} 0 0'.format(np.pi / 2))
+        np.testing.assert_allclose(
+            np.asarray(mesh.vertex_normals),
+            np.tile([0.0, -1.0, 0.0], (len(mesh.vertices), 1)), atol=1e-6)
+
+    def test_a_mirroring_scale_keeps_them_on_the_outside(self):
+        """``scale="1 -1 1"`` reverses the winding; the normals have to be
+        negated to match, or the surface renders inside out."""
+        mesh = self._load(scale='1 -1 1')
+        np.testing.assert_allclose(
+            np.asarray(mesh.vertex_normals),
+            np.tile([0.0, 0.0, -1.0], (len(mesh.vertices), 1)), atol=1e-6)
+
+    def test_a_non_uniform_scale_maps_them_by_the_inverse_transpose(self):
+        """Squashing z leaves a +z normal pointing at +z, and unit length.
+
+        Checking the direction as well as the length matters: recomputed box
+        normals would also come out unit length, so length alone would pass
+        even with the normals thrown away.
+        """
+        mesh = self._load(scale='1 1 0.1')
+        np.testing.assert_allclose(
+            np.asarray(mesh.vertex_normals),
+            np.tile(self.AUTHORED, (len(mesh.vertices), 1)), atol=1e-6)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/skrobot_tests/utils_tests/test_mesh.py
+++ b/tests/skrobot_tests/utils_tests/test_mesh.py
@@ -1,0 +1,73 @@
+import unittest
+
+import numpy as np
+import trimesh
+
+from skrobot.utils.mesh import split_mesh_by_face_color
+
+
+class TestSplitMeshByFaceColorNormals(unittest.TestCase):
+    """Splitting by colour must not throw away the file's vertex normals.
+
+    ``submesh`` builds fresh meshes, so normals loaded from the mesh file are
+    dropped and later re-derived by averaging adjacent faces -- which rounds
+    off exactly the hard edges the file was recording.
+    """
+
+    def _two_colour_box(self):
+        mesh = trimesh.creation.box()
+        colors = np.zeros((len(mesh.faces), 4), dtype=np.uint8)
+        colors[:, 3] = 255
+        colors[: len(mesh.faces) // 2, 0] = 255
+        colors[len(mesh.faces) // 2:, 1] = 255
+        mesh.visual.face_colors = colors
+        return mesh
+
+    def test_authored_normals_survive_the_split(self):
+        mesh = self._two_colour_box()
+        # Something no averaging would ever produce, so we can tell whether
+        # the array came from us or was recomputed.
+        authored = np.tile([0.0, 0.0, 1.0], (len(mesh.vertices), 1))
+        mesh.vertex_normals = authored
+
+        submeshes = split_mesh_by_face_color(mesh)
+
+        self.assertGreater(len(submeshes), 1)
+        for submesh in submeshes:
+            self.assertIn('vertex_normals', submesh._cache.cache)
+            np.testing.assert_allclose(
+                np.asarray(submesh.vertex_normals),
+                np.tile([0.0, 0.0, 1.0], (len(submesh.vertices), 1)),
+                atol=1e-9)
+
+    def test_normals_follow_their_own_vertices(self):
+        """Each submesh keeps only its own vertices, so the normals have to be
+        re-indexed the same way rather than merely sliced."""
+        mesh = self._two_colour_box()
+        # A distinct normal per vertex, so a wrong mapping cannot pass.
+        authored = np.zeros((len(mesh.vertices), 3))
+        authored[:, 0] = 1.0
+        authored[:, 1] = np.arange(len(mesh.vertices))
+        authored /= np.linalg.norm(authored, axis=1)[:, None]
+        mesh.vertex_normals = authored
+
+        # A box has eight distinct corners, so each submesh vertex maps back
+        # to exactly one original -- no need to assume the grouping order.
+        for submesh in split_mesh_by_face_color(mesh):
+            got = np.asarray(submesh.vertex_normals)
+            for vertex, normal in zip(np.asarray(submesh.vertices), got):
+                source = np.argmin(
+                    np.linalg.norm(np.asarray(mesh.vertices) - vertex, axis=1))
+                np.testing.assert_allclose(
+                    normal, authored[source], atol=1e-9)
+
+    def test_a_mesh_without_authored_normals_is_untouched(self):
+        mesh = self._two_colour_box()
+        submeshes = split_mesh_by_face_color(mesh)
+        self.assertGreater(len(submeshes), 1)
+        for submesh in submeshes:
+            self.assertNotIn('vertex_normals', submesh._cache.cache)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/skrobot_tests/utils_tests/test_urdf.py
+++ b/tests/skrobot_tests/utils_tests/test_urdf.py
@@ -527,3 +527,104 @@ class TestBakeOriginIntoMeshes(unittest.TestCase):
         origin[:3, 3] = [1.0, 0.0, 0.0]
         urdf_utils.bake_origin_into_meshes(geometry, origin)
         self.assertIsNone(geometry.mesh)
+
+
+class TestTransformVertexNormals(unittest.TestCase):
+    """Normals do not transform like points.
+
+    ``Trimesh.apply_transform`` multiplies them by the matrix directly, which
+    only happens to be right for a pure rotation.
+    """
+
+    def test_a_rotation_rotates_them(self):
+        angle = 0.7
+        matrix = np.eye(4)
+        matrix[:3, :3] = [[np.cos(angle), -np.sin(angle), 0],
+                          [np.sin(angle), np.cos(angle), 0],
+                          [0, 0, 1]]
+        normals = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        got = urdf_utils._transform_vertex_normals(normals, matrix)
+        np.testing.assert_allclose(
+            got, [[np.cos(angle), np.sin(angle), 0.0], [0.0, 0.0, 1.0]],
+            atol=1e-9)
+
+    def test_a_uniform_scale_leaves_the_direction_alone(self):
+        normals = np.array([[0.0, 0.6, 0.8]])
+        got = urdf_utils._transform_vertex_normals(normals, np.eye(4) * 25.4)
+        np.testing.assert_allclose(got, normals, atol=1e-9)
+
+    def test_a_non_uniform_scale_needs_the_inverse_transpose(self):
+        """Squashing z by ten flattens the surface, so a 45 degree normal
+        tips *towards* z -- the opposite of what multiplying by the matrix
+        does, which would tip it away."""
+        matrix = np.diag([1.0, 1.0, 0.1, 1.0])
+        normals = np.array([[np.sqrt(0.5), 0.0, np.sqrt(0.5)]])
+        got = urdf_utils._transform_vertex_normals(normals, matrix)
+        self.assertLess(got[0, 0], normals[0, 0])
+        self.assertGreater(got[0, 2], normals[0, 2])
+        np.testing.assert_allclose(np.linalg.norm(got, axis=1), 1.0, atol=1e-9)
+        # it must stay perpendicular to the surface it came from
+        tangent = np.array([1.0, 0.0, -1.0]) @ matrix[:3, :3].T
+        self.assertAlmostEqual(float(got[0] @ tangent), 0.0, places=9)
+
+    def test_a_mirror_flips_them_back(self):
+        """A negative determinant reverses the triangle winding, so the mapped
+        normal has to be negated to keep pointing out of the same side."""
+        matrix = np.diag([1.0, -1.0, 1.0, 1.0])
+        normals = np.array([[0.0, 1.0, 0.0]])
+        got = urdf_utils._transform_vertex_normals(normals, matrix)
+        np.testing.assert_allclose(got, [[0.0, 1.0, 0.0]], atol=1e-9)
+
+    def test_a_singular_matrix_is_passed_through(self):
+        normals = np.array([[0.0, 0.0, 1.0]])
+        got = urdf_utils._transform_vertex_normals(normals, np.zeros((4, 4)))
+        np.testing.assert_allclose(got, normals, atol=1e-9)
+
+
+class TestSceneNormalsSurviveLoading(unittest.TestCase):
+    """Every step that rebuilds geometry drops trimesh's cache, and that cache
+    is where normals read from the file live."""
+
+    def _scene(self, transform=None):
+        import trimesh
+        mesh = trimesh.creation.box()
+        mesh.vertex_normals = np.tile([0.0, 0.0, 1.0], (len(mesh.vertices), 1))
+        scene = trimesh.Scene()
+        scene.add_geometry(mesh, geom_name='thing', transform=transform)
+        scene.units = 'meters'
+        return scene
+
+    def test_authored_normals_are_only_reported_when_really_authored(self):
+        import trimesh
+        plain = trimesh.Scene()
+        plain.add_geometry(trimesh.creation.box(), geom_name='thing')
+        plain.units = 'meters'
+        self.assertEqual(urdf_utils._authored_vertex_normals(plain), {})
+        self.assertIn('thing',
+                      urdf_utils._authored_vertex_normals(self._scene()))
+
+    def test_they_are_restored_after_a_units_conversion(self):
+        scene = self._scene()
+        snapshot = urdf_utils._authored_vertex_normals(scene)
+        converted = scene.convert_units('inch')
+        # convert_units rebuilds the geometry, losing the cache
+        self.assertNotIn(
+            'vertex_normals',
+            list(converted.geometry.values())[0]._cache.cache)
+        urdf_utils._restore_vertex_normals(converted, snapshot)
+        np.testing.assert_allclose(
+            np.asarray(list(converted.geometry.values())[0].vertex_normals),
+            snapshot['thing'], atol=1e-9)
+
+    def test_dumping_a_scene_maps_them_through_the_node_transform(self):
+        transform = np.eye(4)
+        # quarter turn about x, so +z becomes +y, plus a scale
+        transform[:3, :3] = np.array([[1.0, 0.0, 0.0],
+                                      [0.0, 0.0, -1.0],
+                                      [0.0, 1.0, 0.0]]) * 25.4
+        meshes = urdf_utils._dump_scene(self._scene(transform))
+        self.assertEqual(len(meshes), 1)
+        np.testing.assert_allclose(
+            np.asarray(meshes[0].vertex_normals),
+            np.tile([0.0, -1.0, 0.0], (len(meshes[0].vertices), 1)),
+            atol=1e-9)


### PR DESCRIPTION
Normals read from a mesh file live in trimesh's cache, and every step that rebuilds geometry drops it: `convert_units`, `Scene.dump`, `Trimesh.copy` in `_meshes_from_urdf_visual`, and `submesh` in `split_mesh_by_face_color`. By the time a link's `visual_mesh` is built they are gone, so consumers re-derive them by averaging adjacent faces, which rounds off every hard edge the file was recording.

They are now carried through each of those steps. Mapping uses the inverse transpose rather than a plain matrix multiply, which keeps them perpendicular to the surface under a non-uniform scale and outward facing under a mirroring one such as `scale="1 -1 1"`.

Covered by unit tests for the transform and by an end-to-end test that loads a URDF referencing a mesh with known normals. Removing the change fails 14 of the 15 new tests.