### PR TITLE
Import pysdfgen lazily instead of at module load

### DIFF
--- a/skrobot/_lazy_imports.py
+++ b/skrobot/_lazy_imports.py
@@ -23,6 +23,17 @@ def _lazy_scipy():
     return _scipy
 
 
+_pysdfgen = None
+
+
+def _lazy_pysdfgen():
+    global _pysdfgen
+    if _pysdfgen is None:
+        import pysdfgen
+        _pysdfgen = pysdfgen
+    return _pysdfgen
+
+
 class LazyImportClass(object):
 
     def __init__(self, module_name, class_name, package):

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -6,8 +6,8 @@ import tempfile
 
 import filelock
 import numpy as np
-import pysdfgen
 
+from skrobot._lazy_imports import _lazy_pysdfgen
 from skrobot._lazy_imports import _lazy_scipy
 from skrobot.coordinates import CascadedCoords
 from skrobot.coordinates import Coordinates
@@ -532,8 +532,9 @@ class GridSDF(SignedDistanceFunction):
                     'trying to acquire lock for %s...', sdf_cache_path)
                 logger.info(
                     'pre-computing sdf and making a cache at %s.', sdf_cache_path)
-                pysdfgen.mesh2sdf(str(obj_filepath), dim_grid, padding_grid,
-                                  output_filepath=sdf_cache_path)
+                _lazy_pysdfgen().mesh2sdf(
+                    str(obj_filepath), dim_grid, padding_grid,
+                    output_filepath=sdf_cache_path)
                 logger.info('finish pre-computation')
         return GridSDF.from_file(sdf_cache_path, **kwargs)
 


### PR DESCRIPTION
signed_distance_function.py imported pysdfgen at module scope, so every import of skrobot.model required a native pysdfgen build. Only mesh2sdf uses it, so route that single call through _lazy_pysdfgen().