### PR TITLE
Keep a joint's limits when re-rooting reverses it

### DIFF
--- a/skrobot/urdf/flip_axis.py
+++ b/skrobot/urdf/flip_axis.py
@@ -60,6 +60,31 @@ def _axis_of(joint):
     return values
 
 
+def _negate_joint_axis(root, joint_name):
+    """Negate one joint's ``<axis xyz>`` and nothing else, in place.
+
+    On its own this is only half a reversal -- the joint value's sign changes
+    while the limits and mimic coefficients still describe the old sense -- so
+    it is deliberately private.  The one caller that wants exactly this is
+    :func:`~skrobot.urdf.change_urdf_root_link`, where swapping a joint's
+    ``<parent>`` and ``<child>`` supplies the other half.  Everyone else wants
+    :func:`flip_joint_axis`.
+
+    Returns the ``<joint>`` element, or None when there is no such joint or it
+    has no usable axis.
+    """
+    for joint in root.findall('joint'):
+        if joint.get('name') != joint_name:
+            continue
+        axis_values = _axis_of(joint)
+        if axis_values is None:
+            return None
+        joint.find('axis').set(
+            'xyz', ' '.join(_fmt(-v) for v in axis_values))
+        return joint
+    return None
+
+
 def flip_joint_axis(root, joint_name):
     """Reverse one joint's positive direction, in place.
 
@@ -120,19 +145,9 @@ def flip_joint_axis(root, joint_name):
     skrobot.urdf.change_urdf_root_link : re-roots a URDF, reversing every joint
         along the path with this function.
     """
-    joint = None
-    for candidate in root.findall('joint'):
-        if candidate.get('name') == joint_name:
-            joint = candidate
-            break
+    joint = _negate_joint_axis(root, joint_name)
     if joint is None:
         return False
-    axis_values = _axis_of(joint)
-    if axis_values is None:
-        return False
-
-    joint.find('axis').set(
-        'xyz', ' '.join(_fmt(-v) for v in axis_values))
 
     # q <= U becomes q' >= -U, so a bound does not merely change sign: it
     # changes side.  A one-sided limit therefore moves to the other attribute

--- a/skrobot/urdf/xml_root_link_changer.py
+++ b/skrobot/urdf/xml_root_link_changer.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.spatial.transform import Rotation as R
 
 from skrobot.coordinates.math import invert_yaw_pitch_roll
-from skrobot.urdf.flip_axis import flip_joint_axis
+from skrobot.urdf.flip_axis import _negate_joint_axis
 
 
 class URDFXMLRootLinkChanger:
@@ -346,10 +346,14 @@ class URDFXMLRootLinkChanger:
         origin.set('xyz', ' '.join(map(str, new_xyz)))
         origin.set('rpy', ' '.join(map(str, new_rpy)))
 
-        # Reverse the joint's sense.  The axis is not the only thing that has
-        # to move: an asymmetric <limit> and any mimic coupling are expressed
-        # in the old sense too, so they are remapped with it.
-        flip_joint_axis(self.root, joint.get('name'))
+        # Negate the axis ONLY.  This joint also has its <parent> and <child>
+        # swapped (see _reverse_joints_along_path), and those two reversals
+        # cancel: the same commanded value still produces the same pose.  So
+        # the limits, safety bounds and mimic coefficients must stay as they
+        # are -- remapping them as well, which a full flip_joint_axis would do,
+        # sends the joint through its range mirrored about zero, and the
+        # re-rooted robot can no longer reach where the original could.
+        _negate_joint_axis(self.root, joint.get('name'))
 
         # The joint's old parent link frame is relocated onto this joint's
         # frame; re-express everything attached to that link (visuals,

--- a/tests/skrobot_tests/urdf_tests/test_flip_axis.py
+++ b/tests/skrobot_tests/urdf_tests/test_flip_axis.py
@@ -191,11 +191,19 @@ class TestFlipJointAxisFile(unittest.TestCase):
                 self.assertEqual(f.read(), _URDF)
 
 
-class TestRootLinkChangeRemapsLimits(unittest.TestCase):
-    """Re-rooting reverses the joints along the path; an asymmetric limit has
-    to be remapped with the axis or the robot's reachable range moves."""
+class TestRootLinkChangeKeepsLimits(unittest.TestCase):
+    """Re-rooting negates the axis of every joint along the path, and must
+    leave the limits alone.
 
-    def test_asymmetric_limits_follow_the_reversed_axis(self):
+    Two reversals happen there, not one: swapping <parent>/<child> already
+    reverses the joint's sense, so negating <axis> puts the sense back.  The
+    same commanded value therefore still produces the same pose, and remapping
+    the limits as well would send the joint through its range mirrored about
+    zero -- shrinking the reach on one side and inventing it on the other.
+    A standalone flip_joint_axis is the case that DOES have to remap them; the
+    tests above cover it."""
+
+    def test_asymmetric_limits_survive_the_reversal(self):
         with tempfile.TemporaryDirectory() as tmp:
             src = os.path.join(tmp, 'in.urdf')
             dst = os.path.join(tmp, 'out.urdf')
@@ -207,9 +215,65 @@ class TestRootLinkChangeRemapsLimits(unittest.TestCase):
             axis = [float(v) for v in drive.find('axis').get('xyz').split()]
             self.assertEqual(axis, [0.0, 0.0, -1.0])
             limit = drive.find('limit')
-            self.assertAlmostEqual(float(limit.get('lower')), -2.0)
-            self.assertAlmostEqual(float(limit.get('upper')), 0.5)
+            self.assertAlmostEqual(float(limit.get('lower')), -0.5)
+            self.assertAlmostEqual(float(limit.get('upper')), 2.0)
 
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestRootLinkChangeKeepsSafetyAndMimic(unittest.TestCase):
+    """The same cancellation applies to everything else expressed in the
+    joint's own value: the soft bounds on <safety_controller>, the reversed
+    joint's own <mimic>, and the <mimic> of a follower that is NOT on the
+    re-rooting path but tracks a joint that is."""
+
+    _URDF_MIMIC = """<?xml version="1.0"?>
+<robot name="m">
+  <link name="base"/><link name="mid"/><link name="tip"/><link name="finger"/>
+  <joint name="drive" type="revolute">
+    <parent link="base"/><child link="mid"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0"/><axis xyz="0 0 1"/>
+    <limit lower="-0.5" upper="2.0" effort="10" velocity="1"/>
+    <safety_controller soft_lower_limit="-0.4" soft_upper_limit="1.9"
+                       k_position="100" k_velocity="10"/>
+  </joint>
+  <joint name="fix" type="fixed">
+    <parent link="mid"/><child link="tip"/>
+    <origin xyz="0.2 0 0" rpy="0 0 0"/>
+  </joint>
+  <joint name="follower" type="revolute">
+    <parent link="mid"/><child link="finger"/>
+    <origin xyz="0.05 0 0" rpy="0 0 0"/><axis xyz="0 1 0"/>
+    <limit lower="-1.0" upper="1.0" effort="10" velocity="1"/>
+    <mimic joint="drive" multiplier="2.5" offset="0.1"/>
+  </joint>
+</robot>"""
+
+    def test_soft_bounds_and_mimic_survive_the_reversal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, 'in.urdf')
+            dst = os.path.join(tmp, 'out.urdf')
+            with open(src, 'w') as f:
+                f.write(self._URDF_MIMIC)
+            change_urdf_root_link(src, 'tip', dst)
+            root = ET.parse(dst).getroot()
+
+            drive = _joint(root, 'drive')
+            self.assertEqual(
+                [float(v) for v in drive.find('axis').get('xyz').split()],
+                [0.0, 0.0, -1.0])
+            safety = drive.find('safety_controller')
+            self.assertAlmostEqual(
+                float(safety.get('soft_lower_limit')), -0.4)
+            self.assertAlmostEqual(
+                float(safety.get('soft_upper_limit')), 1.9)
+
+            # 'follower' hangs off the path rather than lying on it, so it is
+            # never reversed itself; its coupling to 'drive' is unchanged
+            # because 'drive' still means what it meant.
+            mimic = _joint(root, 'follower').find('mimic')
+            self.assertEqual(mimic.get('joint'), 'drive')
+            self.assertAlmostEqual(float(mimic.get('multiplier')), 2.5)
+            self.assertAlmostEqual(float(mimic.get('offset')), 0.1)

--- a/tests/skrobot_tests/urdf_tests/test_xml_root_link_changer.py
+++ b/tests/skrobot_tests/urdf_tests/test_xml_root_link_changer.py
@@ -438,3 +438,67 @@ class TestGeometricFidelity(unittest.TestCase):
                 return np.linalg.inv(ref) @ world
             np.testing.assert_allclose(com_rel(src), com_rel(dst),
                                        atol=1e-9)
+
+    def test_reversed_joint_keeps_its_travel_range(self):
+        """Re-rooting must not mirror a joint's limits.
+
+        Swapping <parent>/<child> already reverses the joint's sense, so
+        negating <axis> restores the original convention: the same commanded
+        value still produces the same pose.  Moving the limits as well would
+        send the joint through its range mirrored about zero, and a re-rooted
+        arm could no longer reach where the original could.
+        """
+        import numpy as np
+
+        from skrobot.coordinates.math import xyzrpy2matrix
+        from skrobot.models.urdf import RobotModelFromURDF
+        urdf = """<?xml version="1.0"?>
+<robot name="m">
+  <link name="base_link">{v}</link>
+  <link name="dummy_link1">{v}</link>
+  <joint name="j1" type="revolute">
+    <parent link="base_link"/><child link="dummy_link1"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0"/><axis xyz="0 0 1"/>
+    <limit lower="-0.2" upper="1.4" effort="1" velocity="1"/>
+  </joint>
+</robot>""".format(v=self._BOX_OFFSET)
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, 'm.urdf')
+            with open(src, 'w') as f:
+                f.write(urdf)
+            dst = os.path.join(tmp, 'r.urdf')
+            change_urdf_root_link(src, 'dummy_link1', dst)
+
+            joint = [j for j in ET.parse(dst).getroot().findall('joint')
+                     if j.get('name') == 'j1'][0]
+            self.assertEqual(joint.find('axis').get('xyz').split(),
+                             ['0', '0', '-1'])
+            limit = joint.find('limit')
+            self.assertAlmostEqual(float(limit.get('lower')), -0.2)
+            self.assertAlmostEqual(float(limit.get('upper')), 1.4)
+
+            # and the range means the same thing: driving both documents to the
+            # same value puts the geometry in the same place
+            def box_rel(path, angle):
+                robot = RobotModelFromURDF(urdf_file=path)
+                robot.j1.joint_angle(angle)
+                links = {link.name: link for link in robot.link_list}
+                root = ET.parse(path).getroot()
+                poses = {}
+                for link in root.findall('link'):
+                    origin = link.find('visual').find('origin')
+                    poses[link.get('name')] = (
+                        links[link.get('name')].worldcoords().T()
+                        @ xyzrpy2matrix(
+                            [float(v) for v in origin.get('xyz').split()],
+                            [float(v) for v in
+                             origin.get('rpy', '0 0 0').split()]))
+                ref = np.linalg.inv(poses['base_link'])
+                return {n: ref @ T for n, T in poses.items()}
+
+            for angle in (0.0, 1.3, -0.15):
+                original, rerooted = box_rel(src, angle), box_rel(dst, angle)
+                for name in original:
+                    np.testing.assert_allclose(
+                        original[name], rerooted[name], atol=1e-9,
+                        err_msg='link {} at q={}'.format(name, angle))


### PR DESCRIPTION
Re-rooting reverses a joint twice, not once: swapping <parent>/<child> reverses
its sense and negating <axis> reverses it back, so the same commanded value
still produces the same pose. Remapping the limits, soft bounds and mimic
coefficients as well sent the joint through its range mirrored about zero, and
a re-rooted arm could no longer reach where the original could -- an asymmetric
[-0.2, 1.4] became [-1.4, 0.2].

The root-link changer now negates the axis alone, through a private helper
flip_joint_axis is itself composed from; used on its own flip_joint_axis still
remaps everything, which is the case that needs it.

Note this inverts the expectation of TestRootLinkChangeRemapsLimits from #847,
which asserted the mirrored values but never that the mechanism still behaved
the same. The new test in test_xml_root_link_changer.py drives both documents
to q = 0, 1.3 and -0.15 and asserts every visual world pose matches to 1e-9; it
fails against the code before this change.
