### PR TITLE
Add compare_kinematics: are two URDFs the same mechanism?

### DIFF
--- a/skrobot/urdf/__init__.py
+++ b/skrobot/urdf/__init__.py
@@ -1,6 +1,8 @@
 from skrobot.urdf.aggregate import aggregate_urdf_mesh_files
 from skrobot.urdf.canonicalize import canonicalize_urdf
 from skrobot.urdf.canonicalize import canonicalize_urdf_file
+from skrobot.urdf.compare import compare_kinematics
+from skrobot.urdf.compare import KinematicComparison
 from skrobot.urdf.extract_sub_urdf import extract_sub_urdf
 from skrobot.urdf.flip_axis import flip_joint_axis
 from skrobot.urdf.flip_axis import flip_joint_axis_file
@@ -55,6 +57,8 @@ __all__ = [
     'generate_robot_class_from_geometry',
     'print_urdf_tree',
     'kinematic_tree',
+    'compare_kinematics',
+    'KinematicComparison',
     'validate_urdf_structure',
     'ValidationResult',
     'generate_groups_from_llm',

--- a/skrobot/urdf/compare.py
+++ b/skrobot/urdf/compare.py
@@ -1,0 +1,323 @@
+"""Compare two URDFs as MECHANISMS rather than as documents.
+
+Every transform in :mod:`skrobot.urdf` -- merging fixed links, re-rooting,
+re-centring link frames, flipping a joint axis, scaling -- is meant to leave the
+robot moving as before.  Checking that from the XML is unreliable: a canonical
+text diff flags what does not matter and stays silent about what does.
+
+What a transform must preserve is where the GEOMETRY ends up, not where the
+link frames are.  :func:`change_urdf_root_link` moves link frames and
+compensates in each ``<visual>``/``<collision>``/``<inertial>`` origin, and
+:func:`normalize_link_origins` does the same by design -- comparing link frames
+would call both of them broken.  So this drives both models through the same
+joint angles and compares the world pose of every shared geometry element, each
+taken relative to a link the two documents share, which also makes a change of
+root invisible.
+
+A link carrying no geometry has no observable pose; those are listed in
+``not_comparable`` rather than silently passing.
+
+Examples
+--------
+>>> from skrobot.urdf import compare_kinematics, merge_fixed_links_file
+>>> merge_fixed_links_file('robot.urdf', 'merged.urdf')
+>>> result = compare_kinematics('merged.urdf', 'robot.urdf')
+>>> result.is_equivalent
+True
+"""
+
+import numpy as np
+
+from skrobot.coordinates.math import rotation_distance
+from skrobot.urdf.structure import _load_robot_model
+from skrobot.urdf.structure import _parse_urdf_root
+from skrobot.utils.urdf import parse_origin
+
+
+_DEFAULT_ANGLES = (0.0, 0.5, -0.7)
+_GEOMETRY_TAGS = ('visual', 'collision', 'inertial')
+
+
+def _is_drivable(joint):
+    """True for a joint that one scalar can drive.
+
+    :attr:`~skrobot.model.joint.Joint.is_movable` also holds for the planar and
+    floating joints, whose value is a vector rather than a single coordinate,
+    so there is no one angle to put both documents at.
+    """
+    return joint.is_movable and joint.joint_dof == 1
+
+
+def _geometry_frames(source):
+    """``{link name: {feature key: 4x4 in the link frame}}`` from the XML.
+
+    Keyed by ``tag#index`` so the n-th ``<visual>`` of a link is compared with
+    the n-th of the other document rather than with whatever comes first.
+    """
+    root = _parse_urdf_root(source)
+    out = {}
+    for link in root.findall('link'):
+        features = {}
+        for tag in _GEOMETRY_TAGS:
+            for i, element in enumerate(link.findall(tag)):
+                features['{}#{}'.format(tag, i)] = parse_origin(element)
+        out[link.get('name')] = features
+    return out
+
+
+def _clamped(value, joints):
+    """``value`` pulled inside every joint's own limits.
+
+    A joint whose limits differ between the documents would otherwise be driven
+    to different angles, and everything below it would look moved when only the
+    limit differs.  Limits are reported separately.
+    """
+    lo = max((j.min_angle for j in joints
+              if j.min_angle is not None and np.isfinite(j.min_angle)),
+             default=-np.inf)
+    hi = min((j.max_angle for j in joints
+              if j.max_angle is not None and np.isfinite(j.max_angle)),
+             default=np.inf)
+    return float(np.clip(value, lo, hi))
+
+
+class KinematicComparison(object):
+    """Result of :func:`compare_kinematics`.
+
+    Attributes
+    ----------
+    is_equivalent : bool
+        True when every compared geometry stayed within the tolerances at
+        every tested configuration and nothing else was reported.
+    max_position_error : float
+        Largest geometry position error over all configurations, in metres.
+    max_rotation_error : float
+        Largest geometry orientation error over all configurations, in radians.
+    compared : list of str
+        ``link/feature`` identifiers whose world poses were compared.
+    compared_joints : list of str
+        Movable joints present in both documents, which were driven.
+    not_comparable : list of str
+        Shared links carrying no geometry, so with no observable pose.
+    only_in_candidate, only_in_reference : list of str
+        Link names the other document does not have.
+    differences : list of str
+        Human-readable differences, motion first.
+    reference_link : str
+        The link both sides' poses were expressed relative to.
+    """
+
+    def __init__(self, is_equivalent, max_position_error, max_rotation_error,
+                 compared, compared_joints, not_comparable, only_in_candidate,
+                 only_in_reference, differences, reference_link):
+        self.is_equivalent = is_equivalent
+        self.max_position_error = max_position_error
+        self.max_rotation_error = max_rotation_error
+        self.compared = compared
+        self.compared_joints = compared_joints
+        self.not_comparable = not_comparable
+        self.only_in_candidate = only_in_candidate
+        self.only_in_reference = only_in_reference
+        self.differences = differences
+        self.reference_link = reference_link
+
+    def format_summary(self):
+        """Return the ``Kinematic Comparison`` text."""
+        lines = ['Kinematic Comparison',
+                 '=' * 20,
+                 'Equivalent: {}'.format(
+                     'yes' if self.is_equivalent else 'NO'),
+                 'Geometry compared: {} (relative to {!r})'.format(
+                     len(self.compared), self.reference_link),
+                 'Joints driven: {}'.format(len(self.compared_joints)),
+                 'Max position error: {:.3e} m'.format(
+                     self.max_position_error),
+                 'Max rotation error: {:.3e} rad'.format(
+                     self.max_rotation_error)]
+        if self.not_comparable:
+            lines.append('Links without geometry (not compared): {}'.format(
+                ', '.join(self.not_comparable)))
+        if self.only_in_candidate:
+            lines.append('Only in candidate: {}'.format(
+                ', '.join(self.only_in_candidate)))
+        if self.only_in_reference:
+            lines.append('Only in reference: {}'.format(
+                ', '.join(self.only_in_reference)))
+        for text in self.differences:
+            lines.append('  - {}'.format(text))
+        return '\n'.join(lines)
+
+    def __str__(self):
+        return self.format_summary()
+
+    def __repr__(self):
+        return '<KinematicComparison equivalent={} compared={} maxpos={:.2e}>'\
+            .format(self.is_equivalent, len(self.compared),
+                    self.max_position_error)
+
+
+def compare_kinematics(candidate, reference, joint_angles=None,
+                       reference_link=None, position_tolerance=1e-9,
+                       rotation_tolerance=1e-6, compare_limits=True):
+    """Compare two URDFs by where their geometry actually goes.
+
+    Both documents are driven to the same joint angles and every geometry
+    element they share is compared, each pose taken relative to a link both
+    documents have.  That makes the comparison blind to what a transform may
+    change -- which link is the root, where a link frame sits, how the
+    compensating ``<origin>`` is written -- and sensitive to what it may not.
+
+    Parameters
+    ----------
+    candidate : str or bytes
+        The URDF under test: a file path or raw URDF XML.
+    reference : str or bytes
+        What it should still behave like.
+    joint_angles : sequence, optional
+        Configurations to test.  Each entry is either a scalar, applied to
+        every shared movable joint, or a ``{joint name: angle}`` mapping.
+        Defaults to ``(0.0, 0.5, -0.7)``: the zero pose alone cannot see a
+        wrong axis.  Angles are clamped into both documents' limits, so a
+        differing limit does not masquerade as a differing pose.
+    reference_link : str, optional
+        The link both sides' poses are expressed relative to.  Defaults to the
+        first shared link carrying geometry.
+    position_tolerance : float, optional
+        Largest geometry position difference still called equivalent, in
+        metres.
+    rotation_tolerance : float, optional
+        Largest geometry orientation difference still called equivalent, in
+        radians.  Looser than the position default on purpose: a transform that
+        writes an orientation back as ``rpy`` loses precision in the
+        matrix -> rpy -> matrix round trip, and re-rooting a three-link chain
+        already costs ~2e-8 rad that way.  1e-6 rad is 6e-5 degrees, far below
+        anything a mechanism cares about, and still catches a wrong axis.
+    compare_limits : bool, optional
+        Also report joints whose travel differs.  A reversed joint keeps the
+        same joint coordinate -- rotating the child about ``-a`` by ``q`` is
+        rotating the parent about ``+a`` by ``q`` -- so its limits should be
+        unchanged, and mirrored limits are a real difference in what the
+        mechanism can reach.
+
+    Returns
+    -------
+    KinematicComparison
+        Use :attr:`~KinematicComparison.is_equivalent` for a verdict and
+        :attr:`~KinematicComparison.differences` for what moved.
+
+    Raises
+    ------
+    ValueError
+        If the documents share no geometry to compare, or ``reference_link``
+        is not in both.
+
+    Examples
+    --------
+    >>> from skrobot.urdf import compare_kinematics
+    >>> compare_kinematics('rerooted.urdf', 'original.urdf').is_equivalent
+    True
+    """
+    for source in (candidate, reference):
+        if hasattr(source, 'link_list'):
+            raise ValueError(
+                'compare_kinematics needs the URDF documents (a path or '
+                'XML), not a loaded model: the geometry origins are read '
+                'from the XML')
+    cand_frames = _geometry_frames(candidate)
+    ref_frames = _geometry_frames(reference)
+
+    cand = _load_robot_model(candidate)
+    ref = _load_robot_model(reference)
+    cand_links = {link.name: link for link in cand.link_list}
+    ref_links = {link.name: link for link in ref.link_list}
+
+    shared = [name for name in (link.name for link in cand.link_list)
+              if name in ref_links]
+    features = {}
+    not_comparable = []
+    for name in shared:
+        keys = sorted(set(cand_frames.get(name, {}))
+                      & set(ref_frames.get(name, {})))
+        if keys:
+            features[name] = keys
+        else:
+            not_comparable.append(name)
+    if not features:
+        raise ValueError(
+            'the two documents share no link carrying geometry, so there is '
+            'no observable pose to compare')
+    if reference_link is None:
+        reference_link = next(name for name in shared if name in features)
+    elif reference_link not in features:
+        raise ValueError(
+            'reference_link {!r} must be in both documents and carry geometry '
+            '-- a bare frame has no observable pose to anchor to'
+            .format(reference_link))
+
+    cand_joints = {j.name: j for j in cand.joint_list if _is_drivable(j)}
+    ref_joints = {j.name: j for j in ref.joint_list if _is_drivable(j)}
+    shared_joints = [j.name for j in cand.joint_list
+                     if _is_drivable(j) and j.name in ref_joints]
+
+    differences = []
+    for name in sorted(set(cand_joints) - set(ref_joints)):
+        differences.append('joint {!r} exists only in the candidate'
+                           .format(name))
+    for name in sorted(set(ref_joints) - set(cand_joints)):
+        differences.append('joint {!r} is missing from the candidate'
+                           .format(name))
+    if compare_limits:
+        for name in shared_joints:
+            a, b = cand_joints[name], ref_joints[name]
+            for attr in ('min_angle', 'max_angle'):
+                va, vb = getattr(a, attr), getattr(b, attr)
+                if va is None or vb is None:
+                    continue
+                if np.isfinite(va) != np.isfinite(vb) or (
+                        np.isfinite(va) and abs(va - vb) > 1e-9):
+                    differences.append(
+                        'joint {!r} {} differs: {} vs {}'
+                        .format(name, attr, va, vb))
+
+    def world(model, links, frames, name, key):
+        return links[name].worldcoords().T() @ frames[name][key]
+
+    max_pos, max_rot = 0.0, 0.0
+    compared = ['{}/{}'.format(n, k) for n in features for k in features[n]]
+    for config in (_DEFAULT_ANGLES if joint_angles is None else joint_angles):
+        for name in shared_joints:
+            pair = (cand_joints[name], ref_joints[name])
+            wanted = config.get(name) if hasattr(config, 'get') else config
+            if wanted is None:
+                continue
+            value = _clamped(float(wanted), pair)
+            for joint in pair:
+                joint.joint_angle(value)
+        # Normalise by the reference link's GEOMETRY, never by its frame: the
+        # transforms under test move link frames and compensate in the
+        # geometry origins, so a frame-relative view would reintroduce exactly
+        # the offset they cancelled.
+        anchor = features[reference_link][0]
+        ref_base = np.linalg.inv(
+            world(ref, ref_links, ref_frames, reference_link, anchor))
+        cand_base = np.linalg.inv(
+            world(cand, cand_links, cand_frames, reference_link, anchor))
+        for name in features:
+            for key in features[name]:
+                a = cand_base @ world(cand, cand_links, cand_frames, name, key)
+                b = ref_base @ world(ref, ref_links, ref_frames, name, key)
+                pos = float(np.linalg.norm(a[:3, 3] - b[:3, 3]))
+                rot = rotation_distance(a[:3, :3], b[:3, :3],
+                                        check=False)
+                max_pos = max(max_pos, pos)
+                max_rot = max(max_rot, rot)
+                if pos > position_tolerance or rot > rotation_tolerance:
+                    differences.append(
+                        '{}/{} moves differently at {!r}: {:.3e} m, '
+                        '{:.3e} rad'.format(name, key, config, pos, rot))
+
+    differences.sort(key=lambda text: 'moves differently' not in text)
+    return KinematicComparison(
+        not differences, max_pos, max_rot, compared, shared_joints,
+        not_comparable, sorted(set(cand_links) - set(ref_links)),
+        sorted(set(ref_links) - set(cand_links)), differences, reference_link)

--- a/skrobot/urdf/structure.py
+++ b/skrobot/urdf/structure.py
@@ -148,8 +148,34 @@ def _axis_tuple(axis):
     return tuple(values)
 
 
-def _structure_from_xml(xml_bytes):
-    root = ET.fromstring(xml_bytes)
+def _parse_urdf_root(source):
+    """Parse ``source`` into the ``<robot>`` element it describes.
+
+    Parameters
+    ----------
+    source : str or bytes
+        A URDF file path, or raw URDF XML as a string or bytes.
+
+    Returns
+    -------
+    root : xml.etree.ElementTree.Element
+        The document's root element.
+    """
+    if isinstance(source, bytes):
+        return ET.fromstring(source)
+    if isinstance(source, str):
+        if source.lstrip().startswith('<'):
+            return ET.fromstring(source.encode('utf-8'))
+        if not os.path.exists(source):
+            raise IOError('URDF file not found: {}'.format(source))
+        with open(source, 'rb') as f:
+            return ET.fromstring(f.read())
+    raise TypeError(
+        'source must be a URDF path or XML string/bytes, got {}'
+        .format(type(source)))
+
+
+def _structure_from_root(root):
     if root.tag != 'robot':
         raise ValueError(
             "Expected 'robot' root element, got '{}'".format(root.tag))
@@ -271,19 +297,11 @@ def _load_structure(source, with_objects=False):
         return _structure_from_robot_model(source)
     if with_objects:
         return _structure_from_robot_model(_load_robot_model(source))
-    if isinstance(source, bytes):
-        return _structure_from_xml(source)
-    if isinstance(source, str):
-        stripped = source.lstrip()
-        if stripped.startswith('<'):
-            return _structure_from_xml(source.encode('utf-8'))
-        if not os.path.exists(source):
-            raise IOError('URDF file not found: {}'.format(source))
-        with open(source, 'rb') as f:
-            return _structure_from_xml(f.read())
-    raise TypeError(
-        'source must be a URDF path, XML string/bytes or a RobotModel, '
-        'got {}'.format(type(source)))
+    if not isinstance(source, (str, bytes)):
+        raise TypeError(
+            'source must be a URDF path, XML string/bytes or a RobotModel, '
+            'got {}'.format(type(source)))
+    return _structure_from_root(_parse_urdf_root(source))
 
 
 # ============================================================================

--- a/tests/skrobot_tests/urdf_tests/test_compare.py
+++ b/tests/skrobot_tests/urdf_tests/test_compare.py
@@ -1,0 +1,154 @@
+"""Tests for skrobot.urdf.compare_kinematics."""
+
+import os
+import tempfile
+import unittest
+
+from skrobot.urdf import change_urdf_root_link
+from skrobot.urdf import compare_kinematics
+from skrobot.urdf import merge_fixed_links_file
+
+
+_VISUAL = ('<visual><origin xyz="0.05 0.01 0" rpy="0.2 0 0"/>'
+           '<geometry><box size="0.02 0.02 0.02"/></geometry></visual>')
+
+
+def _urdf(limit='lower="-0.2" upper="1.4"', axis='0 0 1', visual=_VISUAL):
+    return """<?xml version="1.0"?>
+<robot name="m">
+  <link name="base">{v}</link>
+  <link name="arm">{v}</link>
+  <link name="tip">{v}</link>
+  <joint name="j1" type="revolute">
+    <parent link="base"/><child link="arm"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0"/><axis xyz="{a}"/>
+    <limit {l} effort="1" velocity="1"/>
+  </joint>
+  <joint name="fix" type="fixed">
+    <parent link="arm"/><child link="tip"/>
+    <origin xyz="0.2 0 0" rpy="0 0 0"/>
+  </joint>
+</robot>""".format(v=visual, a=axis, l=limit)
+
+
+def _write(directory, name, text):
+    path = os.path.join(directory, name)
+    with open(path, 'w') as f:
+        f.write(text)
+    return path
+
+
+class TestComparePreservingTransforms(unittest.TestCase):
+    """A transform that is supposed to preserve the mechanism reads as
+    equivalent, even though it rewrites the document heavily."""
+
+    def test_merge_fixed_links_is_equivalent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, 'a.urdf', _urdf())
+            dst = os.path.join(tmp, 'b.urdf')
+            merge_fixed_links_file(src, dst)
+            result = compare_kinematics(dst, src)
+            self.assertTrue(result.is_equivalent, str(result))
+            self.assertEqual(result.only_in_reference, ['tip'])
+
+    def test_change_root_link_is_equivalent(self):
+        """Re-rooting moves every link frame and compensates in the geometry
+        origins, so comparing frames would call it broken; comparing geometry
+        does not."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, 'a.urdf', _urdf())
+            dst = os.path.join(tmp, 'b.urdf')
+            change_urdf_root_link(src, 'tip', dst)
+            result = compare_kinematics(dst, src)
+            self.assertTrue(result.is_equivalent, str(result))
+            self.assertLess(result.max_position_error, 1e-12)
+
+    def test_a_document_equals_itself(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, 'a.urdf', _urdf())
+            self.assertTrue(compare_kinematics(src, src).is_equivalent)
+
+
+class TestCompareCatchesRealChanges(unittest.TestCase):
+
+    def test_a_negated_axis_alone_is_not_equivalent(self):
+        """Negating <axis> without moving the limits reverses the joint, which
+        a canonical text diff would report but could not distinguish from the
+        harmless sign choices it also reports."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, 'a.urdf', _urdf())
+            dst = _write(tmp, 'b.urdf', _urdf(axis='0 0 -1'))
+            result = compare_kinematics(dst, src)
+            self.assertFalse(result.is_equivalent)
+            self.assertTrue(any('moves differently' in d
+                                for d in result.differences), result)
+
+    def test_a_moved_joint_origin_is_not_equivalent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, 'a.urdf', _urdf())
+            dst = _write(tmp, 'b.urdf',
+                         _urdf().replace('xyz="0 0 0.1"', 'xyz="0 0 0.11"'))
+            result = compare_kinematics(dst, src)
+            self.assertFalse(result.is_equivalent)
+            self.assertAlmostEqual(result.max_position_error, 0.01, places=9)
+
+    def test_differing_limits_are_reported_but_do_not_skew_the_poses(self):
+        """The requested angle is clamped into BOTH documents' limits, so a
+        differing limit shows up as itself rather than as everything below the
+        joint appearing to move."""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, 'a.urdf', _urdf())
+            dst = _write(tmp, 'b.urdf', _urdf(limit='lower="-0.2" upper="0.9"'))
+            result = compare_kinematics(dst, src)
+            self.assertFalse(result.is_equivalent)
+            self.assertEqual(result.max_position_error, 0.0)
+            self.assertTrue(any('max_angle differs' in d
+                                for d in result.differences), result)
+            self.assertTrue(
+                compare_kinematics(dst, src, compare_limits=False)
+                .is_equivalent)
+
+
+class TestCompareReporting(unittest.TestCase):
+
+    def test_a_link_without_geometry_is_not_silently_passed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            text = _urdf().replace('<link name="tip">{}</link>'.format(_VISUAL),
+                                   '<link name="tip"/>')
+            src = _write(tmp, 'a.urdf', text)
+            result = compare_kinematics(src, src)
+            self.assertIn('tip', result.not_comparable)
+            self.assertNotIn('tip/visual#0', result.compared)
+
+    def test_no_shared_geometry_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, 'a.urdf', _urdf())
+            other = _write(tmp, 'b.urdf', _urdf().replace('name="m"', 'name="o"')
+                           .replace('"base"', '"b2"').replace('"arm"', '"a2"')
+                           .replace('"tip"', '"t2"'))
+            with self.assertRaises(ValueError):
+                compare_kinematics(other, src)
+
+    def test_per_joint_angles_may_be_given_as_a_mapping(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, 'a.urdf', _urdf())
+            dst = _write(tmp, 'b.urdf', _urdf(axis='0 0 -1'))
+            self.assertTrue(
+                compare_kinematics(dst, src, joint_angles=({'j1': 0.0},),
+                                   compare_limits=False).is_equivalent)
+            self.assertFalse(
+                compare_kinematics(dst, src, joint_angles=({'j1': 0.4},),
+                                   compare_limits=False).is_equivalent)
+
+    def test_summary_names_what_moved(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = _write(tmp, 'a.urdf', _urdf())
+            dst = _write(tmp, 'b.urdf', _urdf(axis='0 0 -1'))
+            text = str(compare_kinematics(dst, src))
+            self.assertIn('Kinematic Comparison', text)
+            self.assertIn('Equivalent: NO', text)
+            self.assertIn('arm/visual#0', text)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Every transform here -- merging fixed links, re-rooting, re-centring link
frames, flipping an axis, scaling -- is meant to leave the robot moving as
before, but nothing checks that. A canonical text diff cannot: it reports sign
choices and frames that slid along their own axis, and stays quiet about an
axis negated without its limits. test_xml_root_link_changer already hand-rolled
a pose comparison for one case; merge_fixed_links and normalize_link_origins,
which both relocate geometry, assert only on XML.

compare_kinematics drives both documents to the same joint angles and compares
the world pose of every shared visual/collision/inertial, each relative to a
shared link's geometry -- so a moved link frame compensated in the geometry
origins reads as equivalent, and a changed motion does not. The default
configurations include non-zero angles because the zero pose cannot see a wrong
axis, and a link carrying no geometry has no observable pose, so it is reported
rather than passed.

Stacked on #861: the re-rooting test here asserts full equivalence, which needs
that fix. This is the tool that found it.

The existing merge_fixed_links and normalize_link_origins tests are left alone
-- adding the tool and rewriting tests with it are separate changes.
