### PR TITLE
Let a joint say whether it moves

### DIFF
--- a/skrobot/model/joint.py
+++ b/skrobot/model/joint.py
@@ -184,6 +184,37 @@ class Joint(object):
     def joint_dof(self):
         raise NotImplementedError
 
+    @property
+    def is_movable(self):
+        """Whether this joint contributes any degree of freedom.
+
+        Defined by the degrees of freedom rather than by the type name.
+        A name-based test has to keep a list of the movable types, and
+        such a list is wrong in two ways at once: it silently omits
+        ``planar`` and ``floating``, which move in three and six
+        directions, and it cannot classify :class:`OmniWheelJoint` at
+        all, which has three degrees of freedom and no ``type`` to
+        compare against. Counting the degrees of freedom asks the
+        question directly and needs no revisiting when a joint type is
+        added.
+
+        Returns
+        -------
+        bool
+            True unless the joint is rigid, i.e. anything but
+            :class:`FixedJoint`.
+
+        Examples
+        --------
+        >>> from skrobot.model import FixedJoint, Link, RotationalJoint
+        >>> parent, child = Link(name='p'), Link(name='c')
+        >>> RotationalJoint(parent_link=parent, child_link=child).is_movable
+        True
+        >>> FixedJoint(parent_link=parent, child_link=child).is_movable
+        False
+        """
+        return self.joint_dof > 0
+
     def joint_angle(self, v=None, relative=None, enable_hook=True):
         raise NotImplementedError
 

--- a/tests/skrobot_tests/model_tests/test_joint_is_movable.py
+++ b/tests/skrobot_tests/model_tests/test_joint_is_movable.py
@@ -1,0 +1,57 @@
+import unittest
+
+from skrobot.model import FixedJoint
+from skrobot.model import FloatingJoint
+from skrobot.model import LinearJoint
+from skrobot.model import Link
+from skrobot.model import OmniWheelJoint
+from skrobot.model import PlanarJoint
+from skrobot.model import RotationalJoint
+from skrobot.urdf.structure import MOVABLE_JOINT_TYPES
+
+
+def _joint(cls):
+    return cls(parent_link=Link(name='p'), child_link=Link(name='c'))
+
+
+class TestJointIsMovable(unittest.TestCase):
+
+    def test_only_a_fixed_joint_is_immovable(self):
+        for cls in (RotationalJoint, LinearJoint, PlanarJoint,
+                    FloatingJoint, OmniWheelJoint):
+            self.assertTrue(_joint(cls).is_movable,
+                            '{} moves'.format(cls.__name__))
+        self.assertFalse(_joint(FixedJoint).is_movable)
+
+    def test_it_follows_the_degrees_of_freedom(self):
+        for cls in (RotationalJoint, LinearJoint, PlanarJoint,
+                    FloatingJoint, OmniWheelJoint, FixedJoint):
+            joint = _joint(cls)
+            self.assertEqual(joint.is_movable, joint.joint_dof > 0)
+
+    def test_it_classifies_a_joint_that_has_no_type(self):
+        """OmniWheelJoint carries three degrees of freedom and no ``type``.
+
+        Anything deciding this by comparing type names raises instead of
+        answering, which is the reason not to decide it that way.
+        """
+        joint = _joint(OmniWheelJoint)
+        with self.assertRaises(NotImplementedError):
+            joint.type
+        self.assertTrue(joint.is_movable)
+
+    def test_it_agrees_with_the_urdf_type_list(self):
+        """The same question is asked of URDF type strings elsewhere.
+
+        ``skrobot.urdf.structure`` has only the type name to go on, so it
+        keeps a list. The two must not drift apart for the joints that
+        both can see.
+        """
+        for cls in (RotationalJoint, LinearJoint, PlanarJoint, FloatingJoint):
+            joint = _joint(cls)
+            self.assertIn(joint.type, MOVABLE_JOINT_TYPES)
+        self.assertNotIn(_joint(FixedJoint).type, MOVABLE_JOINT_TYPES)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The question is asked in several places and answered differently each time. skrobot/urdf/structure.py keeps MOVABLE_JOINT_TYPES with five entries; module_assembly.py keeps its own with three, leaving out planar and floating; callers outside skrobot write the list again. The model's Joint class, which is the one object that actually knows, has been silent on it.

`is_movable` answers from the degrees of freedom rather than the type name. That is not a stylistic preference: OmniWheelJoint has three degrees of freedom and no `type` property at all, so a name comparison raises NotImplementedError instead of returning False, and any list that forgets planar and floating calls a six-DOF joint rigid. Counting the degrees of freedom asks the question directly, and a new joint type answers it correctly without anyone remembering to update a list.

The type-string list in urdf/structure.py stays: parsing a URDF, a type name is all there is to go on. A test pins the two together so they cannot drift apart for the joints both can see.