### PR TITLE
Read a URDF by its own encoding, not the platform's

### DIFF
--- a/skrobot/assembly/module_assembly.py
+++ b/skrobot/assembly/module_assembly.py
@@ -1710,7 +1710,7 @@ class RobotAssembly:
                 "closure's\n"
                 "# two link points (the cut hinge) coincide.\n")
         path = os.path.join(directory, "loop_closures.yaml")
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(head + yaml.safe_dump(config, sort_keys=False,
                                           default_flow_style=None))
         return path

--- a/skrobot/export/isaac/fjt_server.py
+++ b/skrobot/export/isaac/fjt_server.py
@@ -36,7 +36,7 @@ def _load_template(name):
     Template
         string.Template instance.
     """
-    with open(TEMPLATES_DIR / name) as f:
+    with open(TEMPLATES_DIR / name, encoding='utf-8') as f:
         return Template(f.read())
 
 
@@ -94,6 +94,6 @@ def generate_fjt_server(controllers, node_name='isaac_fjt_server',
 
 def write_fjt_server(controllers, path, **kwargs):
     """Write :func:`generate_fjt_server`'s output to ``path``. Returns ``path``."""
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         f.write(generate_fjt_server(controllers, **kwargs))
     return path

--- a/skrobot/kinematics/loop_closure.py
+++ b/skrobot/kinematics/loop_closure.py
@@ -115,7 +115,7 @@ class LoopClosureSolver(object):
     def from_yaml(cls, robot_model, path):
         """Build a solver from a ``loop_closures.yaml`` sidecar file."""
         import yaml
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             return cls(robot_model, yaml.safe_load(f))
 
     @staticmethod

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -3134,7 +3134,8 @@ class RobotModel(CascadedLink):
 
     def _load_urdf_from_string_secure(self, urdf_string, include_mimic_joints):
         """Load URDF from string using secure temporary file handling."""
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=".urdf") as f:
+        with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8',
+                                         delete=False, suffix=".urdf") as f:
             f.write(urdf_string)
             tmp_path = f.name
 
@@ -3227,7 +3228,9 @@ class RobotModel(CascadedLink):
         robot_model = RobotModel()
         if os.path.isfile(urdf_input):
             try:
-                with open(urdf_input, 'r') as f:
+                # 'rb': a URDF is XML and declares its own encoding, so
+                # let the parser decode it rather than the platform default.
+                with open(urdf_input, 'rb') as f:
                     robot_model.load_urdf_file(
                         file_obj=f, include_mimic_joints=include_mimic_joints)
             except Exception as e:
@@ -3263,6 +3266,9 @@ class RobotModel(CascadedLink):
         ----------
         file_obj : str or file-like object
             Path to the URDF file or a file-like object containing URDF data.
+            A file object is parsed from its undecoded bytes where possible,
+            so the URDF's own encoding declaration decides how it is read
+            rather than the platform default encoding.
         include_mimic_joints : bool, optional
             If True, mimic joints are included in the `self.joint_list`.
             If False, mimic joints are excluded from `self.joint_list`,

--- a/skrobot/models/differential_wrist_sample.py
+++ b/skrobot/models/differential_wrist_sample.py
@@ -48,7 +48,7 @@ class DifferentialWristSample(RobotModelFromURDF):
     def _apply_joint_limit_tables(self):
         """Apply joint limit tables from YAML configuration."""
         yaml_path = differential_wrist_sample_joint_limit_table_path()
-        with open(yaml_path, 'r') as f:
+        with open(yaml_path, 'r', encoding='utf-8') as f:
             config = yaml.safe_load(f)
 
         for table_config in config['joint_limit_tables']:

--- a/skrobot/models/r8_6.py
+++ b/skrobot/models/r8_6.py
@@ -21,7 +21,7 @@ class R8_6(skrobot.model.RobotModel):
         super(R8_6, self).__init__(*args, **kwargs)
         urdf_path = r8_6_urdfpath() if urdf_path is None else urdf_path
         if osp.exists(urdf_path):
-            self.load_urdf_file(open(urdf_path, 'r'))
+            self.load_urdf_file(open(urdf_path, 'rb'))
         else:
             raise ValueError()
 

--- a/skrobot/pycompat.py
+++ b/skrobot/pycompat.py
@@ -32,7 +32,7 @@ def is_wsl():
         return False
     if os.path.exists('/proc/version'):
         try:
-            with open('/proc/version', 'r') as f:
+            with open('/proc/version', 'r', encoding='utf-8') as f:
                 version_info = f.read().lower()
             if 'microsoft' in version_info or 'wsl' in version_info:
                 return True

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -480,7 +480,7 @@ class GridSDF(SignedDistanceFunction):
         sdf_instance : skrobot.esdf.GridSDF
             instance of sdf
         """
-        with open(filepath, 'r') as f:
+        with open(filepath, 'r', encoding='utf-8') as f:
             # dimension of each axis should all be equal for LSH
             nx, ny, nz = [int(i) for i in f.readline().split()]
             ox, oy, oz = [float(i) for i in f.readline().split()]

--- a/skrobot/urdf/robot_class_generator.py
+++ b/skrobot/urdf/robot_class_generator.py
@@ -1749,7 +1749,7 @@ class {class_name}(RobotModelFromURDF):
 {viewer_code}'''
 
     if output_path:
-        with open(output_path, 'w') as f:
+        with open(output_path, 'w', encoding='utf-8') as f:
             f.write(code)
 
     return code

--- a/skrobot/urdf/ros_config/moveit_package.py
+++ b/skrobot/urdf/ros_config/moveit_package.py
@@ -46,7 +46,7 @@ def _load_template(name):
     Template
         string.Template instance.
     """
-    with open(TEMPLATES_DIR / name) as f:
+    with open(TEMPLATES_DIR / name, encoding="utf-8") as f:
         return Template(f.read())
 
 
@@ -61,7 +61,7 @@ def _write_file(content, output_path):
         Destination path.
     """
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(content)
 
 
@@ -81,7 +81,7 @@ def _write_yaml(data, output_path):
             return super().increase_indent(flow, False)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         yaml.dump(data, f, Dumper=_CleanDumper, default_flow_style=False, sort_keys=False)
 
 
@@ -331,11 +331,11 @@ def _patch_dae_for_gazebo(dae_path):
       in COLLADA's A_ONE mode and causes black rendering in Gazebo.
     """
     dae_path = Path(dae_path)
-    data = dae_path.read_text()
+    data = dae_path.read_text(encoding="utf-8")
     data = data.replace("<up_axis>Y_UP</up_axis>", "<up_axis>Z_UP</up_axis>")
     data = re.sub(r"\s*<transparent>\s*<color>[^<]+</color>\s*</transparent>", "", data)
     data = re.sub(r"\s*<transparency>\s*<float>[^<]+</float>\s*</transparency>", "", data)
-    dae_path.write_text(data)
+    dae_path.write_text(data, encoding="utf-8")
 
 
 def _convert_urdf_meshes(urdf_path, output_path, visual_format="stl", collision_format="stl"):
@@ -462,7 +462,7 @@ def build_moveit_package(
     # --- Config files ---
 
     # Re-read the converted URDF
-    with open(urdf_dir / f"{robot_name}.urdf") as f:
+    with open(urdf_dir / f"{robot_name}.urdf", encoding="utf-8") as f:
         urdf_content = f.read()
 
     # URDF with ros2_control (for Gazebo / controllers)

--- a/skrobot/urdf/ros_package_exporter.py
+++ b/skrobot/urdf/ros_package_exporter.py
@@ -90,7 +90,7 @@ class ROSPackageExporter:
         original_package_name : str, optional
             Original package name to replace with the new package name.
         """
-        with open(urdf_path) as f:
+        with open(urdf_path, encoding="utf-8") as f:
             content = f.read()
 
         if original_package_name:
@@ -315,7 +315,7 @@ class ROSPackageExporter:
                 # ``<package_name>/meshes/``.
                 export_content = rewrite_mesh_package_references(export_content, self.package_name)
                 urdf_path = urdf_dir / f"{self.package_name}.urdf"
-                with open(urdf_path, "w") as f:
+                with open(urdf_path, "w", encoding="utf-8") as f:
                     f.write(export_content)
                 if progress_callback:
                     progress_callback("Wrote URDF file", 1, 4)
@@ -366,12 +366,12 @@ class ROSPackageExporter:
                 package_xml = generate_package_xml(self.package_name)
                 cmake_content = generate_cmake_lists(self.package_name, include_xacro=False)
 
-            with open(package_dir / "package.xml", "w") as f:
+            with open(package_dir / "package.xml", "w", encoding="utf-8") as f:
                 f.write(package_xml)
             if progress_callback:
                 progress_callback("Generated package.xml", 3, 4)
 
-            with open(package_dir / "CMakeLists.txt", "w") as f:
+            with open(package_dir / "CMakeLists.txt", "w", encoding="utf-8") as f:
                 f.write(cmake_content)
             if progress_callback:
                 progress_callback("Generated CMakeLists.txt", 4, 4)
@@ -401,13 +401,13 @@ class ROSPackageExporter:
         rviz_dir.mkdir(parents=True, exist_ok=True)
 
         launch_content = generate_ros1_display_launch(self.package_name)
-        with open(launch_dir / "display.launch", "w") as f:
+        with open(launch_dir / "display.launch", "w", encoding="utf-8") as f:
             f.write(launch_content)
         if progress_callback:
             progress_callback("Generated display.launch", 1, 2)
 
         rviz_content = generate_ros1_rviz_config()
-        with open(rviz_dir / "urdf.rviz", "w") as f:
+        with open(rviz_dir / "urdf.rviz", "w", encoding="utf-8") as f:
             f.write(rviz_content)
         if progress_callback:
             progress_callback("Generated urdf.rviz", 2, 2)

--- a/skrobot/utils/blender_mesh.py
+++ b/skrobot/utils/blender_mesh.py
@@ -391,7 +391,7 @@ ratio = {ratio}
 decimate_glb_file(input_path, output_path, ratio)
 """
 
-    script_path.write_text(script_content)
+    script_path.write_text(script_content, encoding='utf-8')
 
 
 def _create_blender_wrapper_script(script_path, input_path, output_path, voxel_size, export_format):
@@ -434,4 +434,4 @@ export_format = "{export_format}"
 remesh_and_bake_file(input_path, output_path, voxel_size, export_format)
 """
 
-    script_path.write_text(script_content)
+    script_path.write_text(script_content, encoding='utf-8')

--- a/skrobot/utils/convex_decomposition.py
+++ b/skrobot/utils/convex_decomposition.py
@@ -335,7 +335,7 @@ def _read_cache_entry(part_dir):
     """
     trimesh = _lazy_trimesh()
     try:
-        with open(os.path.join(part_dir, _MANIFEST_NAME)) as f:
+        with open(os.path.join(part_dir, _MANIFEST_NAME), encoding='utf-8') as f:
             manifest = json.load(f)
         if manifest['version'] != _CACHE_VERSION:
             return None

--- a/skrobot/utils/mjcf_converter.py
+++ b/skrobot/utils/mjcf_converter.py
@@ -494,7 +494,7 @@ def urdf_to_mjcf(urdf, out_path, mesh_dir=None, floating_base=False,
 
     _indent(root)
     tree = ET.ElementTree(root)
-    tree.write(out_path, encoding="unicode", xml_declaration=False)
+    tree.write(out_path, encoding="utf-8", xml_declaration=False)
     return ET.tostring(root, encoding="unicode")
 
 

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import copy
+import io
 from logging import getLogger
 import os
 
@@ -51,6 +52,49 @@ from skrobot.utils.urdf_mesh import source_urdf_path
 # imported them from here.
 
 logger = getLogger(__name__)
+
+
+def _byte_stream(file_obj):
+    """Return a byte stream to parse a URDF from, and an encoding override.
+
+    A URDF is XML: it carries its own encoding declaration and defaults to
+    UTF-8. A text file object decodes with whatever encoding it was opened
+    with -- the platform default, ``cp932`` on a Japanese Windows -- so a
+    non-ASCII UTF-8 URDF is misread, or fails to be read at all, before the
+    parser ever sees the declaration. Handing the parser the still-undecoded
+    bytes instead lets the declaration decide.
+
+    A text stream with nothing but text behind it (:class:`io.StringIO`, how
+    :meth:`skrobot.model.RobotModel.load_urdf` passes a URDF string) is
+    already decoded. lxml refuses text that declares an encoding, so such a
+    stream is re-encoded as UTF-8 and the parser is told to ignore the
+    declaration.
+
+    Parameters
+    ----------
+    file_obj : file-like object
+        Stream a URDF is about to be parsed from.
+
+    Returns
+    -------
+    stream : file-like object
+        Byte stream for the parser, or ``file_obj`` itself if it already
+        yields bytes.
+    encoding : str or None
+        Encoding to parse ``stream`` with, overriding the document's own
+        declaration, or None to let the declaration stand.
+    """
+    if not isinstance(file_obj, io.TextIOBase):
+        return file_obj, None
+    buffer = getattr(file_obj, 'buffer', None)
+    if buffer is not None:
+        try:
+            at_start = file_obj.tell() == 0
+        except (OSError, ValueError):
+            at_start = False
+        if at_start:
+            return buffer, None
+    return io.BytesIO(file_obj.read().encode('utf-8')), 'utf-8'
 
 
 def convert_urdf_meshes(urdf_path, output_path, mesh_format,
@@ -3154,13 +3198,15 @@ class URDF(URDFType):
             else:
                 raise ValueError('{} is not a file'.format(file_obj))
         else:
-            parser = ET.XMLParser(remove_comments=True, remove_blank_text=True)
+            path, _ = os.path.split(getattr(file_obj, 'name', ''))
+            stream, encoding = _byte_stream(file_obj)
+            parser = ET.XMLParser(remove_comments=True, remove_blank_text=True,
+                                  encoding=encoding)
             try:
-                tree = ET.parse(file_obj, parser=parser)
+                tree = ET.parse(stream, parser=parser)
             except ET.XMLSyntaxError as e:
                 logger.error('Failed to parse XML from file-like object: %s', e)
                 return URDF(name='INVALID_URDF', links=[])
-            path, _ = os.path.split(file_obj.name)
 
         node = tree.getroot()
         return URDF._from_xml(node, path)

--- a/skrobot/utils/urdf_mesh.py
+++ b/skrobot/utils/urdf_mesh.py
@@ -612,7 +612,7 @@ def _gltf_uses_draco(filename):
                     return False
                 gltf = json.loads(f.read(chunk_length))
         else:
-            with open(filename, 'r') as f:
+            with open(filename, 'r', encoding='utf-8') as f:
                 gltf = json.load(f)
     except Exception:
         return False

--- a/tests/skrobot_tests/data/japanese_material.urdf
+++ b/tests/skrobot_tests/data/japanese_material.urdf
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<robot name="japanese_material">
+  <!-- Two ways a UTF-8 name goes wrong when it is read with the platform
+       default instead of the declared encoding. Half-width katakana "ｱﾙﾐ"
+       ("aluminium") is ef bd b1 ef be 99 ef be 90, and 0xEF is not a valid
+       cp932 lead byte, so the read raises. Full-width "ゴム" ("rubber") is
+       e3 82 b4 e3 83 a0, which is valid cp932 and decodes to garbage, so
+       the name comes back quietly wrong instead. -->
+  <material name="ｱﾙﾐ">
+    <color rgba="0.8 0.8 0.8 1.0"/>
+  </material>
+  <material name="ゴム">
+    <color rgba="0.1 0.1 0.1 1.0"/>
+  </material>
+  <link name="base_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.062"/>
+      <inertia ixx="1e-05" ixy="0" ixz="0" iyy="1e-05" iyz="0" izz="1e-05"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+      <material name="ｱﾙﾐ"/>
+    </visual>
+    <visual>
+      <origin xyz="0.2 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+      <material name="ゴム"/>
+    </visual>
+  </link>
+</robot>

--- a/tests/skrobot_tests/test_urdf_encoding.py
+++ b/tests/skrobot_tests/test_urdf_encoding.py
@@ -1,0 +1,145 @@
+"""A URDF is UTF-8; loading it must not depend on the platform default.
+
+A URDF declares its own encoding and defaults to UTF-8. Reading one with the
+platform default encoding instead (``cp932`` on a Japanese Windows) either
+raises or silently returns the wrong characters, before the parser ever sees
+the declaration.
+"""
+
+import ast
+import os
+import unittest
+
+from skrobot.model import RobotModel
+from skrobot.models.urdf import RobotModelFromURDF
+import skrobot.utils.urdf
+
+
+# Half-width katakana: the UTF-8 bytes start with 0xEF, which is not a
+# valid cp932 lead byte, so reading them as cp932 raises.
+ALUMINIUM = u'ｱﾙﾐ'
+
+# Full-width: the UTF-8 bytes are valid cp932 and decode to something else,
+# so reading them as cp932 gives a name that is wrong without saying so.
+RUBBER = u'ゴム'
+
+URDF_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), 'data',
+    'japanese_material.urdf')
+
+
+def material_names(robot_model):
+    return [m.name for m in robot_model.urdf_robot_model.materials]
+
+
+class TestURDFEncoding(unittest.TestCase):
+
+    def test_load_from_path(self):
+        robot_model = RobotModelFromURDF(urdf_file=URDF_PATH)
+        self.assertEqual([ALUMINIUM, RUBBER],
+                         material_names(robot_model))
+
+    def test_load_from_utf8_text_stream(self):
+        robot_model = RobotModel()
+        with open(URDF_PATH, 'r', encoding='utf-8') as f:
+            robot_model.load_urdf_file(f)
+        self.assertEqual([ALUMINIUM, RUBBER],
+                         material_names(robot_model))
+
+    def test_load_from_binary_stream(self):
+        robot_model = RobotModel()
+        with open(URDF_PATH, 'rb') as f:
+            robot_model.load_urdf_file(f)
+        self.assertEqual([ALUMINIUM, RUBBER],
+                         material_names(robot_model))
+
+    def test_load_from_cp932_text_stream(self):
+        # What ``open(path)`` gives you on a Japanese Windows. The parser
+        # must read the undecoded bytes and honour the declaration.
+        robot_model = RobotModel()
+        with open(URDF_PATH, 'r', encoding='cp932') as f:
+            robot_model.load_urdf_file(f)
+        self.assertEqual([ALUMINIUM, RUBBER],
+                         material_names(robot_model))
+
+    def test_from_urdf(self):
+        robot_model = RobotModel.from_urdf(URDF_PATH)
+        self.assertEqual('japanese_material', robot_model.name)
+        self.assertEqual([ALUMINIUM, RUBBER],
+                         material_names(robot_model))
+
+    def test_load_urdf_string(self):
+        robot_model = RobotModel()
+        with open(URDF_PATH, 'r', encoding='utf-8') as f:
+            robot_model.load_urdf(f.read())
+        self.assertEqual([ALUMINIUM, RUBBER],
+                         material_names(robot_model))
+
+
+class TestNoDefaultEncoding(unittest.TestCase):
+    """Every text file skrobot reads or writes must name its encoding."""
+
+    @staticmethod
+    def _keyword(call, name):
+        for keyword in call.keywords:
+            if keyword.arg == name:
+                return keyword
+        return None
+
+    @classmethod
+    def _mode(cls, call, position, default):
+        keyword = cls._keyword(call, 'mode')
+        if keyword is not None:
+            node = keyword.value
+        elif len(call.args) > position:
+            node = call.args[position]
+        else:
+            return default
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        return None  # computed at runtime; nothing to check statically
+
+    @staticmethod
+    def _function_name(call):
+        if isinstance(call.func, ast.Name):
+            return call.func.id
+        if isinstance(call.func, ast.Attribute):
+            return call.func.attr
+        return ''
+
+    def _offenders(self, path):
+        with open(path, 'r', encoding='utf-8') as f:
+            tree = ast.parse(f.read(), path)
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = self._function_name(node)
+            if name == 'open' and isinstance(node.func, ast.Name):
+                mode = self._mode(node, 1, 'r')
+            elif name in ('NamedTemporaryFile', 'TemporaryFile'):
+                mode = self._mode(node, 0, 'w+b')
+            elif name in ('read_text', 'write_text'):
+                mode = 'r'
+            else:
+                continue
+            if mode is None or 'b' in mode:
+                continue
+            if self._keyword(node, 'encoding') is None:
+                offenders.append('{}:{}: {}()'.format(path, node.lineno, name))
+        return offenders
+
+    def test_no_open_without_encoding(self):
+        package_dir = os.path.dirname(
+            os.path.abspath(skrobot.utils.urdf.__file__))
+        package_dir = os.path.dirname(package_dir)
+        offenders = []
+        for dirpath, _, filenames in os.walk(package_dir):
+            for filename in sorted(filenames):
+                if filename.endswith('.py'):
+                    offenders.extend(
+                        self._offenders(os.path.join(dirpath, filename)))
+        self.assertEqual(
+            [], offenders,
+            'text-mode file I/O without an explicit encoding falls back to '
+            'the platform default:\n' + '\n'.join(offenders))


### PR DESCRIPTION
A URDF declares its own encoding, but skrobot read one with the platform default: on a cp932 machine a UTF-8 file with half-width katakana (`ｱﾙﾐ` is `ef bd b1 ...`, and 0xEF is not a valid cp932 lead byte) raises, while full-width names (`ゴム`) are valid cp932 and come back quietly wrong.

`URDF.load` now parses the undecoded bytes so the declaration decides -- even when the caller opened the file itself -- and every text file skrobot reads or writes names its encoding, so a ROS package or MoveIt export no longer depends on the machine.

Tests cover both failure modes through six load paths, plus a static check that fails on a text-mode `open()` that leaves the encoding to the locale.
