### PR TITLE
Reverse a joint's direction on the model, not only in the URDF

### DIFF
--- a/skrobot/model/joint.py
+++ b/skrobot/model/joint.py
@@ -215,6 +215,96 @@ class Joint(object):
         """
         return self.joint_dof > 0
 
+    def flip_axis(self):
+        """Reverse this joint's positive direction, leaving the robot as it is.
+
+        The joint reaches the same poses afterwards; only the sign of the
+        value that commands it changes. Three things move together:
+
+        - ``axis`` is negated;
+        - ``min_angle`` and ``max_angle`` are swapped and negated, so
+          ``[-0.5, 2.0]`` becomes ``[-2.0, 0.5]``. A bound changes side
+          rather than merely sign: ``q <= U`` is ``q' >= -U``;
+        - the current joint value becomes its own negative, which is the
+          same configuration written in the reversed convention.
+
+        Nothing in the model moves. The child link is driven back to zero
+        and out again to re-express the pose, with the limits opened for
+        that trip: the old range and the new one need not overlap -- a
+        joint limited to ``[0.5, 1.0]`` cannot pass through zero -- and
+        :meth:`joint_angle` clamps rather than refuses, which would leave
+        the robot somewhere nobody asked for.
+
+        Hooks stay silent throughout, for the same reason. A mimic
+        follower is already where it belongs, and firing its hook with the
+        negated value would drive it away; re-signing the coupling is the
+        caller's to do, as :func:`~skrobot.urdf.flip_joint_axis` does for
+        a URDF.
+
+        Returns
+        -------
+        flipped : bool
+            False when there is no single direction to reverse: a
+            :class:`FixedJoint`, a joint whose axis is the zero vector, or
+            a joint with more than one degree of freedom, whose ``axis``
+            is a set of axes rather than one. Nothing is modified then.
+
+        Raises
+        ------
+        ValueError
+            When a joint limit table is attached. Its bounds are functions
+            of another joint's angle written in this joint's old sense, so
+            leaving them would let the table contradict the axis, and
+            rewriting them is not this method's to guess.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from skrobot.model import Link, RotationalJoint
+        >>> joint = RotationalJoint(parent_link=Link(name='p'),
+        ...                         child_link=Link(name='c'),
+        ...                         axis='z', min_angle=-0.5, max_angle=2.0)
+        >>> joint.joint_angle(1.0)
+        1.0
+        >>> joint.flip_axis()
+        True
+        >>> bool(np.allclose(joint.axis, [0, 0, -1]))
+        True
+        >>> joint.joint_angle()
+        -1.0
+        >>> (joint.min_angle, joint.max_angle)
+        (-2.0, 0.5)
+
+        See Also
+        --------
+        skrobot.urdf.flip_joint_axis : the same reversal on a URDF document.
+        """
+        if self.joint_dof != 1:
+            return False
+        axis = getattr(self, 'axis', None)
+        if axis is None:
+            return False
+        axis = np.array(axis, dtype=np.float64).flatten()
+        if axis.shape != (3,) or not np.any(axis):
+            return False
+        if self.joint_min_max_table is not None:
+            raise ValueError(
+                '{} carries a joint limit table, whose bounds are written '
+                'in the sense this would reverse; flip it with the table '
+                'rebuilt, or drop the table first'.format(self))
+
+        value = self.joint_angle()
+        min_angle, max_angle = self.min_angle, self.max_angle
+
+        self.min_angle, self.max_angle = -np.inf, np.inf
+        try:
+            self.joint_angle(0.0, enable_hook=False)
+            self.axis = -axis
+        finally:
+            self.min_angle, self.max_angle = -max_angle, -min_angle
+        self.joint_angle(-value, enable_hook=False)
+        return True
+
     def joint_angle(self, v=None, relative=None, enable_hook=True):
         raise NotImplementedError
 

--- a/tests/skrobot_tests/model_tests/test_joint_flip_axis.py
+++ b/tests/skrobot_tests/model_tests/test_joint_flip_axis.py
@@ -1,0 +1,147 @@
+import unittest
+
+import numpy as np
+
+from skrobot.model import FixedJoint
+from skrobot.model import FloatingJoint
+from skrobot.model import LinearJoint
+from skrobot.model import Link
+from skrobot.model import OmniWheelJoint
+from skrobot.model import PlanarJoint
+from skrobot.model import RotationalJoint
+from skrobot.model.joint_limit_table import JointLimitTable
+
+
+def _arm(cls=RotationalJoint, axis='z', min_angle=-np.pi, max_angle=np.pi):
+    """A parent link with one joint driving a child link 10cm away."""
+    base = Link(name='base_link')
+    arm = Link(name='arm_link', pos=[0.1, 0.0, 0.0])
+    joint = cls(name='arm_joint', parent_link=base, child_link=arm,
+                axis=axis, min_angle=min_angle, max_angle=max_angle)
+    base.add_child_link(arm)
+    arm.add_parent_link(base)
+    arm.add_joint(joint)
+    base.assoc(arm, relative_coords='local')
+    return base, arm, joint
+
+
+class TestJointFlipAxis(unittest.TestCase):
+
+    def test_it_negates_the_axis_and_swaps_the_limits(self):
+        _base, _child, joint = _arm(min_angle=-0.5, max_angle=2.0)
+
+        self.assertTrue(joint.flip_axis())
+
+        np.testing.assert_allclose(joint.axis, [0, 0, -1], atol=1e-12)
+        self.assertEqual(joint.min_angle, -2.0)
+        self.assertEqual(joint.max_angle, 0.5)
+
+    def test_a_posed_joint_does_not_move(self):
+        """The point of the method: the sign changes, the robot does not."""
+        _base, arm, joint = _arm()
+        joint.joint_angle(0.7)
+        before_pos = arm.worldpos().copy()
+        before_rot = arm.worldrot().copy()
+
+        joint.flip_axis()
+
+        np.testing.assert_allclose(arm.worldpos(), before_pos, atol=1e-9)
+        np.testing.assert_allclose(arm.worldrot(), before_rot, atol=1e-9)
+        self.assertEqual(joint.joint_angle(), -0.7)
+
+    def test_a_range_that_excludes_zero_survives_the_flip(self):
+        """The value passes through zero on the way and the limits forbid it.
+
+        ``joint_angle`` clamps rather than refuses, so a flip that did not
+        open the limits for the trip would leave the arm at 0.5 rad and
+        report it as if the user had asked for that.
+        """
+        _base, arm, joint = _arm(min_angle=0.5, max_angle=1.0)
+        joint.joint_angle(0.8)
+        before_pos = arm.worldpos().copy()
+
+        joint.flip_axis()
+
+        self.assertEqual(joint.joint_angle(), -0.8)
+        self.assertEqual((joint.min_angle, joint.max_angle), (-1.0, -0.5))
+        np.testing.assert_allclose(arm.worldpos(), before_pos, atol=1e-9)
+
+    def test_flipping_twice_gives_the_joint_back(self):
+        _base, arm, joint = _arm(axis='y', min_angle=-0.5, max_angle=1.2)
+        joint.joint_angle(0.3)
+        before_pos = arm.worldpos().copy()
+
+        joint.flip_axis()
+        joint.flip_axis()
+
+        np.testing.assert_allclose(joint.axis, [0, 1, 0], atol=1e-12)
+        self.assertEqual((joint.min_angle, joint.max_angle), (-0.5, 1.2))
+        self.assertEqual(joint.joint_angle(), 0.3)
+        np.testing.assert_allclose(arm.worldpos(), before_pos, atol=1e-9)
+
+    def test_a_continuous_joint_keeps_its_unbounded_range(self):
+        _base, _child, joint = _arm(min_angle=-np.inf, max_angle=np.inf)
+
+        self.assertTrue(joint.flip_axis())
+
+        self.assertEqual(joint.min_angle, -np.inf)
+        self.assertEqual(joint.max_angle, np.inf)
+
+    def test_a_linear_joint_flips_the_same_way(self):
+        _base, arm, joint = _arm(cls=LinearJoint, min_angle=-0.2, max_angle=0.5)
+        joint.joint_angle(0.3)
+        before_pos = arm.worldpos().copy()
+
+        self.assertTrue(joint.flip_axis())
+
+        np.testing.assert_allclose(joint.axis, [0, 0, -1], atol=1e-12)
+        self.assertEqual((joint.min_angle, joint.max_angle), (-0.5, 0.2))
+        self.assertEqual(joint.joint_angle(), -0.3)
+        np.testing.assert_allclose(arm.worldpos(), before_pos, atol=1e-9)
+
+    def test_a_joint_with_no_single_direction_is_left_alone(self):
+        """A fixed joint has no direction; a multi-DOF one has several."""
+        base, arm = Link(name='p'), Link(name='c')
+        self.assertFalse(
+            FixedJoint(parent_link=base, child_link=arm).flip_axis())
+        for cls in (PlanarJoint, FloatingJoint, OmniWheelJoint):
+            joint = cls(parent_link=Link(name='p'), child_link=Link(name='c'))
+            self.assertFalse(joint.flip_axis(),
+                             '{} has no single axis'.format(cls.__name__))
+
+    def test_a_mimic_follower_is_not_dragged_along(self):
+        """Flipping a leader must not move the joints hooked to it.
+
+        The follower is already in the pose the mechanism holds; the
+        coupling is what needs re-signing, and that is the caller's job.
+        """
+        _base, _child, leader = _arm()
+        _fbase, follower_link, follower = _arm()
+        leader.joint_angle(0.5)
+        follower.joint_angle(1.0)
+        leader.register_mimic_joint(follower, multiplier=2.0, offset=0.0)
+        follower_pos = follower_link.worldpos().copy()
+
+        leader.flip_axis()
+
+        self.assertEqual(follower.joint_angle(), 1.0)
+        np.testing.assert_allclose(
+            follower_link.worldpos(), follower_pos, atol=1e-9)
+
+    def test_a_joint_limit_table_is_refused_rather_than_contradicted(self):
+        _base, _child, joint = _arm()
+        _tbase, _tchild, target = _arm()
+        joint.joint_min_max_table = JointLimitTable(
+            target, -np.pi / 2.0, np.pi / 2.0,
+            np.array([-1.0, -0.5]), np.array([1.0, 0.5]))
+        joint.joint_min_max_target = target
+
+        with self.assertRaises(ValueError):
+            joint.flip_axis()
+
+        # Nothing was changed on the way to refusing.
+        np.testing.assert_allclose(joint.axis, [0, 0, 1], atol=1e-12)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
flip_joint_axis rewrites a URDF; Joint.flip_axis does the same to a loaded robot -- negate the axis, swap the limits, re-express the current value as its own negative -- so nothing moves and only the sign of the command changes.