### PR TITLE
Load URDFs with a floating base, a reused name, or an unnamed actuator

### DIFF
--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -3361,9 +3361,25 @@ class RobotModel(CascadedLink):
                     max_angle=j.limit.upper,
                     max_joint_torque=j.limit.effort,
                     max_joint_velocity=velocity)
+            else:
+                # 'floating' (6-DoF) and 'planar' (2-DoF) have no joint
+                # class here, and neither does a type we do not know.
+                # Attach the child rigidly at the joint origin, the pose
+                # Joint.get_child_pose already gives those two at zero
+                # configuration, so the kinematic tree stays whole
+                # instead of leaving the joint unbuilt.
+                logger.warning(
+                    "Joint '%s' has type '%s', which is not supported. "
+                    'Treating it as a fixed joint, so its degrees of '
+                    'freedom are not represented in this model.',
+                    j.name, j.joint_type)
+                joint = FixedJoint(
+                    name=j.name,
+                    parent_link=link_maps[j.parent],
+                    child_link=link_maps[j.child])
 
             is_mimic = j.name in mimic_joint_names
-            if j.joint_type != 'fixed':
+            if not isinstance(joint, FixedJoint):
                 if include_mimic_joints or not is_mimic:
                     joint_list.append(joint)
             whole_joint_list.append(joint)
@@ -3446,7 +3462,10 @@ class RobotModel(CascadedLink):
         if root_link is None:
             self.root_link = None
         else:
-            self.root_link = self.__dict__[root_link.name]
+            # Look the link up among the links. URDF keeps link and joint
+            # names in separate namespaces, so a joint may share the base
+            # link's name and overwrite it in ``__dict__`` just above.
+            self.root_link = link_maps[root_link.name]
             self.assoc(self.root_link)
 
         # Add hook of mimic joint.

--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -2044,8 +2044,10 @@ class Actuator(URDFType):
 
     Parameters
     ----------
-    name : str
-        The name of this actuator.
+    name : str, optional
+        The name of this actuator. The URDF spec makes it mandatory, but
+        published models leave it out, and nothing here reads it, so a
+        missing name must not abort loading the robot.
     mechanicalReduction : str, optional
         A specifier for the mechanical reduction at the joint/actuator
         transmission.
@@ -2053,11 +2055,11 @@ class Actuator(URDFType):
         The supported hardware interfaces to the actuator.
     """
     _ATTRIBS = {
-        'name': (str, True),
+        'name': (str, False),
     }
     _TAG = 'actuator'
 
-    def __init__(self, name, mechanicalReduction=None,
+    def __init__(self, name=None, mechanicalReduction=None,
                  hardwareInterfaces=None):
         self.name = name
         self.mechanicalReduction = mechanicalReduction
@@ -2072,7 +2074,7 @@ class Actuator(URDFType):
 
     @name.setter
     def name(self, value):
-        self._name = str(value)
+        self._name = None if value is None else str(value)
 
     @property
     def mechanicalReduction(self):

--- a/tests/skrobot_tests/test_urdf_load_quirks.py
+++ b/tests/skrobot_tests/test_urdf_load_quirks.py
@@ -1,0 +1,138 @@
+"""URDF constructs that other parsers accept but that aborted the load here.
+
+Each case below comes from a published robot description. None of them is
+exotic, and every one of them raised before reaching a usable model.
+"""
+
+import unittest
+
+from skrobot.model import Link
+from skrobot.models.urdf import RobotModelFromURDF
+
+
+def urdf(joints, extra=''):
+    """Wrap link/joint XML in a minimal robot."""
+    return """<?xml version="1.0"?>
+<robot name="quirky">
+  <link name="base"/>
+  <link name="body"/>
+  <link name="tip"/>
+  {}
+  {}
+</robot>""".format(joints, extra)
+
+
+REVOLUTE = """
+  <joint name="elbow" type="revolute">
+    <parent link="body"/>
+    <child link="tip"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1" upper="1" effort="1" velocity="1"/>
+  </joint>"""
+
+
+class TestUnsupportedJointType(unittest.TestCase):
+    """A floating base must not take the whole model down with it.
+
+    ``floating`` and ``planar`` have no counterpart among the joint
+    classes, so the load left the joint object unbuilt and then raised
+    ``UnboundLocalError`` on it. Quadrupeds and drones ship a floating
+    base routinely.
+    """
+
+    def load(self, joint_type):
+        joints = """
+  <joint name="root_joint" type="{}">
+    <parent link="base"/>
+    <child link="body"/>
+  </joint>""".format(joint_type) + REVOLUTE
+        return RobotModelFromURDF(urdf=urdf(joints))
+
+    def test_floating_joint_loads(self):
+        robot = self.load('floating')
+        self.assertEqual(['base', 'body', 'tip'],
+                         sorted(link.name for link in robot.link_list))
+
+    def test_unsupported_joint_is_not_actuated(self):
+        # It carries no angle we can set, so it has no place among the
+        # joints the model drives.
+        robot = self.load('floating')
+        self.assertEqual(['elbow'], [j.name for j in robot.joint_list])
+
+    def test_unsupported_joint_keeps_the_tree_whole(self):
+        # Dropping the joint instead would orphan every link below it.
+        robot = self.load('planar')
+        self.assertIs(robot.base, robot.body.parent_link)
+        self.assertIs(robot.body, robot.tip.parent_link)
+
+    def test_unsupported_joint_is_reported(self):
+        with self.assertLogs('skrobot.model.robot_model', level='WARNING') \
+                as captured:
+            self.load('floating')
+        self.assertIn('floating', '\n'.join(captured.output))
+
+
+class TestNameSharedByLinkAndJoint(unittest.TestCase):
+    """URDF names links and joints in separate namespaces.
+
+    A joint may therefore carry the base link's name. Both were written
+    into the model's attributes under that one name, the joint last, so
+    the base link lookup returned a joint and the load raised.
+    """
+
+    def load(self):
+        joints = """
+  <joint name="base" type="fixed">
+    <parent link="base"/>
+    <child link="body"/>
+  </joint>""" + REVOLUTE
+        return RobotModelFromURDF(urdf=urdf(joints))
+
+    def test_root_link_is_a_link(self):
+        robot = self.load()
+        self.assertIsInstance(robot.root_link, Link)
+        self.assertEqual('base', robot.root_link.name)
+
+    def test_forward_kinematics_runs(self):
+        robot = self.load()
+        robot.elbow.joint_angle(0.5)
+        self.assertTrue(robot.tip.worldcoords().translation.shape == (3,))
+
+
+class TestActuatorWithoutName(unittest.TestCase):
+    """``<actuator>`` is ros_control metadata, not kinematics.
+
+    The spec makes its name mandatory and models omit it anyway. Nothing
+    here reads the name, so its absence must not abort the load.
+    """
+
+    def load(self):
+        transmission = """
+  <transmission name="elbow_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="elbow">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
+    <actuator>
+      <mechanicalReduction>25</mechanicalReduction>
+    </actuator>
+  </transmission>"""
+        joints = """
+  <joint name="waist" type="fixed">
+    <parent link="base"/>
+    <child link="body"/>
+  </joint>""" + REVOLUTE
+        return RobotModelFromURDF(urdf=urdf(joints, transmission))
+
+    def test_model_loads(self):
+        robot = self.load()
+        self.assertEqual(['elbow'], [j.name for j in robot.joint_list])
+
+    def test_missing_name_stays_missing(self):
+        robot = self.load()
+        actuator = robot.urdf_robot_model.transmissions[0].actuators[0]
+        self.assertIsNone(actuator.name)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A `floating` or `planar` joint had no branch, so the joint object was never built and the load raised `UnboundLocalError`; an unsupported type now attaches the child rigidly at the joint origin with a warning, which is the pose `Joint.get_child_pose` already returns for those two at zero configuration.

URDF keeps link and joint names in separate namespaces, so a joint sharing the base link's name overwrote that link in the model's attributes and `root_link` came back as a joint; it is now resolved among the links.

An `<actuator>` with no name aborted the parse even though nothing here reads that name, so the name is optional now.