### PR TITLE
Treat prismatic joints as translations in trajectory-optimization FK

### DIFF
--- a/skrobot/planner/trajectory_optimization/fk_utils.py
+++ b/skrobot/planner/trajectory_optimization/fk_utils.py
@@ -19,6 +19,9 @@ def build_fk_functions(fk_data, backend):
         - link_translations: (n_joints, 3) link translations
         - link_rotations: (n_joints, 3, 3) link rotations
         - joint_axes: (n_joints, 3) joint axes
+        - joint_types: (n_joints,) joint type strings. A 'prismatic' joint
+          translates along its axis; anything else rotates about it. If the
+          key is absent every joint is treated as rotational.
         - base_position: (3,) base position
         - base_rotation: (3, 3) base rotation
         - n_joints: int
@@ -44,6 +47,7 @@ def build_fk_functions(fk_data, backend):
     base_rot = fk_data['base_rotation']
     n_joints = fk_data['n_joints']
     ref_angles = fk_data.get('ref_angles')
+    joint_types = fk_data.get('joint_types')
 
     coll_link_idx = fk_data.get('collision_link_to_chain_idx')
     coll_offsets_pos = fk_data.get('collision_link_offsets_pos')
@@ -78,8 +82,12 @@ def build_fk_functions(fk_data, backend):
             delta = angles[i]
             if ref_angles is not None:
                 delta = delta - ref_angles[i]
-            joint_rot = rodrigues_rotation(xp, joint_axes[i], delta)
-            current_rot = current_rot @ joint_rot
+            if joint_types is not None and joint_types[i] == 'prismatic':
+                current_pos = current_pos \
+                    + current_rot @ (joint_axes[i] * delta)
+            else:
+                joint_rot = rodrigues_rotation(xp, joint_axes[i], delta)
+                current_rot = current_rot @ joint_rot
             positions.append(current_pos)
             rotations.append(current_rot)
 
@@ -384,6 +392,9 @@ def prepare_fk_data(problem, backend):
         'link_translations': xp.array(fk_params['link_translations']),
         'link_rotations': xp.array(fk_params['link_rotations']),
         'joint_axes': xp.array(fk_params['joint_axes']),
+        # Kept as a Python list: it selects the branch in
+        # build_fk_functions rather than taking part in the arithmetic.
+        'joint_types': list(fk_params['joint_types']),
         'base_position': xp.array(fk_params['base_position']),
         'base_rotation': xp.array(fk_params['base_rotation']),
         'n_joints': fk_params['n_joints'],

--- a/tests/skrobot_tests/planner_tests/test_trajectory_optimization.py
+++ b/tests/skrobot_tests/planner_tests/test_trajectory_optimization.py
@@ -245,6 +245,48 @@ class TestTrajectoryProblem(unittest.TestCase):
             self.assertIn(key, fk, msg=f"Missing key: {key}")
 
 
+class TestPrismaticFK(unittest.TestCase):
+    """A prismatic joint must slide along its axis, not rotate about it.
+
+    Fetch is used because its torso lift is prismatic while the arm joints
+    are rotational, so one chain exercises both branches.
+    """
+
+    def test_link_transforms_match_robot_with_prismatic_joint(self):
+        robot = skrobot.models.Fetch()
+        joint_names = [
+            'torso_lift_joint',      # prismatic
+            'shoulder_pan_joint',
+            'shoulder_lift_joint',
+            'upperarm_roll_joint',
+            'elbow_flex_joint',
+        ]
+        link_list = [getattr(robot, n.replace('_joint', '_link'))
+                     for n in joint_names]
+        # A raised torso is what separates translation from rotation here:
+        # at zero lift both interpretations agree.
+        angles = np.array([0.3, 0.2, -0.3, 0.4, 0.5])
+        for link, angle in zip(link_list, angles):
+            link.joint.joint_angle(angle)
+
+        problem = TrajectoryProblem(
+            robot, link_list, n_waypoints=3,
+            move_target=robot.rarm_end_coords)
+        fk_data = prepare_fk_data(problem, np)
+        get_link_transforms, _, _, _ = build_fk_functions(fk_data, np)
+        positions, _ = get_link_transforms(angles)
+
+        # Assert the positions first. Treating the lift as rotational puts
+        # the tip about 0.35 m away, and that is the failure this guards
+        # against; checking joint_types first would hide it behind a
+        # KeyError.
+        for i, link in enumerate(link_list):
+            testing.assert_almost_equal(
+                positions[i], link.worldpos(), decimal=4,
+                err_msg="Position mismatch at {}".format(link.joint.name))
+        self.assertEqual(fk_data['joint_types'][0], 'prismatic')
+
+
 class TestFKUtils(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
build_fk_functions applied rodrigues_rotation to every joint, so a prismatic joint rotated about its axis instead of sliding along it. On Fetch, a 0.3 m torso lift puts the arm tip 0.35 m away from where the robot actually is, silently corrupting IK and trajectory optimisation over any chain containing one.

extract_fk_parameters already returns joint_types and the rest of skrobot.kinematics.differentiable already branches on it; only trajectory_optimization/fk_utils.py ignored it. prepare_fk_data now passes it through and build_fk_functions branches, falling back to rotation when the key is absent so existing callers are unaffected.

Includes a regression test on Fetch, whose torso lift is prismatic while the arm joints are rotational, comparing link transforms against the robot's own worldpos; it fails by 0.3 m without the fix.