### PR TITLE
Keep loading a URDF whose optional elements are left half-written

### DIFF
--- a/skrobot/utils/urdf.py
+++ b/skrobot/utils/urdf.py
@@ -1189,20 +1189,22 @@ class Texture(URDFType):
 
     Parameters
     ----------
-    filename : str
+    filename : str, optional
         The path to the image that contains this texture. This can be
-        relative to the top-level URDF or an absolute path.
+        relative to the top-level URDF or an absolute path. Models omit
+        it, and a texture without one is a material's decoration, not a
+        reason to reject the robot it decorates.
     image : :class:`PIL.Image.Image`, optional
         The image for the texture.
         If not specified, it is loaded automatically from the filename.
     """
 
     _ATTRIBS = {
-        'filename': (str, True)
+        'filename': (str, False)
     }
     _TAG = 'texture'
 
-    def __init__(self, filename, image=None):
+    def __init__(self, filename=None, image=None):
         self.filename = filename
         if image is None:
             if filename and os.path.exists(filename):
@@ -1246,9 +1248,11 @@ class Texture(URDFType):
         kwargs = cls._parse(node, path)
 
         # Load image
-        fn = get_filename(path, kwargs['filename'])
-        if fn and os.path.exists(fn):
-            kwargs['image'] = PIL.Image.open(fn)
+        filename = kwargs.get('filename')
+        if filename:
+            fn = get_filename(path, filename)
+            if fn and os.path.exists(fn):
+                kwargs['image'] = PIL.Image.open(fn)
 
         return Texture(**kwargs)
 
@@ -1269,22 +1273,24 @@ class Material(URDFType):
 
     Parameters
     ----------
-    name : str
-        The name of the material.
+    name : str, optional
+        The name of the material. The spec makes it mandatory and it is
+        how one material refers to another, but a `<material>` that
+        carries its colour inline needs no name and models leave it out.
     color : (4,) float, optional
         The RGBA color of the material in the range [0,1].
     texture : :class:`.Texture`, optional
         A texture for the material.
     """
     _ATTRIBS = {
-        'name': (str, True)
+        'name': (str, False)
     }
     _ELEMENTS = {
         'texture': (Texture, False, False),
     }
     _TAG = 'material'
 
-    def __init__(self, name, color=None, texture=None):
+    def __init__(self, name=None, color=None, texture=None):
         self.name = name
         self.color = color
         self.texture = texture
@@ -1298,7 +1304,7 @@ class Material(URDFType):
 
     @name.setter
     def name(self, value):
-        self._name = str(value)
+        self._name = None if value is None else str(value)
 
     @property
     def color(self):
@@ -1627,14 +1633,31 @@ class Inertial(URDFType):
     @classmethod
     def _from_xml(cls, node, path):
         origin = parse_origin(node)
-        mass = float(node.find('mass').attrib['value'])
-        n = node.find('inertia')
-        xx = float(n.attrib['ixx'])
-        xy = float(n.attrib['ixy'])
-        xz = float(n.attrib['ixz'])
-        yy = float(n.attrib['iyy'])
-        yz = float(n.attrib['iyz'])
-        zz = float(n.attrib['izz'])
+        # A hand-written <inertial> often carries an origin and a mass
+        # and stops there, or gives an inertia with some terms left
+        # out. Reading what is present and defaulting the rest keeps
+        # the link, and the robot; insisting on all of it discards a
+        # model over numbers most callers never ask for.
+        mass_node = node.find('mass')
+        mass = 0.0
+        if mass_node is not None and 'value' in mass_node.attrib:
+            mass = float(mass_node.attrib['value'])
+        else:
+            logger.warning('<inertial> without a mass; assuming zero')
+
+        moments = node.find('inertia')
+        if moments is None:
+            logger.warning('<inertial> without an inertia; assuming zero')
+            moments = ET.Element('inertia')
+
+        def term(name):
+            try:
+                return float(moments.attrib[name])
+            except (KeyError, ValueError):
+                return 0.0
+
+        xx, xy, xz = term('ixx'), term('ixy'), term('ixz')
+        yy, yz, zz = term('iyy'), term('iyz'), term('izz')
         inertia = np.array([
             [xx, xy, xz],
             [xy, yy, yz],
@@ -2111,7 +2134,16 @@ class Actuator(URDFType):
         kwargs = cls._parse(node, path)
         mr = node.find('mechanicalReduction')
         if mr is not None:
-            mr = float(mr.text)
+            try:
+                mr = float(mr.text)
+            except (TypeError, ValueError):
+                # Templates ship the word rather than a ratio. Nothing
+                # here reads it, so record that it was unusable and
+                # carry on rather than refusing the whole model.
+                logger.warning(
+                    '<mechanicalReduction> is %r, not a number; ignoring',
+                    mr.text)
+                mr = None
         kwargs['mechanicalReduction'] = mr
         hi = node.findall('hardwareInterface')
         if len(hi) > 0:

--- a/tests/skrobot_tests/test_urdf_incomplete_elements.py
+++ b/tests/skrobot_tests/test_urdf_incomplete_elements.py
@@ -1,0 +1,147 @@
+"""Elements a URDF leaves half-written, which other parsers tolerate.
+
+Each of these is malformed by the spec and ordinary in practice, and
+each one used to raise from deep inside the parser and take the whole
+robot with it. None of them describes kinematics: a texture, a material
+name, an inertia, a gear ratio nothing reads. Losing the model over any
+of them costs far more than the element was worth.
+"""
+
+import unittest
+
+from skrobot.models.urdf import RobotModelFromURDF
+
+
+def urdf(link_extra='', extra=''):
+    """Wrap the fragment under test in a robot that would load without it."""
+    return """<?xml version="1.0"?>
+<robot name="incomplete">
+  <link name="base">
+    {}
+  </link>
+  <link name="tip"/>
+  <joint name="elbow" type="revolute">
+    <parent link="base"/>
+    <child link="tip"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1" upper="1" effort="1" velocity="1"/>
+  </joint>
+  {}
+</robot>""".format(link_extra, extra)
+
+
+class TestMaterialWithoutName(unittest.TestCase):
+    """``<material>`` carrying its colour inline needs no name.
+
+    The spec says the attribute is required -- it is how one material
+    refers to another -- but a material that states its own colour
+    refers to nothing, and models leave the name out.
+    """
+
+    def test_model_loads(self):
+        robot = RobotModelFromURDF(urdf(link_extra="""
+    <visual>
+      <geometry><box size="1 1 1"/></geometry>
+      <material><color rgba="1 0 0 1"/></material>
+    </visual>"""))
+        self.assertEqual(['base', 'tip'],
+                         sorted(link.name for link in robot.link_list))
+
+    def test_colour_survives(self):
+        # The point of an unnamed material is the colour it carries. The
+        # loader already names such a material for itself once it is
+        # built -- it never got that far, because the constructor
+        # refused to build one at all.
+        robot = RobotModelFromURDF(urdf(link_extra="""
+    <visual>
+      <geometry><box size="1 1 1"/></geometry>
+      <material><color rgba="1 0 0 1"/></material>
+    </visual>"""))
+        material = robot.urdf_robot_model.links[0].visuals[0].material
+        self.assertAlmostEqual(1.0, material.color[0])
+        self.assertAlmostEqual(0.0, material.color[1])
+        self.assertTrue(material.name.startswith('__unnamed_material'))
+
+
+class TestTextureWithoutFilename(unittest.TestCase):
+    """``<texture>`` with no file named is decoration, not kinematics."""
+
+    def test_model_loads(self):
+        robot = RobotModelFromURDF(urdf(link_extra="""
+    <visual>
+      <geometry><box size="1 1 1"/></geometry>
+      <material name="painted"><texture/></material>
+    </visual>"""))
+        self.assertEqual(2, len(robot.link_list))
+
+
+class TestIncompleteInertial(unittest.TestCase):
+    """``<inertial>`` that stops after the mass, or omits terms.
+
+    Hand-written descriptions do this constantly. The link still has a
+    shape and a place in the tree, which is what most callers want from
+    it.
+    """
+
+    def test_inertial_without_inertia(self):
+        robot = RobotModelFromURDF(urdf(link_extra="""
+    <inertial>
+      <origin xyz="0 0 0"/>
+      <mass value="2.5"/>
+    </inertial>"""))
+        self.assertEqual(2, len(robot.link_list))
+        inertial = robot.urdf_robot_model.links[0].inertial
+        self.assertAlmostEqual(2.5, inertial.mass)
+
+    def test_inertial_without_mass(self):
+        robot = RobotModelFromURDF(urdf(link_extra="""
+    <inertial>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>"""))
+        self.assertAlmostEqual(0.0, robot.urdf_robot_model.links[0].inertial.mass)
+
+    def test_inertia_missing_terms(self):
+        # Only the diagonal given; the products of inertia are zero.
+        robot = RobotModelFromURDF(urdf(link_extra="""
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="2" iyy="3" izz="4"/>
+    </inertial>"""))
+        inertia = robot.urdf_robot_model.links[0].inertial.inertia
+        self.assertAlmostEqual(2.0, inertia[0][0])
+        self.assertAlmostEqual(0.0, inertia[0][1])
+
+
+class TestUnusableMechanicalReduction(unittest.TestCase):
+    """``<mechanicalReduction>`` holding a word instead of a ratio.
+
+    Package templates ship the placeholder and nobody replaces it. The
+    value is ros_control metadata that nothing here reads.
+    """
+
+    def test_model_loads(self):
+        robot = RobotModelFromURDF(urdf(extra="""
+  <transmission name="elbow_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="elbow"><hardwareInterface>Effort</hardwareInterface></joint>
+    <actuator name="elbow_motor">
+      <mechanicalReduction>reduction</mechanicalReduction>
+    </actuator>
+  </transmission>"""))
+        self.assertEqual(['elbow'], [j.name for j in robot.joint_list])
+
+    def test_unusable_value_is_dropped(self):
+        robot = RobotModelFromURDF(urdf(extra="""
+  <transmission name="elbow_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="elbow"><hardwareInterface>Effort</hardwareInterface></joint>
+    <actuator name="elbow_motor">
+      <mechanicalReduction>reduction</mechanicalReduction>
+    </actuator>
+  </transmission>"""))
+        actuator = robot.urdf_robot_model.transmissions[0].actuators[0]
+        self.assertIsNone(actuator.mechanicalReduction)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Four elements that published URDFs routinely leave incomplete each raised from inside the parser and took the whole robot with it: a `<material>` with no `name`, a `<texture>` with no `filename`, an `<inertial>` missing its `<mass>` or `<inertia>`, and a `<mechanicalReduction>` still holding the word a package template put there.

None of the four describes kinematics, so a model is now kept and the gap reported instead — an unnamed material keeps its colour (the loader already names such materials once they are built, it just never got that far), a missing inertia term reads as zero, and an unusable gear ratio is dropped with a warning.

Tests cover all four through the loader, and each fails without the corresponding fix.