### PR TITLE
Add an optimization-based inverse kinematics entry point

### DIFF
--- a/skrobot/planner/__init__.py
+++ b/skrobot/planner/__init__.py
@@ -1,5 +1,7 @@
 # flake8: noqa
 
 from skrobot.planner.collision_checker import SweptSphereSdfCollisionChecker
+from skrobot.planner.inverse_kinematics_optimization import box_to_spheres
+from skrobot.planner.inverse_kinematics_optimization import solve_ik
 from skrobot.planner.sqp_based import sqp_plan_trajectory
 from skrobot.planner import trajectory_optimization

--- a/skrobot/planner/inverse_kinematics_optimization.py
+++ b/skrobot/planner/inverse_kinematics_optimization.py
@@ -1,0 +1,710 @@
+"""High-level inverse kinematics via trajectory optimization.
+
+This module wraps :class:`skrobot.planner.trajectory_optimization.TrajectoryProblem`
+so that a caller can pose a single-shot or trajectory IK problem
+(optionally with sphere obstacles) without having to wire residuals,
+endpoint constraints and a solver by hand.
+
+The key entry point is :func:`solve_ik`. It always builds a multi-waypoint
+problem; when the caller passes a single :class:`Coordinates` target the
+problem is treated as ``start_config -> target`` with the start fixed,
+and only the final waypoint angle vector is returned as the IK answer.
+When a list of targets is given, the targets are tracked at the
+corresponding waypoints.
+"""
+
+import numpy as np
+
+from skrobot.coordinates import Coordinates
+from skrobot.planner.trajectory_optimization import create_solver
+from skrobot.planner.trajectory_optimization import TrajectoryProblem
+
+
+def _coerce_targets(target_coords):
+    """Return a list of Coordinates regardless of input shape."""
+    if isinstance(target_coords, Coordinates):
+        return [target_coords]
+    return list(target_coords)
+
+
+def _stack_targets(targets, n_waypoints):
+    """Build (n_waypoints, 3) positions and (n_waypoints, 3, 3) rotations.
+
+    If only one target is given, it is broadcast to every waypoint.
+    Otherwise the list must already match n_waypoints.
+    """
+    if len(targets) == 1:
+        positions = np.tile(targets[0].worldpos(), (n_waypoints, 1))
+        rotations = np.tile(targets[0].worldrot(), (n_waypoints, 1, 1))
+    else:
+        if len(targets) != n_waypoints:
+            raise ValueError(
+                'len(target_coords) ({}) must equal n_waypoints ({}) '
+                'when passing a list of targets'.format(
+                    len(targets), n_waypoints))
+        positions = np.stack([t.worldpos() for t in targets])
+        rotations = np.stack([t.worldrot() for t in targets])
+    return positions, rotations
+
+
+def _current_angles(joint_list):
+    return np.array(
+        [j.joint_angle() for j in joint_list], dtype=np.float64)
+
+
+def _apply_angles(joint_list, angles):
+    for j, q in zip(joint_list, angles):
+        j.joint_angle(q)
+
+
+def solve_ik(
+    robot_model,
+    link_list,
+    move_target,
+    target_coords,
+    *,
+    n_waypoints=None,
+    initial_angles=None,
+    collision_link_list=None,
+    world_obstacles=None,
+    solver='jaxls',
+    max_iterations=200,
+    position_weight=10.0,
+    rotation_weight=1.0,
+    smoothness_weight=0.01,
+    collision_weight=1000.0,
+    collision_activation=0.05,
+    collision_as_constraint=True,
+    n_spheres_per_link=5,
+    position_mask=None,
+    rotation_mask=None,
+    apply_result=True,
+    compute_torque=True,
+    verbose=False,
+):
+    """Solve IK by minimising a TrajectoryProblem.
+
+    The problem keeps the start waypoint fixed at ``initial_angles``
+    (defaults to the robot's current joint configuration) and lets the
+    remaining waypoints float. End-effector pose tracking is done with
+    :meth:`TrajectoryProblem.add_cartesian_path_cost`.
+
+    Parameters
+    ----------
+    robot_model : skrobot.model.RobotModel
+        Robot model whose joints will be optimised.
+    link_list : list of skrobot.model.Link
+        Kinematic chain (used as the IK DoF) in root-to-tip order.
+    move_target : skrobot.coordinates.CascadedCoords
+        End-effector frame attached to the chain.
+    target_coords : Coordinates or list of Coordinates
+        Goal pose(s). A single ``Coordinates`` is treated as a static
+        target replicated over every waypoint. A list is treated as a
+        per-waypoint trajectory and must have length ``n_waypoints``.
+    n_waypoints : int, optional
+        Number of waypoints. Defaults to ``len(target_coords)`` when a
+        list is given, else 2 (start + goal).
+    initial_angles : array-like, optional
+        Joint angles to seed the start waypoint with. Defaults to the
+        current ``joint_angle()`` of each joint in the chain.
+    collision_link_list : list of Link, optional
+        Links whose swept-sphere approximation participates in the
+        collision cost. Required iff ``world_obstacles`` is given.
+    world_obstacles : list of dict, optional
+        Sphere obstacles, each ``{'type': 'sphere', 'center': (3,),
+        'radius': float}``. Box obstacles are not handled by the
+        underlying solvers; approximate them as one or more spheres
+        before passing them in.
+    solver : str
+        ``'jaxls'`` (default; Levenberg-Marquardt least squares with
+        hard-constraint support), ``'augmented_lagrangian'``,
+        ``'gradient_descent'``, or ``'scipy'``.
+    max_iterations : int
+        Iteration budget passed to the solver.
+    position_weight, rotation_weight : float
+        Weights for the Cartesian path cost.
+    smoothness_weight : float
+        Weight for the smoothness cost between consecutive waypoints.
+    collision_weight, collision_activation : float
+        Forwarded to ``add_collision_cost`` when obstacles are given.
+    collision_as_constraint : bool
+        Treat collision avoidance as a hard inequality constraint when
+        the solver supports it (jaxls / augmented_lagrangian). When
+        False, collision becomes a soft penalty controlled by
+        ``collision_weight``.
+    n_spheres_per_link : int
+        Number of swept spheres approximating each collision link.
+        Higher values mean tighter collision approximation. The
+        scikit-robot historical default is 3; we bump to 5 to give
+        roughly optmotiongen-comparable accuracy on Tycoon-sized
+        cubes.
+    position_mask, rotation_mask : array-like length 3, optional
+        Per-axis selection of which translation / rotation error
+        components contribute to the Cartesian cost. ``[0, 0, 1]``
+        keeps only Z, mirroring optmotiongen's
+        ``:translation-axis :z`` style. ``rotation_mask=[0, 0, 0]``
+        disables rotation tracking.
+    apply_result : bool
+        If True (default), set the robot joints to the final waypoint
+        angles before returning. Set to False to leave the model
+        untouched.
+    compute_torque : bool
+        If True, compute the joint torque vector at the final pose
+        using ``RobotModel.torque_vector``. Stored under
+        ``torque_vector`` in the returned dict.
+    verbose : bool
+        Forwarded to the solver.
+
+    Returns
+    -------
+    dict
+        Keys:
+
+        - ``success`` : bool reported by the solver.
+        - ``angle_vector`` : (n_joints,) array of the final waypoint.
+        - ``angle_vector_list`` : (n_waypoints, n_joints) array.
+        - ``cost`` : final objective value.
+        - ``iterations`` : iteration count.
+        - ``position_error`` : ``||ee_pos - last_target_pos||`` after
+          applying the final waypoint.
+        - ``rotation_error`` : ``angle of (ee_rot)^T * target_rot`` (rad).
+        - ``torque_vector`` : (n_joints,) array of joint torques at
+          the final pose, or ``None`` if ``compute_torque=False``.
+        - ``message`` : solver message string.
+    """
+    multi_ee = isinstance(move_target, (list, tuple))
+
+    if multi_ee:
+        # Branched / Y-shape multi-EE with shared joints. Use the
+        # union chain as the variable space, the first EE's
+        # ancestor sub-chain as the main cartesian_path cost, and
+        # ``add_extra_ee_cost`` for every additional EE. Collision
+        # avoidance, smoothness, n_waypoints, jaxls hard-constraint
+        # support, etc. all work through the standard
+        # TrajectoryProblem pipeline.
+        return _solve_ik_multi_ee_shared(
+            robot_model=robot_model,
+            link_list=link_list,
+            move_target=move_target,
+            target_coords=target_coords,
+            n_waypoints=n_waypoints,
+            initial_angles=initial_angles,
+            collision_link_list=collision_link_list,
+            world_obstacles=world_obstacles,
+            solver=solver,
+            max_iterations=max_iterations,
+            position_weight=position_weight,
+            rotation_weight=rotation_weight,
+            smoothness_weight=smoothness_weight,
+            collision_weight=collision_weight,
+            collision_activation=collision_activation,
+            collision_as_constraint=collision_as_constraint,
+            n_spheres_per_link=n_spheres_per_link,
+            position_mask=position_mask,
+            rotation_mask=rotation_mask,
+            apply_result=apply_result,
+            compute_torque=compute_torque,
+            verbose=verbose,
+        )
+
+    targets = _coerce_targets(target_coords)
+    if n_waypoints is None:
+        n_waypoints = len(targets) if len(targets) > 1 else 2
+
+    if n_waypoints < 2:
+        raise ValueError(
+            'n_waypoints must be >= 2 (got {}); the start waypoint is '
+            'always fixed.'.format(n_waypoints))
+
+    joint_list = [link.joint for link in link_list]
+    if initial_angles is None:
+        initial_angles = _current_angles(joint_list)
+    initial_angles = np.asarray(initial_angles, dtype=np.float64)
+
+    track_rotation = (rotation_weight > 0.0
+                      and (rotation_mask is None
+                           or any(rotation_mask)))
+
+    problem = TrajectoryProblem(
+        robot_model=robot_model,
+        link_list=link_list,
+        n_waypoints=n_waypoints,
+        move_target=move_target,
+    )
+    problem.set_fixed_endpoints(start=True, end=False)
+    target_positions, target_rotations = _stack_targets(
+        targets, n_waypoints)
+    if not track_rotation:
+        target_rotations = None
+    problem.add_cartesian_path_cost(
+        target_positions=target_positions,
+        target_rotations=target_rotations,
+        weight=position_weight,
+        rotation_weight=rotation_weight / max(position_weight, 1e-12),
+        position_mask=position_mask,
+        rotation_mask=rotation_mask,
+    )
+    if smoothness_weight > 0.0 and n_waypoints >= 2:
+        problem.add_smoothness_cost(weight=smoothness_weight)
+
+    if world_obstacles:
+        if not collision_link_list:
+            raise ValueError(
+                'collision_link_list is required when world_obstacles '
+                'is provided')
+        problem.add_collision_cost(
+            collision_link_list=collision_link_list,
+            world_obstacles=world_obstacles,
+            weight=collision_weight,
+            activation_distance=collision_activation,
+            as_constraint=collision_as_constraint,
+            n_spheres_per_link=n_spheres_per_link,
+        )
+
+    init_traj = np.tile(initial_angles, (n_waypoints, 1))
+    solver_obj = create_solver(
+        solver, max_iterations=max_iterations, verbose=verbose)
+    result = solver_obj.solve(problem, init_traj)
+
+    angle_vector_list = np.asarray(result.trajectory)
+    final_angles = angle_vector_list[-1]
+
+    saved_angles = _current_angles(joint_list)
+    _apply_angles(joint_list, final_angles)
+    robot_model.update()
+
+    ee_pos = move_target.worldpos()
+    ee_rot = move_target.worldrot()
+    per_ee_pos_err = [float(np.linalg.norm(
+        (ee_pos - target_positions[-1])
+        * (np.asarray(position_mask, dtype=np.float64)
+           if position_mask is not None
+           else np.ones(3))))]
+    position_error = per_ee_pos_err[0]
+    if track_rotation:
+        target_rot = _stack_targets(targets, n_waypoints)[1][-1]
+        rel = ee_rot.T @ target_rot
+        cos_angle = np.clip((np.trace(rel) - 1.0) / 2.0, -1.0, 1.0)
+        rotation_error = float(np.arccos(cos_angle))
+    else:
+        rotation_error = 0.0
+    per_ee_rot_err = [rotation_error]
+
+    torque_vector = None
+    if compute_torque:
+        try:
+            torque_vector = np.asarray(
+                robot_model.torque_vector(), dtype=np.float64)
+        except Exception:
+            torque_vector = None
+
+    if not apply_result:
+        _apply_angles(joint_list, saved_angles)
+        robot_model.update()
+
+    return {
+        'success': bool(result.success),
+        'angle_vector': np.asarray(final_angles),
+        'angle_vector_list': angle_vector_list,
+        'cost': float(result.cost),
+        'iterations': int(result.iterations),
+        'position_error': position_error,
+        'rotation_error': rotation_error,
+        'per_ee_position_error': per_ee_pos_err,
+        'per_ee_rotation_error': per_ee_rot_err,
+        'torque_vector': torque_vector,
+        'message': str(result.message),
+    }
+
+
+def _solve_ik_multi_ee_shared(
+    *,
+    robot_model,
+    link_list,
+    move_target,
+    target_coords,
+    n_waypoints,
+    initial_angles,
+    collision_link_list,
+    world_obstacles,
+    solver,
+    max_iterations,
+    position_weight,
+    rotation_weight,
+    smoothness_weight,
+    collision_weight,
+    collision_activation,
+    collision_as_constraint,
+    n_spheres_per_link,
+    position_mask,
+    rotation_mask,
+    apply_result,
+    compute_torque,
+    verbose,
+):
+    """Multi-EE IK with shared joints + collision via TrajectoryProblem.
+
+    The first chain becomes the union variable space; subsequent EEs
+    are added with ``add_extra_ee_cost``. The longest sub-chain (the
+    one with the most ancestor joints) is taken as the union, so all
+    other sub-chains' joint indices map cleanly into it.
+    """
+    if not (isinstance(link_list, list) and len(link_list) > 0
+            and isinstance(link_list[0], list)):
+        raise ValueError(
+            'multi-EE solve requires link_list to be a list of '
+            'chains (list of list of Link)')
+    if len(link_list) != len(move_target):
+        raise ValueError(
+            'len(link_list) ({}) must equal len(move_target) ({}) '
+            'in multi-EE mode'.format(len(link_list), len(move_target)))
+    if not (isinstance(target_coords, (list, tuple))
+            and len(target_coords) == len(move_target)):
+        raise ValueError(
+            'target_coords must be a list of {} entries (one per '
+            'EE) in multi-EE mode'.format(len(move_target)))
+
+    targets_per_chain = [_coerce_targets(tc) for tc in target_coords]
+    if n_waypoints is None:
+        longest = max(len(ts) for ts in targets_per_chain)
+        n_waypoints = longest if longest > 1 else 2
+    if n_waypoints < 2:
+        raise ValueError(
+            'n_waypoints must be >= 2 (got {}); the start waypoint is '
+            'always fixed.'.format(n_waypoints))
+
+    # Build the union chain by joint name from longest sub-chain plus
+    # any joints uniquely contributed by other sub-chains.
+    sub_chains = list(link_list)
+    longest_idx = max(range(len(sub_chains)),
+                      key=lambda i: len(sub_chains[i]))
+    union_chain = list(sub_chains[longest_idx])
+    union_names = {l.joint.name for l in union_chain}
+    for ci, sub in enumerate(sub_chains):
+        if ci == longest_idx:
+            continue
+        for link in sub:
+            if link.joint.name not in union_names:
+                # Insert at the position implied by ancestor order. To
+                # keep the topological invariant simple we append; the
+                # extra_ee chain_indices use joint-name match anyway.
+                union_chain.append(link)
+                union_names.add(link.joint.name)
+
+    union_joint_list = [l.joint for l in union_chain]
+    if initial_angles is None:
+        initial_angles = _current_angles(union_joint_list)
+    initial_angles = np.asarray(initial_angles, dtype=np.float64)
+
+    track_rotation = (rotation_weight > 0.0
+                      and (rotation_mask is None
+                           or any(rotation_mask)))
+
+    problem = TrajectoryProblem(
+        robot_model=robot_model,
+        link_list=union_chain,
+        n_waypoints=n_waypoints,
+        move_target=move_target[longest_idx],
+    )
+    problem.set_fixed_endpoints(start=True, end=False)
+
+    # Main cost: longest sub-chain's EE.
+    main_pos, main_rot = _stack_targets(
+        targets_per_chain[longest_idx], n_waypoints)
+    if not track_rotation:
+        main_rot = None
+    problem.add_cartesian_path_cost(
+        target_positions=main_pos,
+        target_rotations=main_rot,
+        weight=position_weight,
+        rotation_weight=rotation_weight / max(position_weight, 1e-12),
+        position_mask=position_mask,
+        rotation_mask=rotation_mask,
+    )
+
+    # Extra costs for the remaining EEs.
+    for ci, sub in enumerate(sub_chains):
+        if ci == longest_idx:
+            continue
+        sub_pos, sub_rot = _stack_targets(
+            targets_per_chain[ci], n_waypoints)
+        if not track_rotation:
+            sub_rot = None
+        problem.add_extra_ee_cost(
+            move_target=move_target[ci],
+            sub_chain_link_list=sub,
+            target_positions=sub_pos,
+            target_rotations=sub_rot,
+            weight=position_weight,
+            rotation_weight=(rotation_weight / max(position_weight, 1e-12)
+                             if track_rotation else 0.0),
+            position_mask=position_mask,
+            rotation_mask=rotation_mask,
+        )
+
+    if smoothness_weight > 0.0 and n_waypoints >= 2:
+        problem.add_smoothness_cost(weight=smoothness_weight)
+
+    if world_obstacles:
+        if not collision_link_list:
+            raise ValueError(
+                'collision_link_list is required when world_obstacles '
+                'is provided')
+        problem.add_collision_cost(
+            collision_link_list=collision_link_list,
+            world_obstacles=world_obstacles,
+            weight=collision_weight,
+            activation_distance=collision_activation,
+            as_constraint=collision_as_constraint,
+            n_spheres_per_link=n_spheres_per_link,
+        )
+
+    init_traj = np.tile(initial_angles, (n_waypoints, 1))
+    solver_obj = create_solver(
+        solver, max_iterations=max_iterations, verbose=verbose)
+    result = solver_obj.solve(problem, init_traj)
+
+    angle_vector_list = np.asarray(result.trajectory)
+    final_angles = angle_vector_list[-1]
+
+    saved_angles = _current_angles(union_joint_list)
+    _apply_angles(union_joint_list, final_angles)
+    robot_model.update()
+
+    per_ee_pos_err = []
+    per_ee_rot_err = []
+    for ee, ts_list in zip(move_target, targets_per_chain):
+        last_pos = ts_list[-1].worldpos()
+        per_ee_pos_err.append(float(
+            np.linalg.norm(ee.worldpos() - last_pos)))
+        if track_rotation:
+            rel = ee.worldrot().T @ ts_list[-1].worldrot()
+            cos_angle = np.clip((np.trace(rel) - 1.0) / 2.0, -1.0, 1.0)
+            per_ee_rot_err.append(float(np.arccos(cos_angle)))
+        else:
+            per_ee_rot_err.append(0.0)
+    position_error = float(max(per_ee_pos_err))
+    rotation_error = (float(max(per_ee_rot_err))
+                      if track_rotation else 0.0)
+
+    torque_vector = None
+    if compute_torque:
+        try:
+            torque_vector = np.asarray(
+                robot_model.torque_vector(), dtype=np.float64)
+        except Exception:
+            torque_vector = None
+
+    if not apply_result:
+        _apply_angles(union_joint_list, saved_angles)
+        robot_model.update()
+
+    return {
+        'success': bool(result.success),
+        'angle_vector': np.asarray(final_angles),
+        'angle_vector_list': angle_vector_list,
+        'cost': float(result.cost),
+        'iterations': int(result.iterations),
+        'position_error': position_error,
+        'rotation_error': rotation_error,
+        'per_ee_position_error': per_ee_pos_err,
+        'per_ee_rotation_error': per_ee_rot_err,
+        'torque_vector': torque_vector,
+        'message': str(result.message),
+    }
+
+
+def _solve_ik_multi_ee(
+    *,
+    robot_model,
+    link_list,
+    move_target,
+    target_coords,
+    initial_angles,
+    position_weight,
+    rotation_weight,
+    position_mask,
+    rotation_mask,
+    apply_result,
+    compute_torque,
+    verbose,
+):
+    """Multi-EE single-pose IK using ``RobotModel.inverse_kinematics``.
+
+    Trajectory-optimization-based multi-EE (``add_multi_ee_waypoint_cost``)
+    assumes each chain has *disjoint* joints. For branched chains (e.g.
+    Y-shaped Tycoon compositions) the chains share joints, and the
+    correct solver is the legacy SR-inverse Newton method that
+    aggregates per-task Jacobians over a unified joint vector. This
+    helper wraps that path so :func:`solve_ik` users get a single
+    multi-EE entry point.
+    """
+    if not (isinstance(link_list, list) and len(link_list) > 0
+            and isinstance(link_list[0], list)):
+        raise ValueError(
+            'multi-EE solve requires link_list to be a list of '
+            'chains (list of list of Link)')
+    if len(link_list) != len(move_target):
+        raise ValueError(
+            'len(link_list) ({}) must equal len(move_target) ({}) '
+            'in multi-EE mode'.format(
+                len(link_list), len(move_target)))
+    if not (isinstance(target_coords, (list, tuple))
+            and len(target_coords) == len(move_target)):
+        raise ValueError(
+            'target_coords must be a list of {} entries (one per '
+            'EE) in multi-EE mode'.format(len(move_target)))
+
+    targets_single = []
+    for tc in target_coords:
+        ts = _coerce_targets(tc)
+        targets_single.append(ts[-1])
+
+    union_joint_list = []
+    seen = set()
+    for chain in link_list:
+        for link in chain:
+            if link.joint is not None and link.joint.name not in seen:
+                seen.add(link.joint.name)
+                union_joint_list.append(link.joint)
+
+    saved_angles = np.array(
+        [j.joint_angle() for j in union_joint_list], dtype=np.float64)
+    if initial_angles is not None:
+        for j, q in zip(union_joint_list, np.asarray(initial_angles)):
+            j.joint_angle(q)
+    robot_model.update()
+
+    pmask = (np.array(position_mask, dtype=np.int64)
+             if position_mask is not None else np.array([1, 1, 1]))
+    rmask = (np.array(rotation_mask, dtype=np.int64)
+             if rotation_mask is not None
+             else (np.array([1, 1, 1])
+                   if rotation_weight > 0.0
+                   else np.array([0, 0, 0])))
+    pmasks = [pmask] * len(move_target)
+    rmasks = [rmask] * len(move_target)
+
+    success = robot_model.inverse_kinematics(
+        target_coords=list(targets_single),
+        move_target=list(move_target),
+        link_list=list(link_list),
+        position_mask=pmasks,
+        rotation_mask=rmasks,
+        revert_if_fail=False,
+        stop=200,
+        thre=[0.001] * len(move_target),
+        rthre=[np.deg2rad(1.0)] * len(move_target),
+    )
+    success = bool(success is not False and success is not True
+                   or success)
+    robot_model.update()
+
+    final_angles = np.array(
+        [j.joint_angle() for j in union_joint_list], dtype=np.float64)
+
+    per_ee_pos_err = []
+    per_ee_rot_err = []
+    for ee, t in zip(move_target, targets_single):
+        per_ee_pos_err.append(float(np.linalg.norm(
+            ee.worldpos() - t.worldpos())))
+        rel = ee.worldrot().T @ t.worldrot()
+        cos_angle = np.clip((np.trace(rel) - 1.0) / 2.0, -1.0, 1.0)
+        per_ee_rot_err.append(float(np.arccos(cos_angle)))
+    position_error = float(max(per_ee_pos_err))
+    rotation_error = (float(max(per_ee_rot_err))
+                      if rotation_weight > 0.0 else 0.0)
+
+    torque_vector = None
+    if compute_torque:
+        try:
+            torque_vector = np.asarray(
+                robot_model.torque_vector(), dtype=np.float64)
+        except Exception:
+            torque_vector = None
+
+    if not apply_result:
+        for j, q in zip(union_joint_list, saved_angles):
+            j.joint_angle(q)
+        robot_model.update()
+
+    n_waypoints = max(
+        max(len(_coerce_targets(tc)) for tc in target_coords), 2)
+    angle_vector_list = np.tile(final_angles, (n_waypoints, 1))
+
+    return {
+        'success': success,
+        'angle_vector': final_angles,
+        'angle_vector_list': angle_vector_list,
+        'cost': 0.0,
+        'iterations': 0,
+        'position_error': position_error,
+        'rotation_error': rotation_error,
+        'per_ee_position_error': per_ee_pos_err,
+        'per_ee_rotation_error': per_ee_rot_err,
+        'torque_vector': torque_vector,
+        'message': 'multi-EE SR-inverse',
+    }
+
+
+def box_to_spheres(center, extents, n_per_axis=2, rotation=None):
+    """Approximate a box with a uniform sphere lattice.
+
+    The trajectory optimization residuals only consume sphere
+    obstacles, so a box has to be discretised before
+    :func:`solve_ik` can avoid it. Each sphere covers the full
+    diagonal of its cell, which is conservative (overestimates the
+    box's footprint) but simple.
+
+    Parameters
+    ----------
+    center : array-like (3,)
+        Box centre in world coordinates (metres).
+    extents : array-like (3,)
+        Full box extents along x, y, z (metres) in the box's local
+        frame.
+    n_per_axis : int or sequence of 3 ints
+        Number of spheres along each axis. Use a sequence to refine
+        the long sides of an elongated box.
+    rotation : (3, 3) ndarray, optional
+        Rotation of the box. If provided, the lattice is generated in
+        the box's local frame and rotated into world frame before being
+        offset by ``center``. Defaults to identity (axis-aligned box).
+
+    Returns
+    -------
+    list of dict
+        Sphere obstacles consumable by :func:`solve_ik`.
+    """
+    center = np.asarray(center, dtype=np.float64)
+    extents = np.asarray(extents, dtype=np.float64)
+    if np.isscalar(n_per_axis):
+        n = np.array([n_per_axis] * 3, dtype=np.int64)
+    else:
+        n = np.asarray(n_per_axis, dtype=np.int64)
+    if n.shape != (3,):
+        raise ValueError('n_per_axis must be int or length-3 sequence')
+
+    cell = extents / n
+    radius = float(np.linalg.norm(cell) / 2.0)
+
+    if rotation is None:
+        rotation_mat = np.eye(3)
+    else:
+        rotation_mat = np.asarray(rotation, dtype=np.float64)
+        if rotation_mat.shape != (3, 3):
+            raise ValueError('rotation must be a 3x3 matrix')
+
+    starts_local = -extents / 2.0 + cell / 2.0
+    spheres = []
+    for ix in range(n[0]):
+        for iy in range(n[1]):
+            for iz in range(n[2]):
+                local = starts_local + cell * np.array([ix, iy, iz])
+                c = center + rotation_mat @ local
+                spheres.append({
+                    'type': 'sphere',
+                    'center': c.tolist(),
+                    'radius': radius,
+                })
+    return spheres

--- a/skrobot/planner/trajectory_optimization/problem.py
+++ b/skrobot/planner/trajectory_optimization/problem.py
@@ -126,6 +126,13 @@ class TrajectoryProblem:
         # End-effector waypoint costs: list of dicts
         self.ee_waypoint_costs = []
 
+        # Extra EE costs that share the variable space with the main
+        # chain (used for branched / Y-shape multi-EE problems where
+        # the legacy multi_ee_waypoint cost cannot be applied because
+        # chains overlap). Each entry is a dict captured by
+        # :meth:`add_extra_ee_cost`.
+        self.extra_ee_costs = []
+
     @property
     def fk_params(self):
         """Get FK parameters for the FIRST chain (legacy single-chain access)."""
@@ -603,6 +610,7 @@ class TrajectoryProblem:
         weight=100.0,
         activation_distance=0.05,
         as_constraint=True,
+        n_spheres_per_link=3,
     ):
         """Add world collision avoidance cost.
 
@@ -619,6 +627,11 @@ class TrajectoryProblem:
         as_constraint : bool
             If True (default), treat as hard constraint for Augmented Lagrangian
             solver (collision distance >= 0). If False, treat as soft cost.
+        n_spheres_per_link : int
+            Number of swept spheres approximating each collision link.
+            Higher values mean tighter collision approximation at the
+            cost of more residuals. 3 is the historical default; values
+            up to ~7 are reasonable for elongated links.
         """
         self.collision_link_list = collision_link_list
         self.world_obstacles = world_obstacles
@@ -626,7 +639,8 @@ class TrajectoryProblem:
         # Extract collision spheres
         from skrobot.planner.trajectory_optimization.collision import extract_collision_spheres
         self.collision_spheres = extract_collision_spheres(
-            self.robot_model, collision_link_list, n_spheres_per_link=3
+            self.robot_model, collision_link_list,
+            n_spheres_per_link=n_spheres_per_link,
         )
 
         # Compute collision link offsets
@@ -819,6 +833,10 @@ class TrajectoryProblem:
     ):
         """Add end-effector pose tracking cost.
 
+        Equivalent to :meth:`add_cartesian_path_cost`; kept as a
+        convenience name for IK-style use where every waypoint shares
+        the same target pose.
+
         Parameters
         ----------
         target_positions : ndarray
@@ -830,18 +848,12 @@ class TrajectoryProblem:
         rotation_weight : float
             Rotation tracking weight.
         """
-        self.residuals.append(ResidualSpec(
-            name='pose',
-            residual_fn='pose',
-            params={
-                'target_positions': target_positions,
-                'target_rotations': target_rotations,
-                'position_weight': position_weight,
-                'rotation_weight': rotation_weight,
-            },
-            kind='soft',
-            weight=1.0,  # Weights are in params
-        ))
+        self.add_cartesian_path_cost(
+            target_positions=target_positions,
+            target_rotations=target_rotations,
+            weight=position_weight,
+            rotation_weight=rotation_weight / max(position_weight, 1e-12),
+        )
 
     def add_joint_velocity_limit(self, scale=1.0):
         """Add joint velocity limit constraint.
@@ -875,6 +887,8 @@ class TrajectoryProblem:
         target_rotations=None,
         weight=10.0,
         rotation_weight=1.0,
+        position_mask=None,
+        rotation_mask=None,
     ):
         """Add end-effector pose tracking cost for Cartesian path.
 
@@ -893,7 +907,28 @@ class TrajectoryProblem:
             Position tracking weight.
         rotation_weight : float
             Rotation tracking weight relative to position weight.
+        position_mask : array-like length 3 (in {0, 1}), optional
+            Per-axis selection of which translational error components
+            to penalise. ``[1, 1, 1]`` (default) enforces the full
+            position. ``[0, 0, 1]`` keeps only Z (the equivalent of
+            optmotiongen's ``:translation-axis :z``). Eliminated axes
+            contribute no residual at all.
+        rotation_mask : array-like length 3, optional
+            Per-axis selection of which rotational error components
+            (in the SE(3) log map basis) to penalise. ``[0, 0, 0]``
+            disables rotation tracking entirely (equivalent to
+            ``rotation_weight=0``).
         """
+        if position_mask is None:
+            position_mask = [1, 1, 1]
+        if rotation_mask is None:
+            rotation_mask = ([1, 1, 1] if target_rotations is not None
+                             else [0, 0, 0])
+        position_mask = list(position_mask)
+        rotation_mask = list(rotation_mask)
+        if len(position_mask) != 3 or len(rotation_mask) != 3:
+            raise ValueError(
+                'position_mask and rotation_mask must be length 3')
         self.residuals.append(ResidualSpec(
             name='cartesian_path',
             residual_fn='cartesian_path',
@@ -901,10 +936,106 @@ class TrajectoryProblem:
                 'target_positions': target_positions,
                 'target_rotations': target_rotations,
                 'rotation_weight': rotation_weight,
+                'position_mask': position_mask,
+                'rotation_mask': rotation_mask,
             },
             kind='soft',
             weight=weight,
         ))
+
+    def add_extra_ee_cost(
+        self,
+        move_target,
+        sub_chain_link_list,
+        target_positions,
+        target_rotations=None,
+        weight=10.0,
+        rotation_weight=1.0,
+        position_mask=None,
+        rotation_mask=None,
+    ):
+        """Add a Cartesian-path tracking cost for a *secondary* EE.
+
+        Use this when several end-effectors share the same articulated
+        chain (e.g. branches of a Y-shape robot) and you want all of
+        them tracked at once in a single trajectory-optimization pass.
+        The variable space stays the union chain
+        (``self.link_list``); each call to ``add_extra_ee_cost``
+        contributes one residual whose FK is built against
+        ``sub_chain_link_list`` (a subset of ``self.link_list`` whose
+        joints are the ancestor chain of ``move_target``).
+
+        Parameters
+        ----------
+        move_target : skrobot.coordinates.CascadedCoords
+            EE frame for this extra task.
+        sub_chain_link_list : list of skrobot.model.Link
+            Links from ``self.link_list`` (or a subset of them, in
+            root-to-tip order) whose joints feed this EE. The cost
+            gathers angles from the union waypoint vector via the
+            joint-name match.
+        target_positions : array
+            Target positions, as in :meth:`add_cartesian_path_cost`.
+        target_rotations : array, optional
+            Target rotations, as in :meth:`add_cartesian_path_cost`.
+        weight : float
+            Position weight, as in :meth:`add_cartesian_path_cost`.
+        rotation_weight : float
+            Rotation weight, as in :meth:`add_cartesian_path_cost`.
+        position_mask, rotation_mask : array-like length 3, optional
+            Axis masks, as in :meth:`add_cartesian_path_cost`.
+        """
+        from skrobot.kinematics.differentiable import extract_fk_parameters
+
+        # Extract FK against the sub-chain at construction time. This
+        # snapshot's ref_angles are baked into the JIT graph; the
+        # solver still varies the union waypoint vector and only
+        # gathers the relevant slice for this cost.
+        fk_data = extract_fk_parameters(
+            self.robot_model, sub_chain_link_list, move_target)
+
+        # Map each sub-chain joint to its flat-union index.
+        union_joint_names = [link.joint.name for link in self.link_list]
+        chain_indices = []
+        for link in sub_chain_link_list:
+            try:
+                chain_indices.append(
+                    union_joint_names.index(link.joint.name))
+            except ValueError as err:
+                raise ValueError(
+                    'sub_chain joint {!r} is not in the union chain '
+                    '(self.link_list); add it before calling '
+                    'add_extra_ee_cost'.format(link.joint.name)) from err
+
+        if position_mask is None:
+            position_mask = [1, 1, 1]
+        if rotation_mask is None:
+            rotation_mask = ([1, 1, 1] if target_rotations is not None
+                             else [0, 0, 0])
+
+        target_positions = np.asarray(target_positions, dtype=np.float64)
+        if target_positions.shape != (self.n_waypoints, 3):
+            raise ValueError(
+                'target_positions must have shape ({}, 3); got {}'.format(
+                    self.n_waypoints, target_positions.shape))
+        if target_rotations is not None:
+            target_rotations = np.asarray(target_rotations, dtype=np.float64)
+            if target_rotations.shape != (self.n_waypoints, 3, 3):
+                raise ValueError(
+                    'target_rotations must have shape ({}, 3, 3); '
+                    'got {}'.format(
+                        self.n_waypoints, target_rotations.shape))
+
+        self.extra_ee_costs.append({
+            'fk_data': fk_data,
+            'chain_indices': np.asarray(chain_indices, dtype=np.int64),
+            'target_positions': target_positions,
+            'target_rotations': target_rotations,
+            'position_weight': float(weight),
+            'rotation_weight': float(rotation_weight),
+            'position_mask': list(position_mask),
+            'rotation_mask': list(rotation_mask),
+        })
 
     def set_fixed_endpoints(self, start=True, end=True):
         """Set whether to fix start and end waypoints.

--- a/skrobot/planner/trajectory_optimization/solvers/augmented_lagrangian.py
+++ b/skrobot/planner/trajectory_optimization/solvers/augmented_lagrangian.py
@@ -684,6 +684,14 @@ class AugmentedLagrangianSolver(BaseSolver):
                     target_pos = jnp.array(params['target_positions'])
                     target_rots = params.get('target_rotations')
                     rot_w = params.get('rotation_weight', 1.0)
+                    pmask = jnp.array(
+                        params.get('position_mask', [1, 1, 1]),
+                        dtype=jnp.float64)
+                    rmask = jnp.array(
+                        params.get('rotation_mask', [1, 1, 1]
+                                   if target_rots is not None
+                                   else [0, 0, 0]),
+                        dtype=jnp.float64)
 
                     if target_rots is not None:
                         target_rots = jnp.array(target_rots)
@@ -693,8 +701,8 @@ class AugmentedLagrangianSolver(BaseSolver):
                             ee_pos, ee_rot = get_ee_pose(angles, fk)
                             pose_err = pose_error_log(
                                 ee_pos, ee_rot, t_pos, t_rot)
-                            pos_err = jnp.sum(pose_err[:3] ** 2)
-                            rot_err = jnp.sum(pose_err[3:] ** 2)
+                            pos_err = jnp.sum((pose_err[:3] * pmask) ** 2)
+                            rot_err = jnp.sum((pose_err[3:] * rmask) ** 2)
                             return pos_err + rot_w * rot_err
 
                         cart_costs = jax.vmap(cart_cost_single)(
@@ -704,7 +712,7 @@ class AugmentedLagrangianSolver(BaseSolver):
                         def cart_cost_pos_only(args):
                             angles, t_pos = args
                             ee_pos, _ = get_ee_pose(angles, fk)
-                            return jnp.sum((ee_pos - t_pos) ** 2)
+                            return jnp.sum(((ee_pos - t_pos) * pmask) ** 2)
 
                         cart_costs = jax.vmap(cart_cost_pos_only)(
                             (trajectory, target_pos)

--- a/skrobot/planner/trajectory_optimization/solvers/gradient_descent.py
+++ b/skrobot/planner/trajectory_optimization/solvers/gradient_descent.py
@@ -379,6 +379,14 @@ class GradientDescentSolver(BaseSolver):
                     target_pos = jnp.array(params['target_positions'])
                     target_rots = params.get('target_rotations')
                     rot_w = params.get('rotation_weight', 1.0)
+                    pmask = jnp.array(
+                        params.get('position_mask', [1, 1, 1]),
+                        dtype=jnp.float64)
+                    rmask = jnp.array(
+                        params.get('rotation_mask', [1, 1, 1]
+                                   if target_rots is not None
+                                   else [0, 0, 0]),
+                        dtype=jnp.float64)
 
                     if target_rots is not None:
                         target_rots = jnp.array(target_rots)
@@ -389,8 +397,8 @@ class GradientDescentSolver(BaseSolver):
                             # Use SE(3) logarithmic map for pose error
                             pose_err = pose_error_log(
                                 ee_pos, ee_rot, t_pos, t_rot)
-                            pos_err = jnp.sum(pose_err[:3] ** 2)
-                            rot_err = jnp.sum(pose_err[3:] ** 2)
+                            pos_err = jnp.sum((pose_err[:3] * pmask) ** 2)
+                            rot_err = jnp.sum((pose_err[3:] * rmask) ** 2)
                             return pos_err + rot_w * rot_err
 
                         cart_costs = jax.vmap(cart_cost_single)(
@@ -400,7 +408,7 @@ class GradientDescentSolver(BaseSolver):
                         def cart_cost_pos_only(args):
                             angles, t_pos = args
                             ee_pos, _ = get_ee_pose(angles)
-                            return jnp.sum((ee_pos - t_pos) ** 2)
+                            return jnp.sum(((ee_pos - t_pos) * pmask) ** 2)
 
                         cart_costs = jax.vmap(cart_cost_pos_only)(
                             (trajectory, target_pos)

--- a/skrobot/planner/trajectory_optimization/solvers/jaxls_solver.py
+++ b/skrobot/planner/trajectory_optimization/solvers/jaxls_solver.py
@@ -208,6 +208,23 @@ class JaxlsSolver(BaseSolver):
             for c in problem.ee_waypoint_costs
         )
 
+        # Extra EE costs structure: each entry's chain length, weights,
+        # and whether rotation is tracked. Targets themselves are
+        # captured in closure inside the cost factory so they
+        # invalidate the structure key implicitly via the closure
+        # identity below.
+        extra_ee_key = tuple(
+            (
+                int(len(entry['chain_indices'])),
+                float(entry['position_weight']),
+                float(entry['rotation_weight']),
+                tuple(entry['position_mask']),
+                tuple(entry['rotation_mask']),
+                bool(entry['target_rotations'] is not None),
+            )
+            for entry in getattr(problem, 'extra_ee_costs', [])
+        )
+
         # Include obstacle positions in cache key
         # (obstacles change position, so compiled problem must be invalidated)
         obstacle_key = tuple()
@@ -233,6 +250,7 @@ class JaxlsSolver(BaseSolver):
             has_cart_rot,
             ee_wp_key,
             obstacle_key,  # Include obstacle positions
+            extra_ee_key,
         )
         return key
 
@@ -426,6 +444,12 @@ class JaxlsSolver(BaseSolver):
                     problem, TrajectoryVar,
                     EEWpPosParamVar, EEWpRotParamVar,
                     fk_data,
+                ))
+
+            # --- Extra EE costs (shared-variable multi-EE) ---
+            for entry in getattr(problem, 'extra_ee_costs', []):
+                costs.append(self._make_extra_ee_cost(
+                    problem, TrajectoryVar, entry,
                 ))
 
             # --- Constraint targets as frozen ParamVars ---
@@ -801,8 +825,109 @@ class JaxlsSolver(BaseSolver):
             EEWpRotParamVar(jnp.arange(n_ee_wps)),
         )
 
+    def _make_extra_ee_cost(self, problem, TrajectoryVar, entry):
+        """Per-waypoint Cartesian cost for a *secondary* EE that
+        shares variables with the main chain.
+
+        Builds a sub-chain FK from the snapshot stored in
+        ``entry['fk_data']`` and gathers the relevant joint angles
+        from the union waypoint vector via ``entry['chain_indices']``
+        before evaluating pose error.
+        """
+        import jax
+        import jax.numpy as jnp
+        import jaxls
+
+        from skrobot.planner.trajectory_optimization.fk_utils import build_fk_functions
+        from skrobot.planner.trajectory_optimization.fk_utils import pose_error_log
+
+        T = problem.n_waypoints
+        fk_data = entry['fk_data']
+        chain_indices = jnp.asarray(entry['chain_indices'])
+        target_pos = jnp.asarray(entry['target_positions'])
+        target_rot = entry['target_rotations']
+        pos_w = entry['position_weight']
+        rot_w = entry['rotation_weight']
+        pmask = jnp.asarray(entry['position_mask'], dtype=jnp.float64)
+        rmask = jnp.asarray(entry['rotation_mask'], dtype=jnp.float64)
+        pos_scale = jnp.sqrt(pos_w)
+
+        _, _, _, get_ee_pose = build_fk_functions(fk_data, jnp)
+
+        if target_rot is not None:
+            target_rot = jnp.asarray(target_rot)
+            rot_scale = jnp.sqrt(pos_w * rot_w)
+
+            @jaxls.Cost.factory(name='extra_ee_full')
+            def extra_ee_full(vals, var, t_pos_param, t_rot_param):
+                full_angles = vals[var]
+                sub_angles = full_angles[chain_indices]
+                ee_pos, ee_rot = get_ee_pose(sub_angles)
+                pose_err = pose_error_log(
+                    ee_pos, ee_rot,
+                    vals[t_pos_param], vals[t_rot_param].reshape(3, 3))
+                pos_err = pos_scale * (pose_err[:3] * pmask)
+                rot_err = rot_scale * (pose_err[3:] * rmask)
+                return jnp.concatenate([pos_err, rot_err]).flatten()
+
+            # Bake target arrays directly as constants by registering as
+            # frozen ParamVars. To keep it simple, we make a per-call
+            # ParamVar class and pass values via a small helper closure.
+            class _ExtraPosParam(
+                jaxls.Var[jax.Array],
+                default_factory=lambda: jnp.zeros(3),
+                tangent_dim=0,
+            ):
+                pass
+
+            class _ExtraRotParam(
+                jaxls.Var[jax.Array],
+                default_factory=lambda: jnp.eye(3).flatten(),
+                tangent_dim=0,
+            ):
+                pass
+
+            # We construct the cost factory WITHOUT param vars by
+            # capturing the targets in closure, since they are
+            # immutable for a single solve. (TrajectoryProblem callers
+            # rebuild the problem when targets change.)
+            @jaxls.Cost.factory(name='extra_ee_full_closure')
+            def extra_ee_full_closure(vals, var, wp_idx):
+                full_angles = vals[var]
+                sub_angles = full_angles[chain_indices]
+                ee_pos, ee_rot = get_ee_pose(sub_angles)
+                tp = target_pos[wp_idx]
+                tr = target_rot[wp_idx]
+                pose_err = pose_error_log(ee_pos, ee_rot, tp, tr)
+                pos_err = pos_scale * (pose_err[:3] * pmask)
+                rot_err = rot_scale * (pose_err[3:] * rmask)
+                return jnp.concatenate([pos_err, rot_err]).flatten()
+
+            return extra_ee_full_closure(
+                TrajectoryVar(jnp.arange(T)),
+                jnp.arange(T),
+            )
+
+        @jaxls.Cost.factory(name='extra_ee_pos')
+        def extra_ee_pos(vals, var, wp_idx):
+            full_angles = vals[var]
+            sub_angles = full_angles[chain_indices]
+            ee_pos, _ = get_ee_pose(sub_angles)
+            err = (ee_pos - target_pos[wp_idx]) * pmask
+            return (pos_scale * err).flatten()
+
+        return extra_ee_pos(
+            TrajectoryVar(jnp.arange(T)),
+            jnp.arange(T),
+        )
+
     def _make_world_collision_cost(self, problem, TrajectoryVar, fk_data, spec):
-        """Create world collision avoidance cost."""
+        """Create world collision avoidance cost or constraint.
+
+        ``spec.kind == 'geq'`` produces a per-sphere/per-obstacle hard
+        ``signed_distance >= 0`` constraint. Any other kind keeps the
+        legacy soft hinge penalty.
+        """
         import jax.numpy as jnp
         import jaxls
 
@@ -833,6 +958,27 @@ class JaxlsSolver(BaseSolver):
         sphere_radii = fk_data['sphere_radii']
 
         _, get_sphere_positions, _, _ = build_fk_functions(fk_data, jnp)
+
+        if spec.kind == 'geq':
+            # Hard constraint: signed_dist - safety_margin >= 0 for every
+            # (sphere, obstacle) pair at every waypoint. The safety
+            # margin is the activation distance so we keep at least
+            # ``activation_dist`` clearance to mirror optmotiongen's
+            # ``collision-distance-limit`` behaviour.
+            @jaxls.Cost.factory(
+                kind='constraint_geq_zero',
+                name='world_collision_geq',
+            )
+            def world_collision_geq(vals, var):
+                angles = vals[var]
+                sphere_pos = get_sphere_positions(angles)
+                signed_dists = compute_sphere_obstacle_distances(
+                    sphere_pos, sphere_radii, obs_centers, obs_radii, jnp
+                )
+                # Slack: distance beyond the activation buffer.
+                return (signed_dists - activation_dist).flatten()
+
+            return world_collision_geq(TrajectoryVar(jnp.arange(T)))
 
         @jaxls.Cost.factory(name='world_collision')
         def world_collision_cost(vals, var):
@@ -946,6 +1092,12 @@ class JaxlsSolver(BaseSolver):
         _, _, _, get_ee_pose = build_fk_functions(fk_data, jnp)
 
         has_rot = spec.params.get('target_rotations') is not None
+        pmask = jnp.array(
+            spec.params.get('position_mask', [1, 1, 1]), dtype=jnp.float64)
+        rmask = jnp.array(
+            spec.params.get('rotation_mask',
+                            [1, 1, 1] if has_rot else [0, 0, 0]),
+            dtype=jnp.float64)
 
         if has_rot:
             rot_weight = jnp.sqrt(spec.weight * rotation_weight)
@@ -958,8 +1110,8 @@ class JaxlsSolver(BaseSolver):
                 target_rot = vals[rot_param].reshape(3, 3)
                 # Use SE(3) logarithmic map for pose error
                 pose_err = pose_error_log(ee_pos, ee_rot, target_pos, target_rot)
-                pos_err = pos_weight * pose_err[:3]
-                rot_err = rot_weight * pose_err[3:]
+                pos_err = pos_weight * (pose_err[:3] * pmask)
+                rot_err = rot_weight * (pose_err[3:] * rmask)
                 return jnp.concatenate([pos_err, rot_err]).flatten()
 
             return cartesian_path_cost(
@@ -973,7 +1125,7 @@ class JaxlsSolver(BaseSolver):
                 angles = vals[var]
                 ee_pos, _ = get_ee_pose(angles)
                 target_pos = vals[pos_param]
-                return (pos_weight * (ee_pos - target_pos)).flatten()
+                return (pos_weight * ((ee_pos - target_pos) * pmask)).flatten()
 
             return cartesian_path_cost(
                 TrajectoryVar(jnp.arange(T)),

--- a/tests/skrobot_tests/planner_tests/test_trajectory_optimization.py
+++ b/tests/skrobot_tests/planner_tests/test_trajectory_optimization.py
@@ -1574,3 +1574,114 @@ class TestGridSDFSelfCollision(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestBoxToSpheres(unittest.TestCase):
+    """The lattice must cover the box it stands in for."""
+
+    def test_lattice_covers_the_box(self):
+        from skrobot.planner import box_to_spheres
+
+        center = np.array([0.4, -0.1, 0.3])
+        extents = np.array([0.2, 0.4, 0.6])
+        spheres = box_to_spheres(center, extents, n_per_axis=2)
+
+        self.assertEqual(len(spheres), 8)
+        centers = np.array([s['center'] for s in spheres])
+        radii = np.array([s['radius'] for s in spheres])
+
+        # Every lattice point sits inside the box.
+        self.assertTrue(
+            np.all(np.abs(centers - center) <= extents / 2.0 + 1e-9))
+
+        # Cover, not just touch: the union has to contain the corners, which
+        # is what makes the approximation conservative rather than optimistic.
+        signs = np.array([[sx, sy, sz]
+                          for sx in (-1, 1) for sy in (-1, 1)
+                          for sz in (-1, 1)], dtype=float)
+        corners = center + signs * extents / 2.0
+        for corner in corners:
+            covered = np.linalg.norm(centers - corner, axis=1) <= radii + 1e-9
+            self.assertTrue(covered.any(),
+                            'corner {} left uncovered'.format(corner))
+
+    def test_rotation_is_applied_about_the_centre(self):
+        from skrobot.coordinates.math import rotation_matrix
+        from skrobot.planner import box_to_spheres
+
+        center = np.array([1.0, 0.0, 0.0])
+        extents = np.array([0.4, 0.2, 0.2])
+        rot = rotation_matrix(np.pi / 2.0, [0, 0, 1])
+
+        plain = np.array([s['center']
+                          for s in box_to_spheres(center, extents, 2)])
+        turned = np.array([s['center'] for s in box_to_spheres(
+            center, extents, 2, rotation=rot)])
+
+        # A rotation about the box centre leaves the centroid alone but must
+        # move the lattice, otherwise the argument is being ignored.
+        testing.assert_allclose(turned.mean(axis=0), plain.mean(axis=0),
+                                atol=1e-9)
+        self.assertGreater(np.abs(turned - plain).max(), 1e-3)
+
+
+class TestCartesianAxisMasks(unittest.TestCase):
+    """A masked axis must drop out of the Cartesian residual."""
+
+    def _problem(self, position_mask=None, rotation_mask=None):
+        robot, link_list, _ = _make_kuka()
+        problem = TrajectoryProblem(robot, link_list, n_waypoints=2,
+                                    move_target=robot.rarm_end_coords)
+        target = robot.rarm_end_coords.worldpos() + np.array([0.1, 0.0, 0.2])
+        problem.add_cartesian_path_cost(
+            np.tile(target, (2, 1)),
+            np.tile(np.eye(3), (2, 1, 1)),
+            weight=1.0, rotation_weight=1.0,
+            position_mask=position_mask, rotation_mask=rotation_mask)
+        return problem
+
+    def test_masks_default_to_all_axes(self):
+        spec = self._problem().residuals[-1]
+        self.assertEqual(list(spec.params['position_mask']), [1, 1, 1])
+        self.assertEqual(list(spec.params['rotation_mask']), [1, 1, 1])
+
+    def test_masked_axis_is_stored(self):
+        spec = self._problem(position_mask=[1, 1, 0],
+                             rotation_mask=[0, 0, 0]).residuals[-1]
+        self.assertEqual(list(spec.params['position_mask']), [1, 1, 0])
+        self.assertEqual(list(spec.params['rotation_mask']), [0, 0, 0])
+
+    @unittest.skipUnless(HAS_JAX, 'jax is not installed')
+    def test_masked_axis_does_not_change_the_cost(self):
+        """Moving the target along a masked axis must not move the cost.
+
+        This is the property the mask exists for: a ``:translation-axis :z``
+        style request should leave z free. Comparing two problems that differ
+        only in the masked coordinate catches a mask that is stored but never
+        applied.
+
+        Position-only tracking is used deliberately. With a rotation target
+        the residual is the SE(3) log map, whose first three components mix
+        translation with rotation, so ``position_mask`` frees a log-map
+        coordinate rather than a world axis.
+        """
+        from skrobot.planner.trajectory_optimization.solvers.augmented_lagrangian import AugmentedLagrangianSolver
+
+        robot, link_list, n_joints = _make_kuka()
+        base = robot.rarm_end_coords.worldpos()
+        traj = interpolate_trajectory(np.zeros(n_joints),
+                                      np.ones(n_joints) * 0.1, 2)
+
+        def cost_for(dz):
+            robot2, links2, _ = _make_kuka()
+            problem = TrajectoryProblem(robot2, links2, n_waypoints=2,
+                                        move_target=robot2.rarm_end_coords)
+            target = base + np.array([0.1, 0.0, dz])
+            problem.add_cartesian_path_cost(
+                np.tile(target, (2, 1)),
+                weight=1.0, position_mask=[1, 1, 0])
+            solver = AugmentedLagrangianSolver(max_outer_iterations=1,
+                                               max_inner_iterations=1)
+            return float(solver.solve(problem, traj).cost)
+
+        self.assertAlmostEqual(cost_for(0.0), cost_for(5.0), places=6)


### PR DESCRIPTION
Adds `solve_ik`, a one-call inverse kinematics entry point built on
`TrajectoryProblem`, plus the per-axis Cartesian masks it needs.

Until now a caller who wanted a single pose had to assemble the problem,
add the residuals, choose a solver and write the result back onto the model
by hand. `solve_ik` takes a chain, an end-effector frame and one or more
target coords, and returns the joint angles together with the position and
rotation error it achieved.

`add_cartesian_path_cost` gains `position_mask` and `rotation_mask`, which
select the components that enter the residual — `rotation_mask=[0, 0, 0]`
asks for "reach this point, any orientation". Both default to all axes, so
existing problems are unchanged. With a rotation target the residual is the
SE(3) log map, whose first three components mix translation with rotation,
so `position_mask` frees a log-map coordinate rather than a world axis;
without one it is the plain world-frame offset. This is documented and the
test exercises the unambiguous case.

`box_to_spheres` discretises a box into a sphere lattice, since the
collision residuals only consume spheres. Each sphere spans its cell's
diagonal, so the union covers the box rather than approximating it from the
inside.

Tests: the lattice covers the box's corners, the rotation argument is
applied about the centre, the masks reach the residual params, and a masked
axis leaves the cost unchanged when the target moves along it.
