### PR TITLE
Treat box obstacles exactly and sample link surfaces from the hull

### DIFF
--- a/skrobot/planner/inverse_kinematics_optimization.py
+++ b/skrobot/planner/inverse_kinematics_optimization.py
@@ -76,6 +76,8 @@ def solve_ik(
     collision_activation=0.05,
     collision_as_constraint=True,
     n_spheres_per_link=5,
+    world_collision_mode='sphere',
+    n_surface=None,
     position_mask=None,
     rotation_mask=None,
     apply_result=True,
@@ -259,6 +261,8 @@ def solve_ik(
             activation_distance=collision_activation,
             as_constraint=collision_as_constraint,
             n_spheres_per_link=n_spheres_per_link,
+            mode=world_collision_mode,
+            n_surface=n_surface,
         )
 
     init_traj = np.tile(initial_angles, (n_waypoints, 1))

--- a/skrobot/planner/trajectory_optimization/fk_utils.py
+++ b/skrobot/planner/trajectory_optimization/fk_utils.py
@@ -4,6 +4,8 @@ This module provides backend-agnostic FK computation functions
 shared across different solvers (scipy, jaxls, gradient_descent).
 """
 
+import numpy as np
+
 from skrobot.backend import rodrigues_rotation
 from skrobot.kinematics.differentiable import pose_error_se3_log as pose_error_log
 from skrobot.kinematics.differentiable import rotation_error_so3_log as rotation_error_log
@@ -328,6 +330,156 @@ def compute_sphere_obstacle_distances(sphere_positions, sphere_radii,
     dists = xp.sqrt(xp.sum(diff ** 2, axis=-1) + 1e-10)
     signed_dists = dists - sphere_radii[:, None] - obstacle_radii[None, :]
     return signed_dists
+
+
+def prepare_world_obstacle_arrays(obstacles):
+    """Split a world-obstacle list into per-type static arrays.
+
+    The trajectory residuals need fixed-shape arrays, so the obstacle
+    dicts are turned into arrays once (outside the traced/compiled cost).
+
+    Parameters
+    ----------
+    obstacles : list[dict]
+        Obstacle dicts. ``{'type': 'sphere', 'center', 'radius'}`` and
+        ``{'type': 'box', 'center', 'extents'[, 'rotation']}`` are
+        supported; ``extents`` are the *full* side lengths and
+        ``rotation`` is a (3, 3) world-from-box matrix (identity if
+        omitted). Unknown types raise.
+
+    Returns
+    -------
+    dict
+        ``sphere_centers`` (Ns, 3), ``sphere_radii`` (Ns,),
+        ``box_centers`` (Nb, 3), ``box_half_extents`` (Nb, 3),
+        ``box_rotations`` (Nb, 3, 3). Empty arrays keep the trailing
+        dimensions so ``backend`` code can branch on ``len``.
+
+    Raises
+    ------
+    ValueError
+        If an obstacle has an unsupported ``type``.
+    """
+    sphere_centers, sphere_radii = [], []
+    box_centers, box_half_extents, box_rotations = [], [], []
+    for o in obstacles:
+        kind = o.get('type')
+        if kind == 'sphere':
+            sphere_centers.append(np.asarray(o['center'], dtype=np.float64))
+            sphere_radii.append(float(o['radius']))
+        elif kind == 'box':
+            box_centers.append(np.asarray(o['center'], dtype=np.float64))
+            box_half_extents.append(
+                0.5 * np.asarray(o['extents'], dtype=np.float64))
+            rot = o.get('rotation')
+            box_rotations.append(
+                np.eye(3) if rot is None
+                else np.asarray(rot, dtype=np.float64))
+        else:
+            raise ValueError(
+                'unsupported obstacle type {!r}; expected '
+                "'sphere' or 'box'".format(kind))
+    return {
+        'sphere_centers': (np.asarray(sphere_centers, dtype=np.float64)
+                           if sphere_centers else np.zeros((0, 3))),
+        'sphere_radii': (np.asarray(sphere_radii, dtype=np.float64)
+                         if sphere_radii else np.zeros((0,))),
+        'box_centers': (np.asarray(box_centers, dtype=np.float64)
+                        if box_centers else np.zeros((0, 3))),
+        'box_half_extents': (np.asarray(box_half_extents, dtype=np.float64)
+                             if box_half_extents else np.zeros((0, 3))),
+        'box_rotations': (np.asarray(box_rotations, dtype=np.float64)
+                          if box_rotations else np.zeros((0, 3, 3))),
+    }
+
+
+def compute_box_obstacle_distances(sphere_positions, sphere_radii,
+                                   box_centers, box_half_extents,
+                                   box_rotations, backend):
+    """Signed distances between collision spheres and box obstacles.
+
+    Uses the exact box signed-distance function, so a box is *not*
+    inflated the way a sphere-lattice approximation of it would be::
+
+        d(p) = ||max(|p| - h, 0)|| + min(max_i(|p|_i - h_i), 0)
+
+    evaluated in the box frame, then reduced by the sphere radius.
+
+    Parameters
+    ----------
+    sphere_positions : array
+        Collision sphere positions (n_spheres, 3), world frame.
+    sphere_radii : array
+        Collision sphere radii (n_spheres,).
+    box_centers : array
+        Box centres (n_boxes, 3), world frame.
+    box_half_extents : array
+        Box half side lengths (n_boxes, 3).
+    box_rotations : array
+        World-from-box rotation matrices (n_boxes, 3, 3).
+    backend : module
+        Array module (``numpy`` or ``jax.numpy``).
+
+    Returns
+    -------
+    array
+        Signed distances (n_spheres, n_boxes).
+        Positive = separated, negative = penetrating.
+    """
+    xp = backend
+    # (n_spheres, n_boxes, 3) in world frame, then rotated into each box frame
+    # by R^T (einsum indices: R is world-from-box, so transpose via 'bji').
+    diff = sphere_positions[:, None, :] - box_centers[None, :, :]
+    local = xp.einsum('bji,sbj->sbi', box_rotations, diff)
+
+    q = xp.abs(local) - box_half_extents[None, :, :]
+    outside = xp.sqrt(xp.sum(xp.maximum(q, 0.0) ** 2, axis=-1) + 1e-10)
+    inside = xp.minimum(xp.max(q, axis=-1), 0.0)
+    return outside + inside - sphere_radii[:, None]
+
+
+def compute_world_obstacle_distances(sphere_positions, sphere_radii,
+                                     obstacle_arrays, backend):
+    """Signed distances to every world obstacle, spheres then boxes.
+
+    Concatenates :func:`compute_sphere_obstacle_distances` and
+    :func:`compute_box_obstacle_distances` so the total column count
+    equals the number of obstacles handed to ``add_collision_cost``.
+
+    Parameters
+    ----------
+    sphere_positions : array
+        Collision sphere positions (n_spheres, 3).
+    sphere_radii : array
+        Collision sphere radii (n_spheres,).
+    obstacle_arrays : dict
+        Output of :func:`prepare_world_obstacle_arrays`.
+    backend : module
+        Array module.
+
+    Returns
+    -------
+    array
+        Signed distances (n_spheres, n_obstacles).
+    """
+    xp = backend
+    blocks = []
+    if len(obstacle_arrays['sphere_radii']):
+        blocks.append(compute_sphere_obstacle_distances(
+            sphere_positions, sphere_radii,
+            xp.asarray(obstacle_arrays['sphere_centers']),
+            xp.asarray(obstacle_arrays['sphere_radii']), xp))
+    if len(obstacle_arrays['box_half_extents']):
+        blocks.append(compute_box_obstacle_distances(
+            sphere_positions, sphere_radii,
+            xp.asarray(obstacle_arrays['box_centers']),
+            xp.asarray(obstacle_arrays['box_half_extents']),
+            xp.asarray(obstacle_arrays['box_rotations']), xp))
+    if not blocks:
+        return xp.zeros((sphere_positions.shape[0], 0))
+    if len(blocks) == 1:
+        return blocks[0]
+    return xp.concatenate(blocks, axis=1)
 
 
 def compute_self_collision_distances(sphere_positions, sphere_radii,

--- a/skrobot/planner/trajectory_optimization/problem.py
+++ b/skrobot/planner/trajectory_optimization/problem.py
@@ -611,6 +611,8 @@ class TrajectoryProblem:
         activation_distance=0.05,
         as_constraint=True,
         n_spheres_per_link=3,
+        mode='sphere',
+        n_surface=None,
     ):
         """Add world collision avoidance cost.
 
@@ -632,7 +634,27 @@ class TrajectoryProblem:
             Higher values mean tighter collision approximation at the
             cost of more residuals. 3 is the historical default; values
             up to ~7 are reasonable for elongated links.
+            (``mode='sphere'`` only.)
+        mode : str
+            Robot-side shape representation. ``'sphere'`` (default) wraps
+            each link in swept spheres: cheap, but the spheres stick out
+            beyond a boxy link, so a link that physically fits through a
+            narrow gap can read as colliding. ``'surface'`` samples points
+            on each link's own collision mesh and evaluates the obstacle
+            distance there, which is not inflated; combined with box
+            obstacles neither side of the pair is approximated outward.
+            Requires a collision mesh on every collision link.
+        n_surface : int
+            Surface sample points kept per link (``mode='surface'`` only).
+
+        Raises
+        ------
+        ValueError
+            If ``mode`` is not one of ``'sphere'`` / ``'surface'``.
         """
+        if mode not in ('sphere', 'surface'):
+            raise ValueError(
+                "mode must be 'sphere' or 'surface', got {}".format(mode))
         self.collision_link_list = collision_link_list
         self.world_obstacles = world_obstacles
 
@@ -650,13 +672,20 @@ class TrajectoryProblem:
         # Use 'soft' for soft cost (gradient descent, etc.)
         kind = 'geq' if as_constraint else 'soft'
 
+        params = {
+            'obstacles': world_obstacles,
+            'activation_distance': activation_distance,
+            'mode': mode,
+        }
+        if mode == 'surface':
+            from skrobot.planner.trajectory_optimization.world_surface_collision import build_world_surface_data
+            params['surface_data'] = build_world_surface_data(
+                collision_link_list, n_surface=n_surface)
+
         self.residuals.append(ResidualSpec(
             name='world_collision',
             residual_fn='world_collision',
-            params={
-                'obstacles': world_obstacles,
-                'activation_distance': activation_distance,
-            },
+            params=params,
             kind=kind,
             weight=weight,
         ))
@@ -668,7 +697,7 @@ class TrajectoryProblem:
         as_constraint=True,
         mode='sphere',
         dim_grid=40,
-        n_surface=48,
+        n_surface=None,
     ):
         """Add self-collision avoidance cost.
 

--- a/skrobot/planner/trajectory_optimization/solvers/augmented_lagrangian.py
+++ b/skrobot/planner/trajectory_optimization/solvers/augmented_lagrangian.py
@@ -141,6 +141,57 @@ def _build_inner_step(problem, objective_fn, constraint_fn, jax, jnp):
     return augmented_lagrangian, inner_loop
 
 
+def _world_distance_fn(params, fk_data, obstacle_arrays, backend,
+                       get_sphere_positions, sphere_radii,
+                       parameterized=False):
+    """Build ``angles -> (n_points, n_obstacles)`` world-collision distances.
+
+    Dispatches on the robot-side representation chosen in
+    :meth:`TrajectoryProblem.add_collision_cost`: swept spheres (default) or
+    link surface samples.
+
+    Parameters
+    ----------
+    params : dict
+        ``world_collision`` residual params.
+    fk_data : dict
+        Output of :func:`prepare_fk_data`.
+    obstacle_arrays : dict
+        Output of :func:`prepare_world_obstacle_arrays`.
+    backend : module
+        Array module.
+    get_sphere_positions : callable
+        ``angles -> (n_spheres, 3)``; used by ``mode='sphere'``.
+    sphere_radii : array
+        Collision sphere radii; used by ``mode='sphere'``.
+
+    Returns
+    -------
+    callable
+        ``f(angles) -> signed distances``.
+    """
+    from skrobot.planner.trajectory_optimization.fk_utils import compute_world_obstacle_distances
+    from skrobot.planner.trajectory_optimization.world_surface_collision import make_world_surface_distance_fn
+
+    if params.get('mode') == 'surface':
+        return make_world_surface_distance_fn(
+            fk_data, params['surface_data'], obstacle_arrays, backend,
+            parameterized=parameterized)
+
+    if parameterized:
+        def sphere_fn(angles, fk):
+            return compute_world_obstacle_distances(
+                get_sphere_positions(angles, fk), sphere_radii,
+                obstacle_arrays, backend)
+    else:
+        def sphere_fn(angles):
+            return compute_world_obstacle_distances(
+                get_sphere_positions(angles), sphere_radii,
+                obstacle_arrays, backend)
+
+    return sphere_fn
+
+
 class AugmentedLagrangianSolver(BaseSolver):
     """Augmented Lagrangian solver for trajectory optimization.
 
@@ -501,9 +552,9 @@ class AugmentedLagrangianSolver(BaseSolver):
         from skrobot.planner.trajectory_optimization.fk_utils import build_fk_functions
         from skrobot.planner.trajectory_optimization.fk_utils import compute_collision_residuals
         from skrobot.planner.trajectory_optimization.fk_utils import compute_self_collision_distances
-        from skrobot.planner.trajectory_optimization.fk_utils import compute_sphere_obstacle_distances
         from skrobot.planner.trajectory_optimization.fk_utils import pose_error_log
         from skrobot.planner.trajectory_optimization.fk_utils import prepare_fk_data
+        from skrobot.planner.trajectory_optimization.fk_utils import prepare_world_obstacle_arrays
         from skrobot.planner.trajectory_optimization.solvers.solver_utils import build_gridsdf_self_distance_fn
 
         dt = problem.dt
@@ -548,11 +599,15 @@ class AugmentedLagrangianSolver(BaseSolver):
 
         for spec in hard_constraints:
             if spec.name == 'world_collision' and has_collision:
-                n_spheres = len(sphere_radii)
                 n_obstacles = len(spec.params['obstacles'])
-                # One constraint per sphere-obstacle pair per waypoint
+                if spec.params.get('mode') == 'surface':
+                    surf = spec.params['surface_data']['surface_points']
+                    n_points = int(surf.shape[0] * surf.shape[1])
+                else:
+                    n_points = len(sphere_radii)
+                # One constraint per (robot point, obstacle) per waypoint
                 n_waypoints = problem.n_waypoints
-                n_coll = n_spheres * n_obstacles * n_waypoints
+                n_coll = n_points * n_obstacles * n_waypoints
                 constraint_specs.append(('world_collision', spec, n_coll))
                 n_constraints += n_coll
 
@@ -617,19 +672,15 @@ class AugmentedLagrangianSolver(BaseSolver):
                     obstacles = params['obstacles']
                     activation = params['activation_distance']
 
-                    sphere_obs = [o for o in obstacles if o['type'] == 'sphere']
-                    if sphere_obs:
-                        obs_centers = jnp.stack(
-                            [jnp.array(o['center']) for o in sphere_obs]
-                        )
-                        obs_radii = jnp.array([o['radius'] for o in sphere_obs])
+                    obs_arrays = prepare_world_obstacle_arrays(obstacles)
+                    if obstacles:
+                        world_dist_fn = _world_distance_fn(
+                            params, fk_data, obs_arrays, jnp,
+                            get_sphere_positions, sphere_radii,
+                            parameterized=True)
 
                         def coll_cost_single(angles):
-                            sphere_pos = get_sphere_positions(angles, fk)
-                            signed_dists = compute_sphere_obstacle_distances(
-                                sphere_pos, sphere_radii,
-                                obs_centers, obs_radii, jnp
-                            )
+                            signed_dists = world_dist_fn(angles, fk)
                             residuals = compute_collision_residuals(
                                 signed_dists, activation, jnp
                             )
@@ -755,21 +806,16 @@ class AugmentedLagrangianSolver(BaseSolver):
                     obstacles = params['obstacles']
                     activation = params['activation_distance']
 
-                    sphere_obs = [o for o in obstacles if o['type'] == 'sphere']
-                    if sphere_obs:
-                        obs_centers = jnp.stack(
-                            [jnp.array(o['center']) for o in sphere_obs]
-                        )
-                        obs_radii = jnp.array([o['radius'] for o in sphere_obs])
+                    obs_arrays = prepare_world_obstacle_arrays(obstacles)
+                    if obstacles:
+                        world_dist_fn = _world_distance_fn(
+                            params, fk_data, obs_arrays, jnp,
+                            get_sphere_positions, sphere_radii,
+                            parameterized=True)
 
                         def coll_dist_single(angles):
-                            sphere_pos = get_sphere_positions(angles, fk)
-                            signed_dists = compute_sphere_obstacle_distances(
-                                sphere_pos, sphere_radii,
-                                obs_centers, obs_radii, jnp
-                            )
                             # Return signed distance (>= 0 is no collision)
-                            return signed_dists.flatten()
+                            return world_dist_fn(angles, fk).flatten()
 
                         # (n_waypoints, n_spheres * n_obstacles)
                         dists = jax.vmap(coll_dist_single)(trajectory)

--- a/skrobot/planner/trajectory_optimization/solvers/gradient_descent.py
+++ b/skrobot/planner/trajectory_optimization/solvers/gradient_descent.py
@@ -238,9 +238,10 @@ class GradientDescentSolver(BaseSolver):
         from skrobot.planner.trajectory_optimization.fk_utils import build_fk_functions
         from skrobot.planner.trajectory_optimization.fk_utils import compute_collision_residuals
         from skrobot.planner.trajectory_optimization.fk_utils import compute_self_collision_distances
-        from skrobot.planner.trajectory_optimization.fk_utils import compute_sphere_obstacle_distances
+        from skrobot.planner.trajectory_optimization.fk_utils import compute_world_obstacle_distances
         from skrobot.planner.trajectory_optimization.fk_utils import pose_error_log
         from skrobot.planner.trajectory_optimization.fk_utils import prepare_fk_data
+        from skrobot.planner.trajectory_optimization.fk_utils import prepare_world_obstacle_arrays
         from skrobot.planner.trajectory_optimization.solvers.solver_utils import build_gridsdf_self_distance_fn
 
         dt = problem.dt
@@ -313,18 +314,13 @@ class GradientDescentSolver(BaseSolver):
                     obstacles = params['obstacles']
                     activation = params['activation_distance']
 
-                    sphere_obs = [o for o in obstacles if o['type'] == 'sphere']
-                    if sphere_obs:
-                        obs_centers = jnp.stack(
-                            [jnp.array(o['center']) for o in sphere_obs]
-                        )
-                        obs_radii = jnp.array([o['radius'] for o in sphere_obs])
+                    obs_arrays = prepare_world_obstacle_arrays(obstacles)
+                    if obstacles:
 
                         def coll_cost_single(angles):
                             sphere_pos = get_sphere_positions(angles)
-                            signed_dists = compute_sphere_obstacle_distances(
-                                sphere_pos, sphere_radii,
-                                obs_centers, obs_radii, jnp
+                            signed_dists = compute_world_obstacle_distances(
+                                sphere_pos, sphere_radii, obs_arrays, jnp
                             )
                             residuals = compute_collision_residuals(
                                 signed_dists, activation, jnp

--- a/skrobot/planner/trajectory_optimization/solvers/jaxls_solver.py
+++ b/skrobot/planner/trajectory_optimization/solvers/jaxls_solver.py
@@ -933,7 +933,8 @@ class JaxlsSolver(BaseSolver):
 
         from skrobot.planner.trajectory_optimization.fk_utils import build_fk_functions
         from skrobot.planner.trajectory_optimization.fk_utils import compute_collision_residuals
-        from skrobot.planner.trajectory_optimization.fk_utils import compute_sphere_obstacle_distances
+        from skrobot.planner.trajectory_optimization.fk_utils import compute_world_obstacle_distances
+        from skrobot.planner.trajectory_optimization.fk_utils import prepare_world_obstacle_arrays
 
         T = problem.n_waypoints
         obstacles = spec.params['obstacles']
@@ -941,11 +942,9 @@ class JaxlsSolver(BaseSolver):
         weight = jnp.sqrt(spec.weight)
 
         # Parse obstacles
-        sphere_obs = [
-            obs for obs in obstacles if obs['type'] == 'sphere'
-        ]
+        obs_arrays = prepare_world_obstacle_arrays(obstacles)
 
-        if not sphere_obs:
+        if not obstacles:
             # No obstacles, return dummy cost
             @jaxls.Cost.factory(name='world_collision_dummy')
             def dummy_cost(vals, var):
@@ -953,8 +952,6 @@ class JaxlsSolver(BaseSolver):
 
             return dummy_cost(TrajectoryVar(jnp.array([0])))
 
-        obs_centers = jnp.stack([jnp.array(o['center']) for o in sphere_obs])
-        obs_radii = jnp.array([o['radius'] for o in sphere_obs])
         sphere_radii = fk_data['sphere_radii']
 
         _, get_sphere_positions, _, _ = build_fk_functions(fk_data, jnp)
@@ -972,8 +969,8 @@ class JaxlsSolver(BaseSolver):
             def world_collision_geq(vals, var):
                 angles = vals[var]
                 sphere_pos = get_sphere_positions(angles)
-                signed_dists = compute_sphere_obstacle_distances(
-                    sphere_pos, sphere_radii, obs_centers, obs_radii, jnp
+                signed_dists = compute_world_obstacle_distances(
+                    sphere_pos, sphere_radii, obs_arrays, jnp
                 )
                 # Slack: distance beyond the activation buffer.
                 return (signed_dists - activation_dist).flatten()
@@ -986,8 +983,8 @@ class JaxlsSolver(BaseSolver):
             sphere_pos = get_sphere_positions(angles)
 
             # Use helper functions for distance computation
-            signed_dists = compute_sphere_obstacle_distances(
-                sphere_pos, sphere_radii, obs_centers, obs_radii, jnp
+            signed_dists = compute_world_obstacle_distances(
+                sphere_pos, sphere_radii, obs_arrays, jnp
             )
             residuals = compute_collision_residuals(
                 signed_dists, activation_dist, jnp

--- a/skrobot/planner/trajectory_optimization/solvers/scipy_solver.py
+++ b/skrobot/planner/trajectory_optimization/solvers/scipy_solver.py
@@ -205,18 +205,17 @@ class ScipySolver(BaseSolver):
             Constraint function returning (values, jacobian).
         """
         from skrobot.planner.trajectory_optimization.fk_utils import build_fk_functions
-        from skrobot.planner.trajectory_optimization.fk_utils import compute_sphere_obstacle_distances
+        from skrobot.planner.trajectory_optimization.fk_utils import compute_world_obstacle_distances
         from skrobot.planner.trajectory_optimization.fk_utils import prepare_fk_data
+        from skrobot.planner.trajectory_optimization.fk_utils import prepare_world_obstacle_arrays
 
         # Parse obstacles
-        sphere_obs = [o for o in problem.world_obstacles if o['type'] == 'sphere']
-        if not sphere_obs:
+        if not problem.world_obstacles:
             def dummy_constraint(x):
                 return np.array([1.0]), np.zeros((1, n_wp * n_dof))
             return dummy_constraint
 
-        obs_centers = np.array([o['center'] for o in sphere_obs])
-        obs_radii = np.array([o['radius'] for o in sphere_obs])
+        obs_arrays = prepare_world_obstacle_arrays(problem.world_obstacles)
 
         # Build FK functions using shared module
         fk_data = prepare_fk_data(problem, np)
@@ -236,8 +235,8 @@ class ScipySolver(BaseSolver):
                 sphere_pos = get_sphere_positions(angles)
 
                 # Compute distances to all obstacles
-                signed_dists = compute_sphere_obstacle_distances(
-                    sphere_pos, sphere_radii, obs_centers, obs_radii, np
+                signed_dists = compute_world_obstacle_distances(
+                    sphere_pos, sphere_radii, obs_arrays, np
                 )
                 min_dist = np.min(signed_dists)
                 min_dists.append(min_dist)

--- a/skrobot/planner/trajectory_optimization/world_surface_collision.py
+++ b/skrobot/planner/trajectory_optimization/world_surface_collision.py
@@ -1,0 +1,205 @@
+"""Surface-point based world-collision distances (backend-agnostic).
+
+The default world-collision cost approximates every robot link with a few
+spheres and measures the distance from those sphere centres to the obstacles.
+For links that are far from spherical -- a boxy modular-robot module, say --
+that is heavily over-conservative: the enclosing spheres stick out well beyond
+the real geometry, so a link that physically fits through a gap reads as
+colliding.
+
+This module instead samples points on each collision link's own surface,
+transforms them into the world frame with the link transforms, and evaluates
+the obstacle's *exact* signed distance function at those points.  Combined
+with the analytic box SDF in
+:func:`~skrobot.planner.trajectory_optimization.fk_utils.compute_box_obstacle_distances`
+neither side of the pair is inflated.
+
+Build the static data once with :func:`build_world_surface_data` (NumPy), then
+get a plain ``angles -> signed distances`` callable from
+:func:`make_world_surface_distance_fn` and feed it to
+:func:`~skrobot.planner.trajectory_optimization.fk_utils.compute_collision_residuals`,
+exactly as for the sphere model.
+
+Querying sampled surface points of the robot against a signed distance field
+of the environment is the scheme used by recent GPU trajectory optimizers such
+as cuRobo [1]_; the hinge residual ``max(activation_distance - d, 0)`` on top
+of it is the obstacle cost of CHOMP [2]_.
+
+References
+----------
+.. [1] B. Sundaralingam, S. K. S. Hari, A. Fishman, C. Garrett, K. Van Wyk,
+   V. Blukis, A. Millane, H. Oleynikova, A. Handa, F. Ramos, N. Ratliff and
+   D. Fox.  "cuRobo: Parallelized Collision-Free Robot Motion Generation."
+   IEEE International Conference on Robotics and Automation (ICRA), 2024.
+.. [2] N. Ratliff, M. Zucker, J. A. Bagnell and S. Srinivasa.
+   "CHOMP: Gradient Optimization Techniques for Efficient Motion Planning."
+   IEEE International Conference on Robotics and Automation (ICRA), 2009.
+"""
+import numpy as np
+
+from skrobot.planner.trajectory_optimization.fk_utils import build_collision_link_transform_fn
+from skrobot.planner.trajectory_optimization.fk_utils import compute_world_obstacle_distances
+
+
+def build_world_surface_data(collision_link_list, n_surface=None):
+    """Sample surface points on each collision link.
+
+    Points are taken from the link's **convex hull**, not from the raw
+    collision mesh.  Randomly sampling raw vertices misses the extreme
+    points that actually decide a near-miss: a TYCOON module housing has
+    ~19k vertices, so even 500 random samples cover 2.6% of them and the
+    deepest point of a 1 cm penetration is almost never among them.  The
+    hull has a few hundred vertices, contains every extreme point, and
+    encloses the mesh -- so the distance it yields is conservative (never
+    optimistic) for convex obstacles.
+
+    Parameters
+    ----------
+    collision_link_list : list[skrobot.model.Link]
+        Collision links, in the same order handed to
+        :meth:`TrajectoryProblem.add_collision_cost`.
+    n_surface : int, optional
+        Cap on points per link.  ``None`` (default) keeps every hull
+        vertex.  When given and the hull has more, a deterministic
+        farthest-point subset of that size is used.
+
+    Returns
+    -------
+    dict
+        ``surface_points`` (n_meshed, S, 3) in link-local coordinates,
+        where ``S`` is the largest per-link count (shorter links are
+        padded by repeating a point, which only duplicates residuals),
+        and ``link_indices`` (n_meshed,) giving each entry's position in
+        ``collision_link_list``.  Links without a collision mesh carry no
+        geometry to sample and are skipped.
+
+    Raises
+    ------
+    ValueError
+        If no collision link has a collision mesh.
+    """
+    per_link, kept = [], []
+    for i, link in enumerate(collision_link_list):
+        if link.collision_mesh is None:
+            continue
+        hull = np.asarray(link.collision_mesh.convex_hull.vertices,
+                          dtype=np.float64)
+        if n_surface is not None and len(hull) > n_surface:
+            hull = _farthest_point_subset(hull, n_surface)
+        per_link.append(hull)
+        kept.append(i)
+    if not per_link:
+        raise ValueError(
+            "mode='surface' needs a collision mesh on at least one "
+            'collision link, but none of the {} links has one'.format(
+                len(collision_link_list)))
+
+    size = max(len(p) for p in per_link)
+    padded = np.stack([
+        p if len(p) == size
+        else np.concatenate([p, np.repeat(p[:1], size - len(p), axis=0)])
+        for p in per_link])
+    return {'surface_points': padded,
+            'link_indices': np.asarray(kept, dtype=np.int64)}
+
+
+def _farthest_point_subset(points, k):
+    """Deterministic farthest-point subset of ``points`` (k, 3).
+
+    Greedy farthest-point sampling keeps the extremes, which is what the
+    collision distance depends on; a random subset does not.
+    """
+    chosen = [int(np.argmax(points[:, 0]))]
+    d = np.linalg.norm(points - points[chosen[0]], axis=1)
+    for _ in range(k - 1):
+        nxt = int(np.argmax(d))
+        chosen.append(nxt)
+        d = np.minimum(d, np.linalg.norm(points - points[nxt], axis=1))
+    return points[np.asarray(chosen)]
+
+
+def world_surface_distances(link_positions, link_rotations, surface_points,
+                            obstacle_arrays, backend, link_indices=None):
+    """Signed distances from link surface points to the world obstacles.
+
+    Parameters
+    ----------
+    link_positions : array
+        Collision link origins in the world frame (n_links, 3).
+    link_rotations : array
+        Collision link rotations in the world frame (n_links, 3, 3).
+    surface_points : array
+        Link-local surface samples (n_links, n_surface, 3).
+    obstacle_arrays : dict
+        Output of
+        :func:`~skrobot.planner.trajectory_optimization.fk_utils.prepare_world_obstacle_arrays`.
+    backend : module
+        Array module (``numpy`` or ``jax.numpy``).
+    link_indices : array, optional
+        Rows of ``link_positions`` / ``link_rotations`` that
+        ``surface_points`` refers to.  Needed when some collision links
+        were skipped for having no mesh.
+
+    Returns
+    -------
+    array
+        Signed distances (n_meshed * n_surface, n_obstacles).
+        Positive = separated, negative = penetrating.
+    """
+    xp = backend
+    if link_indices is not None:
+        link_positions = link_positions[link_indices]
+        link_rotations = link_rotations[link_indices]
+    # (n_meshed, n_surface, 3) local -> world
+    world_pts = link_positions[:, None, :] \
+        + xp.einsum('lij,lsj->lsi', link_rotations, surface_points)
+    flat = world_pts.reshape((-1, 3))
+    # Surface points have no radius of their own: the link geometry is
+    # already represented by where the points are.
+    radii = xp.zeros(flat.shape[0])
+    return compute_world_obstacle_distances(
+        flat, radii, obstacle_arrays, xp)
+
+
+def make_world_surface_distance_fn(fk_data, surface_data, obstacle_arrays,
+                                   backend, parameterized=False):
+    """Build the ``angles -> signed distances`` callable.
+
+    Parameters
+    ----------
+    fk_data : dict
+        Output of
+        :func:`~skrobot.planner.trajectory_optimization.fk_utils.prepare_fk_data`.
+    surface_data : dict
+        Output of :func:`build_world_surface_data`.
+    obstacle_arrays : dict
+        Output of
+        :func:`~skrobot.planner.trajectory_optimization.fk_utils.prepare_world_obstacle_arrays`.
+    backend : module
+        Array module (``numpy`` or ``jax.numpy``).
+
+    Returns
+    -------
+    callable
+        ``f(angles) -> (n_links * n_surface, n_obstacles)`` signed distances.
+    """
+    xp = backend
+    get_link_transforms = build_collision_link_transform_fn(
+        fk_data, backend, parameterized=parameterized)
+    surface_points = xp.asarray(surface_data['surface_points'])
+    link_indices = xp.asarray(surface_data['link_indices'])
+
+    if parameterized:
+        def distance_fn(angles, fk):
+            link_pos, link_rot = get_link_transforms(angles, fk)
+            return world_surface_distances(
+                link_pos, link_rot, surface_points, obstacle_arrays, xp,
+                link_indices=link_indices)
+    else:
+        def distance_fn(angles):
+            link_pos, link_rot = get_link_transforms(angles)
+            return world_surface_distances(
+                link_pos, link_rot, surface_points, obstacle_arrays, xp,
+                link_indices=link_indices)
+
+    return distance_fn

--- a/tests/skrobot_tests/planner_tests/test_trajectory_optimization.py
+++ b/tests/skrobot_tests/planner_tests/test_trajectory_optimization.py
@@ -1685,3 +1685,143 @@ class TestCartesianAxisMasks(unittest.TestCase):
             return float(solver.solve(problem, traj).cost)
 
         self.assertAlmostEqual(cost_for(0.0), cost_for(5.0), places=6)
+
+
+class TestBoxObstacles(unittest.TestCase):
+    """A box obstacle must use the exact SDF, not an inflated stand-in."""
+
+    def test_prepare_splits_by_type(self):
+        from skrobot.planner.trajectory_optimization.fk_utils import prepare_world_obstacle_arrays
+
+        arrays = prepare_world_obstacle_arrays([
+            {'type': 'sphere', 'center': [0.0, 0.0, 0.0], 'radius': 0.1},
+            {'type': 'box', 'center': [1.0, 0.0, 0.0],
+             'extents': [0.2, 0.4, 0.6]},
+        ])
+        self.assertEqual(arrays['sphere_centers'].shape, (1, 3))
+        self.assertEqual(arrays['box_centers'].shape, (1, 3))
+        # extents are full side lengths; the residual wants half extents
+        testing.assert_allclose(arrays['box_half_extents'][0],
+                                [0.1, 0.2, 0.3])
+        testing.assert_allclose(arrays['box_rotations'][0], np.eye(3))
+
+    def test_unknown_type_is_rejected(self):
+        from skrobot.planner.trajectory_optimization.fk_utils import prepare_world_obstacle_arrays
+
+        with self.assertRaises(ValueError):
+            prepare_world_obstacle_arrays([{'type': 'cone', 'center': [0] * 3}])
+
+    def test_signed_distance_matches_the_analytic_box(self):
+        from skrobot.planner.trajectory_optimization.fk_utils import compute_box_obstacle_distances
+
+        centers = np.array([[0.0, 0.0, 0.0]])
+        half = np.array([[0.1, 0.2, 0.3]])
+        rots = np.array([np.eye(3)])
+        radii = np.array([0.0])
+
+        # face, corner, and a point strictly inside
+        points = np.array([
+            [0.5, 0.0, 0.0],     # 0.4 clear of the +x face
+            [0.1 + 0.3, 0.2 + 0.4, 0.3],  # (0.3, 0.4, 0) from the corner
+            [0.0, 0.0, 0.0],     # centre: -min(h) inside
+        ])
+        d = compute_box_obstacle_distances(points, radii, centers, half,
+                                           rots, np)
+        testing.assert_allclose(d[0, 0], 0.4, atol=1e-6)
+        testing.assert_allclose(d[1, 0], 0.5, atol=1e-6)
+        self.assertLess(d[2, 0], 0.0)
+        # Inside the box the exact value is -min(h) = -0.1. The residual
+        # keeps an epsilon under the sqrt so the gradient stays finite at
+        # the surface, which shifts an interior distance by sqrt(1e-10).
+        testing.assert_allclose(d[2, 0], -0.1 + 1e-5, atol=1e-7)
+
+    def test_sphere_radius_shrinks_the_clearance(self):
+        from skrobot.planner.trajectory_optimization.fk_utils import compute_box_obstacle_distances
+
+        centers = np.array([[0.0, 0.0, 0.0]])
+        half = np.array([[0.1, 0.1, 0.1]])
+        rots = np.array([np.eye(3)])
+        point = np.array([[0.5, 0.0, 0.0]])
+
+        bare = compute_box_obstacle_distances(point, np.array([0.0]),
+                                              centers, half, rots, np)
+        fat = compute_box_obstacle_distances(point, np.array([0.05]),
+                                             centers, half, rots, np)
+        testing.assert_allclose(bare[0, 0] - fat[0, 0], 0.05, atol=1e-6)
+
+    def test_rotation_turns_the_box(self):
+        from skrobot.coordinates.math import rotation_matrix
+        from skrobot.planner.trajectory_optimization.fk_utils import compute_box_obstacle_distances
+
+        centers = np.array([[0.0, 0.0, 0.0]])
+        half = np.array([[0.4, 0.05, 0.05]])
+        radii = np.array([0.0])
+        point = np.array([[0.0, 0.3, 0.0]])
+
+        upright = compute_box_obstacle_distances(
+            point, radii, centers, half, np.array([np.eye(3)]), np)
+        # Turning the long axis to +y puts the slab under the query point.
+        turned = compute_box_obstacle_distances(
+            point, radii, centers, half,
+            np.array([rotation_matrix(np.pi / 2.0, [0, 0, 1])]), np)
+        self.assertGreater(upright[0, 0], turned[0, 0])
+        # Turned, the box-local query point is (0.3, 0, 0) against half
+        # extents (0.4, 0.05, 0.05): inside on every axis, and the signed
+        # distance is the least-negative slack, -0.05.
+        testing.assert_allclose(turned[0, 0], -0.05 + 1e-5, atol=1e-7)
+
+
+class TestWorldSurfaceData(unittest.TestCase):
+    """Surface points come from the convex hull, not raw mesh vertices."""
+
+    def _links(self):
+        robot = skrobot.models.Panda()
+        return [ln for ln in robot.link_list
+                if ln.collision_mesh is not None][:3]
+
+    def test_points_are_hull_vertices(self):
+        from skrobot.planner.trajectory_optimization.world_surface_collision import build_world_surface_data
+
+        links = self._links()
+        data = build_world_surface_data(links)
+        points = data['surface_points']
+        self.assertEqual(points.shape[0], len(links))
+        self.assertEqual(points.shape[2], 3)
+
+        # Sampling raw vertices would miss the extreme points that decide a
+        # near miss. Every hull vertex must be present for each link.
+        for i, link in enumerate(links):
+            hull = np.asarray(link.collision_mesh.convex_hull.vertices)
+            kept = points[i]
+            for v in hull:
+                self.assertTrue(
+                    np.isclose(kept, v, atol=1e-9).all(axis=1).any(),
+                    'hull vertex {} missing for {}'.format(v, link.name))
+
+    def test_n_surface_caps_each_link(self):
+        from skrobot.planner.trajectory_optimization.world_surface_collision import build_world_surface_data
+
+        links = self._links()
+        data = build_world_surface_data(links, n_surface=8)
+        self.assertLessEqual(data['surface_points'].shape[1], 8)
+        testing.assert_array_equal(data['link_indices'],
+                                   np.arange(len(links)))
+
+    def test_subset_is_deterministic(self):
+        from skrobot.planner.trajectory_optimization.world_surface_collision import build_world_surface_data
+
+        links = self._links()
+        first = build_world_surface_data(links, n_surface=8)
+        second = build_world_surface_data(links, n_surface=8)
+        testing.assert_array_equal(first['surface_points'],
+                                   second['surface_points'])
+
+    def test_links_without_a_mesh_are_rejected_when_none_has_one(self):
+        from skrobot.planner.trajectory_optimization.world_surface_collision import build_world_surface_data
+
+        robot = skrobot.models.Panda()
+        bare = [ln for ln in robot.link_list if ln.collision_mesh is None]
+        if not bare:
+            self.skipTest('every Panda link carries a collision mesh')
+        with self.assertRaises(ValueError):
+            build_world_surface_data(bare)


### PR DESCRIPTION
Adds exact box obstacles and a surface-sample collision model for the
robot side.

**Boxes.** World obstacles were spheres only, so a box had to be
approximated by a sphere lattice, which inflates it — the union bulges past
every face — and grows the residual count with the lattice. `add_collision_cost`
now accepts `{'type': 'box', 'center', 'extents'[, 'rotation']}` and uses the
exact box SDF, so the obstacle is the size it says it is and one residual
covers it.

**Surface sampling.** `mode='surface'` measures points sampled on each
collision link against the obstacles instead of wrapping the link in swept
spheres. The points come from the link's **convex hull**, not the raw mesh.
Randomly sampling raw vertices misses the extreme points that decide a near
miss: a bulky housing can carry ~19k vertices, so even 500 samples cover a
few percent of them and the deepest point of a shallow penetration is almost
never among them. A hull has a few hundred vertices, contains every extreme
point, and encloses the mesh, so the reported distance stays conservative for
convex obstacles. `n_surface` caps the per-link count with a deterministic
farthest-point subset.

Tests: the type split and rejection of unknown types, signed distances
against hand-computed values outside / at a corner / inside, the sphere
radius shrinking the clearance, a rotated box, and the surface data keeping
every hull vertex, honouring the cap, and being deterministic.
