### PR TITLE
Share compiled trajectory costs across solver instances

### DIFF
--- a/skrobot/planner/trajectory_optimization/solvers/augmented_lagrangian.py
+++ b/skrobot/planner/trajectory_optimization/solvers/augmented_lagrangian.py
@@ -30,8 +30,34 @@ if platform.system() == 'Darwin':
 import numpy as np
 
 from skrobot.planner.trajectory_optimization.fk_utils import fk_runtime_arrays
+from skrobot.planner.trajectory_optimization.fk_utils import prepare_fk_data
 from skrobot.planner.trajectory_optimization.solvers.base import BaseSolver
 from skrobot.planner.trajectory_optimization.solvers.base import SolverResult
+
+
+#: Compiled objective/constraint pairs, shared by every solver instance.
+#:
+#: Keyed by the problem's structure and by a hash of every value the trace
+#: closes over. The FK arrays are deliberately absent from both: they travel
+#: as a runtime argument, so one entry serves every problem with the same
+#: structure whatever its kinematics. That is what makes a process-wide cache
+#: safe here -- while FK was baked into the trace, sharing an entry between
+#: two robots would have returned one robot's motion for the other.
+#:
+#: A solver instance used to own this, and callers that build a solver per
+#: solve (``solve_ik`` does) therefore compiled from scratch every time and
+#: leaked the executable's mmap regions until the process hit
+#: ``vm.max_map_count``.
+_JIT_CACHE = {}
+
+
+def clear_jit_cache():
+    """Drop every compiled objective/constraint pair held by the cache.
+
+    Only useful to reclaim memory in a process that has solved many
+    structurally different problems; correctness never requires it.
+    """
+    _JIT_CACHE.clear()
 
 
 def _build_inner_step(problem, objective_fn, constraint_fn, jax, jnp):
@@ -255,7 +281,6 @@ class AugmentedLagrangianSolver(BaseSolver):
         self.penalty_multiplier = penalty_multiplier
         self.max_penalty = max_penalty
         self.constraint_tolerance = constraint_tolerance
-        self._jit_cache = {}
 
     @property
     def max_iterations(self):
@@ -322,20 +347,22 @@ class AugmentedLagrangianSolver(BaseSolver):
         structure_key = self._get_problem_structure_key(problem)
         value_hash = self._get_problem_value_hash(problem)
 
-        need_rebuild = False
-        if structure_key not in self._jit_cache:
-            need_rebuild = True
-        elif self._jit_cache[structure_key].get('value_hash') != value_hash:
-            need_rebuild = True
+        cache_key = (structure_key, value_hash)
+        entry = _JIT_CACHE.get(cache_key)
+        if entry is None:
+            objective_fn, constraint_fn, n_constraints, fk_data = \
+                self._build_functions(problem)
+            # Only the compiled functions are shared. fk_data belongs to the
+            # problem that happened to build them, and keeping it here would
+            # hand its kinematics to every later problem that hits this entry
+            # -- the compiled functions are FK-agnostic precisely so that they
+            # can be shared, and reusing the arrays would undo that.
+            _JIT_CACHE[cache_key] = (objective_fn, constraint_fn,
+                                     n_constraints, fk_data is not None)
+        else:
+            objective_fn, constraint_fn, n_constraints, has_fk = entry
+            fk_data = prepare_fk_data(problem, jnp) if has_fk else None
 
-        if need_rebuild:
-            self._jit_cache[structure_key] = {
-                'value_hash': value_hash,
-                'functions': self._build_functions(problem),
-            }
-
-        objective_fn, constraint_fn, n_constraints, fk_data = \
-            self._jit_cache[structure_key]['functions']
         # The FK arrays travel as an argument; the structure that shapes the
         # graph stays in the closure built above.
         fk = fk_runtime_arrays(fk_data) if fk_data is not None else {}

--- a/skrobot/planner/trajectory_optimization/solvers/solver_utils.py
+++ b/skrobot/planner/trajectory_optimization/solvers/solver_utils.py
@@ -2,6 +2,8 @@
 
 import hashlib
 
+import numpy as np
+
 
 def get_problem_structure_key(problem):
     """Generate cache key from problem structure.
@@ -79,10 +81,47 @@ def _self_collision_structure(spec):
     return (mode, len(data['pairs_a']), data['surface_points'].shape[1])
 
 
-def get_problem_value_hash(problem):
-    """Generate hash of problem values (obstacle positions, targets, etc.).
+def _feed_value(md5, value):
+    """Fold one problem value into ``md5``.
 
-    Combined with structure key to detect when functions need rebuilding.
+    Walks containers so a residual's params are covered whatever shape they
+    take. Anything that is not a container is folded in through ``repr``,
+    which is stable for the scalars and strings these params hold.
+    """
+    if isinstance(value, np.ndarray):
+        md5.update(b'a')
+        md5.update(repr((value.shape, value.dtype.str)).encode())
+        md5.update(np.ascontiguousarray(value).tobytes())
+    elif isinstance(value, dict):
+        md5.update(b'd')
+        for key in sorted(value, key=repr):
+            md5.update(repr(key).encode())
+            _feed_value(md5, value[key])
+    elif isinstance(value, (list, tuple)):
+        md5.update(b'l')
+        for item in value:
+            _feed_value(md5, item)
+    else:
+        md5.update(b's')
+        md5.update(repr(value).encode())
+
+
+def get_problem_value_hash(problem):
+    """Hash every problem value the compiled functions close over.
+
+    Combined with the structure key this decides whether a cached pair of
+    compiled functions may serve a problem. The FK arrays are excluded: they
+    travel as a runtime argument, so one executable serves every problem with
+    the same structure regardless of kinematics.
+
+    Everything else the residuals hold -- targets, obstacle geometry, sphere
+    radii, axis masks, activation distances, grid contents -- is still baked
+    into the trace, so it has to be part of the key. Rather than listing those
+    fields, this walks the residual params wholesale: a field added by a later
+    residual is then covered without anyone remembering to extend this
+    function. Two earlier additions (the box obstacles' extents and rotation,
+    and the Cartesian axis masks) were missed by the field-by-field version
+    that came before, which would have let one problem's values serve another.
 
     Parameters
     ----------
@@ -92,43 +131,37 @@ def get_problem_value_hash(problem):
     Returns
     -------
     str or None
-        MD5 hash of problem values, or None if no values to hash.
+        Hash of the problem's values, or None when it holds none.
     """
-    hash_parts = []
+    md5 = hashlib.md5()
+    empty = True
 
-    # Hash obstacle positions
     if problem.world_obstacles:
-        for obs in problem.world_obstacles:
-            hash_parts.append(str(obs.get('center', [])))
-            hash_parts.append(str(obs.get('radius', 0)))
+        empty = False
+        _feed_value(md5, problem.world_obstacles)
 
-    # Hash EE waypoint targets
-    for c in problem.ee_waypoint_costs:
-        hash_parts.append(c['target_position'].tobytes())
-        hash_parts.append(c['target_rotation'].tobytes())
-
-    # Hash cartesian path targets
     for spec in problem.residuals:
-        if spec.name == 'cartesian_path':
-            params = spec.params
-            target_pos = params.get('target_positions')
-            if target_pos is not None:
-                hash_parts.append(target_pos.tobytes())
-            target_rot = params.get('target_rotations')
-            if target_rot is not None:
-                hash_parts.append(target_rot.tobytes())
+        empty = False
+        md5.update(repr(spec.name).encode())
+        _feed_value(md5, spec.weight)
+        _feed_value(md5, spec.params)
 
-    # Hash waypoint constraint values
-    for _, angles in problem.waypoint_constraints:
-        hash_parts.append(angles.tobytes())
+    for cost in problem.ee_waypoint_costs:
+        empty = False
+        _feed_value(md5, cost)
 
-    if not hash_parts:
+    for idx, angles in problem.waypoint_constraints:
+        empty = False
+        _feed_value(md5, idx)
+        _feed_value(md5, angles)
+
+    if problem.collision_spheres is not None:
+        empty = False
+        _feed_value(md5, problem.collision_spheres)
+
+    if empty:
         return None
-
-    combined = b''.join(
-        p if isinstance(p, bytes) else p.encode() for p in hash_parts
-    )
-    return hashlib.md5(combined).hexdigest()[:16]
+    return md5.hexdigest()[:16]
 
 
 def build_gridsdf_self_distance_fn(problem, fk_data, backend,

--- a/tests/skrobot_tests/planner_tests/test_trajectory_optimization.py
+++ b/tests/skrobot_tests/planner_tests/test_trajectory_optimization.py
@@ -1335,18 +1335,26 @@ class TestAugmentedLagrangianSolver(unittest.TestCase):
         end = np.ones(self.n_joints) * 0.3
         initial_traj = interpolate_trajectory(start, end, 3)
 
+        # The cache is module-level, not per-solver, so the assertions read
+        # it there. Clearing first keeps the test independent of whatever an
+        # earlier test left behind.
+        from skrobot.planner.trajectory_optimization.solvers.augmented_lagrangian import _JIT_CACHE
+        from skrobot.planner.trajectory_optimization.solvers.augmented_lagrangian import clear_jit_cache
+        clear_jit_cache()
+        self.addCleanup(clear_jit_cache)
+
         solver = AugmentedLagrangianSolver(max_iterations=20)
 
         # First solve builds cache
         solver.solve(problem, initial_traj)
-        cache_keys_after_first = list(solver._jit_cache.keys())
+        cache_keys_after_first = list(_JIT_CACHE.keys())
 
         # Second solve with same structure should reuse cache
         end2 = np.ones(self.n_joints) * 0.4
         initial_traj2 = interpolate_trajectory(start, end2, 3)
         solver.solve(problem, initial_traj2)
 
-        cache_keys_after_second = list(solver._jit_cache.keys())
+        cache_keys_after_second = list(_JIT_CACHE.keys())
         self.assertEqual(cache_keys_after_first, cache_keys_after_second)
 
 
@@ -1825,3 +1833,149 @@ class TestWorldSurfaceData(unittest.TestCase):
             self.skipTest('every Panda link carries a collision mesh')
         with self.assertRaises(ValueError):
             build_world_surface_data(bare)
+
+
+class TestJitCacheKey(unittest.TestCase):
+    """The cache is process-wide, so its key has to separate the values."""
+
+    def _chain(self):
+        robot = skrobot.models.Kuka()
+        robot.reset_manip_pose()
+        return robot, robot.rarm.link_list
+
+    def _cartesian(self, position_mask=None):
+        robot, link_list = self._chain()
+        problem = TrajectoryProblem(robot, link_list, n_waypoints=3,
+                                    move_target=robot.rarm_end_coords)
+        target = robot.rarm_end_coords.worldpos() + np.array([0.05, 0.0, 0.05])
+        problem.add_cartesian_path_cost(
+            np.tile(target, (3, 1)), weight=10.0,
+            position_mask=position_mask)
+        return problem
+
+    def _boxed(self, extents):
+        robot, link_list = self._chain()
+        problem = TrajectoryProblem(robot, link_list, n_waypoints=3,
+                                    move_target=robot.rarm_end_coords)
+        problem.add_collision_cost(
+            link_list,
+            [{'type': 'box', 'center': [0.4, 0.0, 0.4], 'extents': extents}])
+        return problem
+
+    def _key(self, problem):
+        from skrobot.planner.trajectory_optimization.solvers.solver_utils import get_problem_structure_key
+        from skrobot.planner.trajectory_optimization.solvers.solver_utils import get_problem_value_hash
+        return (get_problem_structure_key(problem),
+                get_problem_value_hash(problem))
+
+    def test_same_problem_shares_a_key(self):
+        # Without this the cache never hits and the change is pointless.
+        self.assertEqual(self._key(self._cartesian([1, 1, 0])),
+                         self._key(self._cartesian([1, 1, 0])))
+
+    def test_axis_mask_separates_the_key(self):
+        """A masked axis is baked into the trace, so it must reach the key.
+
+        Structure is identical here, so only the value hash can tell these
+        apart. The field-by-field hash this replaced did not look at the
+        masks, and would have handed one problem's compiled cost to the
+        other.
+        """
+        a = self._cartesian([1, 1, 1])
+        b = self._cartesian([1, 1, 0])
+        from skrobot.planner.trajectory_optimization.solvers.solver_utils import get_problem_structure_key
+        self.assertEqual(get_problem_structure_key(a),
+                         get_problem_structure_key(b))
+        self.assertNotEqual(self._key(a), self._key(b))
+
+    def test_box_extents_separate_the_key(self):
+        """Same as above for a box obstacle's size."""
+        a = self._boxed([0.2, 0.2, 0.2])
+        b = self._boxed([0.2, 0.2, 0.6])
+        from skrobot.planner.trajectory_optimization.solvers.solver_utils import get_problem_structure_key
+        self.assertEqual(get_problem_structure_key(a),
+                         get_problem_structure_key(b))
+        self.assertNotEqual(self._key(a), self._key(b))
+
+    @unittest.skipUnless(HAS_JAX, 'jax is not installed')
+    def test_cache_is_reused_across_solver_instances(self):
+        """solve_ik builds a solver per call, so the cache cannot live on one.
+
+        Two solves of the same problem through two solver objects must leave
+        a single entry behind; one entry per solve is what made a long sweep
+        recompile every time and leak the executables' mmaps.
+        """
+        from skrobot.planner.trajectory_optimization.solvers.augmented_lagrangian import _JIT_CACHE
+        from skrobot.planner.trajectory_optimization.solvers.augmented_lagrangian import AugmentedLagrangianSolver
+        from skrobot.planner.trajectory_optimization.solvers.augmented_lagrangian import clear_jit_cache
+
+        clear_jit_cache()
+        self.addCleanup(clear_jit_cache)
+
+        _, link_list = self._chain()
+        n_joints = len(link_list)
+        traj = interpolate_trajectory(
+            np.zeros(n_joints), np.ones(n_joints) * 0.2, 3)
+        kwargs = dict(max_outer_iterations=1, max_inner_iterations=5)
+
+        first = AugmentedLagrangianSolver(**kwargs).solve(
+            self._cartesian(), traj)
+        self.assertEqual(len(_JIT_CACHE), 1)
+        second = AugmentedLagrangianSolver(**kwargs).solve(
+            self._cartesian(), traj)
+        self.assertEqual(len(_JIT_CACHE), 1)
+
+        # Reuse must not change the answer.
+        testing.assert_allclose(second.trajectory, first.trajectory,
+                                rtol=0, atol=0)
+
+    @unittest.skipUnless(HAS_JAX, 'jax is not installed')
+    def test_shared_entry_does_not_carry_the_first_robot_kinematics(self):
+        """A cache hit must not reuse the first problem's FK.
+
+        Two robots at different base positions share a structure key and a
+        value hash -- the targets and residuals are identical, and the key
+        deliberately excludes FK so the compiled functions can be shared.
+        What must not be shared is ``fk_data``: the second solve has to build
+        its own from its own model. Caching it alongside the functions makes
+        the second robot move as if it stood where the first one does, and
+        the trajectory then differs from solving it alone.
+        """
+        from skrobot.planner.trajectory_optimization.solvers.augmented_lagrangian import AugmentedLagrangianSolver
+        from skrobot.planner.trajectory_optimization.solvers.augmented_lagrangian import clear_jit_cache
+
+        # A fixed world-frame goal, so both problems hold the same values.
+        target = np.array([0.6, 0.2, 0.4])
+
+        def problem_at(dx):
+            robot = skrobot.models.Kuka()
+            robot.reset_manip_pose()
+            robot.translate(np.array([dx, 0.0, 0.0]))
+            link_list = robot.rarm.link_list
+            problem = TrajectoryProblem(robot, link_list, n_waypoints=3,
+                                        move_target=robot.rarm_end_coords)
+            problem.add_cartesian_path_cost(
+                np.tile(target, (3, 1)), weight=10.0)
+            problem.add_smoothness_cost(weight=0.05)
+            return problem, len(link_list)
+
+        kwargs = dict(max_outer_iterations=2, max_inner_iterations=20)
+        _, n_joints = problem_at(0.0)
+        traj = interpolate_trajectory(
+            np.zeros(n_joints), np.ones(n_joints) * 0.2, 3)
+
+        # Solve the moved robot on its own.
+        clear_jit_cache()
+        alone = AugmentedLagrangianSolver(**kwargs).solve(
+            problem_at(0.3)[0], traj)
+
+        # Now solve it after another robot has populated the cache.
+        clear_jit_cache()
+        self.addCleanup(clear_jit_cache)
+        AugmentedLagrangianSolver(**kwargs).solve(problem_at(0.0)[0], traj)
+        after = AugmentedLagrangianSolver(**kwargs).solve(
+            problem_at(0.3)[0], traj)
+
+        testing.assert_allclose(
+            after.trajectory, alone.trajectory, rtol=0, atol=0,
+            err_msg='cache hit changed the answer, so it carried FK across')


### PR DESCRIPTION
Closes #871.

`AugmentedLagrangianSolver` kept its jit cache on the instance, and callers
that build a solver per solve — `solve_ik` does — started from an empty
cache every time. Nothing was ever reused: the same problem solved twice
compiled twice, and each executable's mmap regions were never released, so
a long sweep reached `vm.max_map_count` and died with `Cannot allocate
memory` while RAM was free. The cache is module-level now.

That move only became safe once #872 made the FK arrays a runtime argument.
Two things still had to be settled, and both are worth a look in review.

**The value hash did not cover everything the trace closes over.** It listed
fields by hand and had fallen behind twice: box obstacle extents and
rotation (#874) and the Cartesian axis masks (#873) were both absent, so two
problems differing only in those hashed identically. That is a latent bug on
main today for anyone reusing one solver across problems. It now walks the
residual params wholesale, so the next residual to carry a value is covered
without anyone remembering this function.

**The cached tuple carried `fk_data`.** Sharing an entry then shared the
kinematics that built it — the exact failure the argument passing was meant
to rule out. It is not subtle: on one workload a candidate went from solved
at 0.011 m error to unsolved at 0.389 m. Only the compiled functions are
cached now, and `fk_data` is rebuilt from the problem in hand.

`clear_jit_cache()` is exposed for processes that solve many structurally
different problems and want the memory back.

Tests: the key separates masks and box extents while still matching
identical problems; one entry survives two solver instances; and a second
robot's trajectory is unchanged by a first robot having populated the cache
— that last one fails if `fk_data` goes back into the entry, which is how
the bug above was caught.

Eight representative candidates of a real sweep are bit-identical before and
after.
