### PR TITLE
Add normalize_angle to coordinates.math

### DIFF
--- a/skrobot/coordinates/math.py
+++ b/skrobot/coordinates/math.py
@@ -2532,6 +2532,31 @@ def quaternion_norm(q):
     return norm_q
 
 
+def normalize_angle(angle):
+    """Wrap angles to the range ``[-pi, pi)``.
+
+    Parameters
+    ----------
+    angle : float or numpy.ndarray
+        Angle(s) in radians, in any range.
+
+    Returns
+    -------
+    numpy.float64 or numpy.ndarray
+        The same angle(s) folded into ``[-pi, pi)``; an array keeps its shape.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skrobot.coordinates.math import normalize_angle
+    >>> float(normalize_angle(3 * np.pi / 2))
+    -1.5707963267948966
+    >>> normalize_angle([0.0, np.pi, -np.pi, 2 * np.pi])
+    array([ 0.        , -3.14159265, -3.14159265,  0.        ])
+    """
+    return (np.asarray(angle, dtype=np.float64) + np.pi) % (2 * np.pi) - np.pi
+
+
 def quaternion_normalize(q):
     """Return the normalized quaternion.
 

--- a/tests/skrobot_tests/coordinates_tests/test_math.py
+++ b/tests/skrobot_tests/coordinates_tests/test_math.py
@@ -25,6 +25,7 @@ from skrobot.coordinates.math import matrix2translation_quaternion_xyzw
 from skrobot.coordinates.math import matrix2xyzrpy
 from skrobot.coordinates.math import matrix2ypr
 from skrobot.coordinates.math import matrix_relative
+from skrobot.coordinates.math import normalize_angle
 from skrobot.coordinates.math import normalize_vector
 from skrobot.coordinates.math import orthonormalize_rotation_matrix
 from skrobot.coordinates.math import quaternion2matrix
@@ -682,6 +683,20 @@ class TestMath(unittest.TestCase):
 
         q = np.array([0, 0, 0, 0])
         self.assertEqual(quaternion_norm(q), 0.0)
+
+    def test_normalize_angle(self):
+        testing.assert_almost_equal(normalize_angle(0.0), 0.0)
+        testing.assert_almost_equal(normalize_angle(3 * pi / 2), -pi / 2)
+        testing.assert_almost_equal(normalize_angle(-3 * pi / 2), pi / 2)
+        # the boundary pi maps to -pi (half-open interval)
+        testing.assert_almost_equal(normalize_angle(pi), -pi)
+        testing.assert_almost_equal(normalize_angle(-pi), -pi)
+        angles = np.array([[0.0, 2 * pi], [5 * pi, -7 * pi / 2]])
+        result = normalize_angle(angles)
+        self.assertEqual(result.shape, angles.shape)
+        testing.assert_almost_equal(result, [[0.0, 0.0], [-pi, pi / 2]])
+        self.assertTrue(np.all(result >= -pi))
+        self.assertTrue(np.all(result < pi))
 
     def test_quaternion_normalize(self):
         q = np.array([1, 0, 0, 0])


### PR DESCRIPTION
Adds `normalize_angle(angle)`, which folds an angle (scalar or array of any shape) into `[-pi, pi)` with the boundary `pi` mapping to `-pi`.
Heading errors and joint-angle differences need this before they are usable as control signals, and callers kept re-implementing the same modulo.
Comes with a unit test covering scalars, the boundaries and a 2-D array.