### PR TITLE
Render LineString in the viser viewer

### DIFF
--- a/examples/walk_with_trajectory_optimization.py
+++ b/examples/walk_with_trajectory_optimization.py
@@ -321,15 +321,13 @@ def add_ground_with_stripes(viewer, segments_data, viewer_name,
         viewer.add(stripe)
 
     # Planned CoG trail as a polyline plus per-segment endpoint markers
-    # so the walk's progress is easy to read off. ViserViewer does not
-    # implement LineString rendering, so we skip the polyline there.
-    if viewer_name != 'viser':
-        all_pts = np.concatenate(
-            [np.column_stack([s['com_pos'][:, 0], s['com_pos'][:, 1],
-                              np.full(s['com_pos'].shape[0], 0.005)])
-             for s in segments_data], axis=0)
-        if all_pts.shape[0] > 1:
-            viewer.add(skrobot.model.LineString(points=all_pts))
+    # so the walk's progress is easy to read off.
+    all_pts = np.concatenate(
+        [np.column_stack([s['com_pos'][:, 0], s['com_pos'][:, 1],
+                          np.full(s['com_pos'].shape[0], 0.005)])
+         for s in segments_data], axis=0)
+    if all_pts.shape[0] > 1:
+        viewer.add(skrobot.model.LineString(points=all_pts))
     palette = [(0.85, 0.30, 0.20),
                (0.20, 0.55, 0.95),
                (0.25, 0.80, 0.35),

--- a/skrobot/viewers/_mitsuba.py
+++ b/skrobot/viewers/_mitsuba.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from skrobot.coordinates import Coordinates
 import skrobot.model as model_module
+from skrobot.viewers._path_utils import polyline_segments
 
 
 def _load_mitsuba(variant):
@@ -471,49 +472,8 @@ class MitsubaViewer(object):
 
     @staticmethod
     def _polyline_segments(mesh):
-        vertices = getattr(mesh, 'vertices', None)
-        if vertices is None:
-            return []
-        vertices = np.asarray(vertices, dtype=np.float64)
-        if vertices.ndim != 2 or vertices.shape[1] != 3:
-            return []
-        if len(vertices) < 2:
-            return []
-
-        segments = []
-
-        def append_segment(i, j):
-            if i < 0 or j < 0 or i >= len(vertices) or j >= len(vertices):
-                return
-            segments.append((vertices[i], vertices[j]))
-
-        entities = getattr(mesh, 'entities', None)
-        if entities is not None:
-            for entity in entities:
-                points = np.asarray(
-                    getattr(entity, 'points', []), dtype=np.int64).reshape(-1)
-                if len(points) < 2:
-                    continue
-                for i in range(len(points) - 1):
-                    append_segment(int(points[i]), int(points[i + 1]))
-                if getattr(entity, 'closed', False) and len(points) > 2:
-                    append_segment(int(points[-1]), int(points[0]))
-
-        if not segments:
-            vertex_nodes = getattr(mesh, 'vertex_nodes', None)
-            if vertex_nodes is None:
-                return segments
-            vertex_nodes = np.asarray(vertex_nodes, dtype=np.int64)
-            if vertex_nodes.ndim == 1:
-                if len(vertex_nodes) % 2 != 0:
-                    return segments
-                vertex_nodes = vertex_nodes.reshape(-1, 2)
-            if vertex_nodes.ndim != 2 or vertex_nodes.shape[1] < 2:
-                return segments
-            for node in vertex_nodes:
-                append_segment(int(node[0]), int(node[1]))
-
-        return segments
+        segments, _ = polyline_segments(mesh)
+        return [(segment[0], segment[1]) for segment in segments]
 
     def _path_to_tube_mesh(self, mesh):
         segments = self._polyline_segments(mesh)

--- a/skrobot/viewers/_path_utils.py
+++ b/skrobot/viewers/_path_utils.py
@@ -1,0 +1,140 @@
+import warnings
+
+import numpy as np
+
+
+def polyline_segments(mesh):
+    """Extract line segments from a trimesh ``Path3D``.
+
+    ``LineString`` stores its geometry as a :class:`trimesh.path.Path3D`,
+    which keeps the vertices in a flat array and the connectivity in its
+    entities. This flattens that into explicit segment endpoints.
+
+    Parameters
+    ----------
+    mesh : trimesh.path.Path3D
+        Path whose entities are walked to build the segments.
+
+    Returns
+    -------
+    segments : numpy.ndarray
+        ``(n_segments, 2, 3)`` float array of segment endpoints. Empty
+        with shape ``(0, 2, 3)`` when the path holds no usable segment.
+    entity_indices : numpy.ndarray
+        ``(n_segments,)`` int array giving, for each segment, the index
+        of the entity it came from. Used to expand per-entity colors to
+        per-segment colors. Segments recovered from ``vertex_nodes``
+        (i.e. when the path exposes no entities) are all attributed to
+        entity ``0``.
+    """
+    empty = (np.zeros((0, 2, 3), dtype=np.float64),
+             np.zeros(0, dtype=np.int64))
+
+    vertices = getattr(mesh, 'vertices', None)
+    if vertices is None:
+        return empty
+    vertices = np.asarray(vertices, dtype=np.float64)
+    if vertices.ndim != 2 or vertices.shape[1] != 3:
+        return empty
+    if len(vertices) < 2:
+        return empty
+
+    segments = []
+    entity_indices = []
+
+    def append_segment(i, j, entity_index):
+        if i < 0 or j < 0 or i >= len(vertices) or j >= len(vertices):
+            return
+        segments.append((vertices[i], vertices[j]))
+        entity_indices.append(entity_index)
+
+    entities = getattr(mesh, 'entities', None)
+    if entities is not None:
+        for entity_index, entity in enumerate(entities):
+            points = np.asarray(
+                getattr(entity, 'points', []), dtype=np.int64).reshape(-1)
+            if len(points) < 2:
+                continue
+            for i in range(len(points) - 1):
+                append_segment(int(points[i]), int(points[i + 1]),
+                               entity_index)
+            # ``closed`` entities usually already repeat the first index
+            # as their last point, in which case the loop above has
+            # drawn the closing segment.
+            if (getattr(entity, 'closed', False) and len(points) > 2
+                    and points[-1] != points[0]):
+                append_segment(int(points[-1]), int(points[0]), entity_index)
+
+    if not segments:
+        vertex_nodes = getattr(mesh, 'vertex_nodes', None)
+        if vertex_nodes is None:
+            return empty
+        vertex_nodes = np.asarray(vertex_nodes, dtype=np.int64)
+        if vertex_nodes.ndim == 1:
+            if len(vertex_nodes) % 2 != 0:
+                return empty
+            vertex_nodes = vertex_nodes.reshape(-1, 2)
+        if vertex_nodes.ndim != 2 or vertex_nodes.shape[1] < 2:
+            return empty
+        for node in vertex_nodes:
+            append_segment(int(node[0]), int(node[1]), 0)
+
+    if not segments:
+        return empty
+    return (np.asarray(segments, dtype=np.float64),
+            np.asarray(entity_indices, dtype=np.int64))
+
+
+def polyline_segment_colors(mesh, entity_indices):
+    """Resolve per-segment RGB colors for a trimesh ``Path3D``.
+
+    trimesh stores path colors per entity, while renderers usually want
+    one color per segment.
+
+    Parameters
+    ----------
+    mesh : trimesh.path.Path3D
+        Path holding the colors.
+    entity_indices : numpy.ndarray
+        ``(n_segments,)`` entity index of each segment, as returned by
+        :func:`polyline_segments`.
+
+    Returns
+    -------
+    numpy.ndarray or None
+        ``(n_segments, 3)`` uint8 RGB array, or ``None`` when the path
+        carries no color or the colors cannot be matched to the
+        segments.
+    """
+    colors = getattr(mesh, 'colors', None)
+    if colors is None:
+        return None
+    colors = np.asarray(colors)
+    if colors.ndim == 1:
+        colors = colors.reshape(1, -1)
+    if colors.ndim != 2 or colors.shape[0] == 0 or colors.shape[1] < 3:
+        return None
+
+    entities = getattr(mesh, 'entities', None)
+    n_entities = 0 if entities is None else len(entities)
+    if colors.shape[0] == 1:
+        per_entity = np.repeat(colors, max(n_entities, 1), axis=0)
+    elif colors.shape[0] == n_entities:
+        per_entity = colors
+    else:
+        warnings.warn(
+            ('Dropping Path3D colors: expected 1 or {} rows (per-entity), '
+             'got {}.').format(n_entities, colors.shape[0]),
+            UserWarning)
+        return None
+
+    if entity_indices.size and entity_indices.max() >= per_entity.shape[0]:
+        warnings.warn(
+            'Dropping Path3D colors: segment entity index out of range.',
+            UserWarning)
+        return None
+
+    rgb = per_entity[entity_indices][:, :3]
+    if np.issubdtype(rgb.dtype, np.floating) and rgb.size and rgb.max() <= 1.0:
+        rgb = rgb * 255.0
+    return np.clip(rgb, 0, 255).astype(np.uint8)

--- a/skrobot/viewers/_viser.py
+++ b/skrobot/viewers/_viser.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from contextlib import contextmanager
 from functools import cached_property as _functools_cached_property
+import inspect
 import threading
 import time
 from typing import Dict
@@ -30,6 +31,8 @@ from skrobot.model.robot_model import CascadedLink
 from skrobot.model.robot_model import RobotModel
 from skrobot.viewers._base import _InteractiveViewerMixin
 from skrobot.viewers._manipulability_ellipse import ManipulabilityEllipse
+from skrobot.viewers._path_utils import polyline_segment_colors
+from skrobot.viewers._path_utils import polyline_segments
 
 
 try:
@@ -41,6 +44,16 @@ except ImportError:
 
 
 _CHECK_INTERVAL_NOT_GIVEN = object()
+
+# ``SceneApi.add_line_segments`` took a screen-space ``line_width`` (in
+# pixels) until viser 1.1, which replaced it with a world-space
+# ``thickness``. Only the latter can express a line width in metres.
+_LINE_SEGMENTS_SUPPORTS_THICKNESS = 'thickness' in inspect.signature(
+    viser.SceneApi.add_line_segments).parameters
+
+# Color used for a ``LineString`` that carries no color of its own, matching
+# the fallback used for uncolored point clouds.
+_DEFAULT_LINE_COLOR = (0, 0, 0)
 
 
 class ViserViewer(_InteractiveViewerMixin):
@@ -58,6 +71,12 @@ class ViserViewer(_InteractiveViewerMixin):
         Whether to enable motion planning controls. When enabled,
         users can save waypoints, plan trajectories between them,
         and animate the results. Implicitly enables IK. Default is False.
+    line_thickness : float
+        World-space thickness, in metres, used to draw
+        :class:`~skrobot.model.primitives.LineString` primitives.
+        Default is 0.005. Requires viser >= 1.1; older viser draws
+        lines with a fixed screen-space width and this value is
+        ignored (a warning is emitted when a ``LineString`` is added).
     """
 
     _LIMB_ATTR_MAP = {
@@ -91,8 +110,10 @@ class ViserViewer(_InteractiveViewerMixin):
         draw_grid: bool = True,
         enable_ik: bool = False,
         enable_motion_planning: bool = False,
+        line_thickness: float = 0.005,
     ):
         self._server = viser.ViserServer()
+        self._line_thickness = float(line_thickness)
         self._linkid_to_handle = dict()
         self._linkid_to_link = dict()
         self._is_active = True
@@ -3433,6 +3454,61 @@ class ViserViewer(_InteractiveViewerMixin):
             position=np.array([0.0, 0.0, -0.01]),
         )
 
+    def _add_line_string(self, name: str, link: LineString):
+        """Add a ``LineString`` to the scene as viser line segments.
+
+        The polyline is stored as a :class:`trimesh.path.Path3D`, whose
+        vertices live in the link frame; the segments are handed to viser
+        as-is and the link's world pose is applied to the scene node so
+        that :meth:`redraw` can keep it in sync.
+
+        Parameters
+        ----------
+        name : str
+            Scene node name.
+        link : skrobot.model.primitives.LineString
+            The polyline to render.
+
+        Returns
+        -------
+        viser.LineSegmentsHandle or None
+            The created handle, or ``None`` when the polyline holds no
+            drawable segment.
+        """
+        mesh = link.visual_mesh
+        segments, entity_indices = polyline_segments(mesh)
+        if len(segments) == 0:
+            warnings.warn(
+                "LineString '{}' has no drawable segment; skipping.".format(
+                    link.name),
+                UserWarning)
+            return None
+
+        colors = polyline_segment_colors(mesh, entity_indices)
+        if colors is None:
+            colors = np.array(_DEFAULT_LINE_COLOR, dtype=np.uint8)
+        else:
+            # viser wants a color per segment endpoint.
+            colors = np.repeat(colors[:, None, :], 2, axis=1)
+
+        kwargs = {}
+        if _LINE_SEGMENTS_SUPPORTS_THICKNESS:
+            kwargs['thickness'] = self._line_thickness
+        else:
+            warnings.warn(
+                'viser {} draws line segments with a screen-space width; '
+                'line_thickness={} is ignored. Upgrade to viser >= 1.1 for '
+                'world-space line thickness.'.format(
+                    viser.__version__, self._line_thickness),
+                UserWarning)
+        return self._server.scene.add_line_segments(
+            name,
+            points=segments,
+            colors=colors,
+            wxyz=matrix2quaternion(link.worldrot()),
+            position=link.worldpos(),
+            **kwargs)
+
     def _add_link(self, link: Link, is_obstacle: bool = False):
         from skrobot.model.primitives import Box
         from skrobot.model.primitives import Cylinder
@@ -3485,7 +3561,7 @@ class ViserViewer(_InteractiveViewerMixin):
                     point_size=0.002,  # TODO(HiroIshida): configurable
                 )
         elif isinstance(link, LineString):
-            raise NotImplementedError("not implemented yet")
+            handle = self._add_line_string(link_id, link)
         else:
             mesh = link.concatenated_visual_mesh
             if mesh is not None:

--- a/tests/skrobot_tests/viewers_tests/test_viser_viewer.py
+++ b/tests/skrobot_tests/viewers_tests/test_viser_viewer.py
@@ -6,14 +6,29 @@ import time
 import unittest
 import warnings
 
+import numpy as np
+
+from skrobot.model.primitives import LineString
+from skrobot.viewers import _viser as viser_module
 from skrobot.viewers import ViserViewer
 from skrobot.viewers._base import _InteractiveViewerMixin
+
+
+class _RecordingScene(object):
+
+    def __init__(self):
+        self.line_segments_calls = []
+
+    def add_line_segments(self, name, **kwargs):
+        self.line_segments_calls.append((name, kwargs))
+        return object()
 
 
 class _DummyServer(object):
 
     def __init__(self):
         self.stop_count = 0
+        self.scene = _RecordingScene()
 
     def stop(self):
         self.stop_count += 1
@@ -88,6 +103,57 @@ class TestViserViewer(unittest.TestCase):
         self.assertEqual(viewer.has_exit, not viewer.is_active)
         viewer._is_active = False
         self.assertEqual(viewer.has_exit, not viewer.is_active)
+
+
+class TestViserLineString(unittest.TestCase):
+
+    def setUp(self):
+        self.viewer = _viewer()
+        self.viewer._line_thickness = 0.004
+        self.viewer._linkid_to_handle = dict()
+        self.viewer._linkid_to_link = dict()
+        self.viewer._obstacle_link_ids = set()
+        self.viewer._obstacle_original_colors = dict()
+        self.points = np.array([[0.0, 0.0, 0.0],
+                                [1.0, 0.0, 0.0],
+                                [1.0, 1.0, 0.0]])
+
+    def _add(self, line):
+        self.viewer._add_link(line)
+        self.assertEqual(len(self.viewer._server.scene.line_segments_calls), 1)
+        return self.viewer._server.scene.line_segments_calls[0][1]
+
+    def test_line_string_is_added_as_line_segments(self):
+        line = LineString(self.points, color=[255, 0, 0, 255])
+        kwargs = self._add(line)
+
+        segments = kwargs['points']
+        self.assertEqual(segments.shape, (2, 2, 3))
+        np.testing.assert_allclose(segments[0], self.points[:2])
+        np.testing.assert_allclose(segments[1], self.points[1:])
+        np.testing.assert_array_equal(
+            kwargs['colors'],
+            np.tile(np.array([255, 0, 0], dtype=np.uint8), (2, 2, 1)))
+        self.assertIn(str(id(line)), self.viewer._linkid_to_handle)
+
+    def test_line_string_uses_link_world_pose(self):
+        line = LineString(self.points, pos=(0.0, 0.0, 0.5))
+        kwargs = self._add(line)
+        np.testing.assert_allclose(kwargs['position'], [0.0, 0.0, 0.5])
+
+    def test_line_string_without_color_falls_back_to_default(self):
+        line = LineString(self.points)
+        kwargs = self._add(line)
+        np.testing.assert_array_equal(
+            kwargs['colors'], np.array(viser_module._DEFAULT_LINE_COLOR))
+
+    def test_line_thickness_is_forwarded_when_supported(self):
+        line = LineString(self.points)
+        kwargs = self._add(line)
+        if viser_module._LINE_SEGMENTS_SUPPORTS_THICKNESS:
+            self.assertEqual(kwargs['thickness'], 0.004)
+        else:
+            self.assertNotIn('thickness', kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
ViserViewer raised `NotImplementedError` for `LineString`, so polyline overlays such as planned trajectories had to be skipped on that backend. It now draws them with `scene.add_line_segments`, honoring per-entity colors and a new world-space `line_thickness` option.

The trimesh `Path3D`-to-segment extraction moves into a shared helper so the mitsuba viewer reuses it instead of keeping its own copy.

Test plan: `pytest tests/skrobot_tests/viewers_tests/test_viser_viewer.py test_mitsuba_viewer.py`, `ruff check skrobot/ tests/ examples/`, plus a manual browser check against viser 1.1.0 and 0.2.23.



<img width="896" height="753" alt="Screenshot 2026-09-07 at 20 41 37" src="https://github.com/user-attachments/assets/388e23f1-757a-48b9-8c6f-6c4e0c16203f" />


