### PR TITLE
Make translucent meshes render translucent in the viser viewer

### DIFF
--- a/skrobot/viewers/_viser.py
+++ b/skrobot/viewers/_viser.py
@@ -56,6 +56,85 @@ _LINE_SEGMENTS_SUPPORTS_THICKNESS = 'thickness' in inspect.signature(
 _DEFAULT_LINE_COLOR = (0, 0, 0)
 
 
+def _visual_alpha(visual):
+    """Return the smallest alpha (0-255) carried by a trimesh visual.
+
+    Parameters
+    ----------
+    visual : trimesh.visual.ColorVisuals or trimesh.visual.TextureVisuals
+        Visual to inspect.
+
+    Returns
+    -------
+    int
+        Minimum alpha found, or 255 when the visual carries no alpha
+        this function knows how to read (an alpha channel inside a base
+        color texture is not inspected).
+    """
+    material = getattr(visual, 'material', None)
+    if material is not None:
+        color = getattr(material, 'main_color', None)
+        if color is None or len(color) < 4:
+            return 255
+        return int(color[3])
+
+    if getattr(visual, 'kind', None) not in ('face', 'vertex'):
+        return 255
+    colors = np.asarray(getattr(visual, 'vertex_colors', None))
+    if colors.ndim != 2 or colors.shape[0] == 0 or colors.shape[1] < 4:
+        return 255
+    return int(colors[:, 3].min())
+
+
+def _alpha_blended_mesh(mesh):
+    """Make a translucent trimesh actually render translucent in viser.
+
+    Viser ships meshes to the browser as GLB, and a glTF material
+    defaults to ``alphaMode="OPAQUE"``: the alpha of ``face_colors`` or
+    ``vertex_colors`` survives the export as ``COLOR_0`` but the renderer
+    ignores it, so ``face_colors=(r, g, b, 128)`` comes out solid. This
+    attaches a :class:`trimesh.visual.material.PBRMaterial` with
+    ``alphaMode='BLEND'`` so the exported GLB asks for blending.
+
+    Parameters
+    ----------
+    mesh : trimesh.Trimesh
+        Mesh about to be handed to viser.
+
+    Returns
+    -------
+    trimesh.Trimesh
+        ``mesh`` itself when it is opaque or already blended, otherwise a
+        copy carrying the blending material. The input is never modified.
+    """
+    visual = getattr(mesh, 'visual', None)
+    if visual is None or _visual_alpha(visual) >= 255:
+        return mesh
+
+    material = getattr(visual, 'material', None)
+    if material is not None:
+        if getattr(material, 'alphaMode', None) == 'BLEND':
+            return mesh
+        if hasattr(material, 'to_pbr'):
+            pbr = material.to_pbr()
+        else:
+            pbr = material.copy()
+        pbr.alphaMode = 'BLEND'
+        blended = mesh.copy()
+        blended.visual.material = pbr
+        return blended
+
+    # ColorVisuals carries no material at all, so keep the RGBA as a
+    # vertex attribute (still exported as COLOR_0) and put the blending
+    # material beside it.
+    vertex_colors = np.array(visual.vertex_colors, copy=True)
+    blended = mesh.copy()
+    blended.visual = trimesh.visual.TextureVisuals(
+        material=trimesh.visual.material.PBRMaterial(alphaMode='BLEND'))
+    blended.visual.vertex_attributes['color'] = vertex_colors
+    return blended
+
+
 class ViserViewer(_InteractiveViewerMixin):
     """Viser-based 3D viewer for scikit-robot.
 
@@ -3581,7 +3660,7 @@ class ViserViewer(_InteractiveViewerMixin):
                             100, 100, 100)
                 handle = self._server.scene.add_mesh_trimesh(
                         link_id,
-                        mesh=mesh,
+                        mesh=_alpha_blended_mesh(mesh),
                         wxyz=matrix2quaternion(link.worldrot()),
                         position=link.worldpos(),
                     )

--- a/tests/skrobot_tests/viewers_tests/test_viser_viewer.py
+++ b/tests/skrobot_tests/viewers_tests/test_viser_viewer.py
@@ -7,7 +7,9 @@ import unittest
 import warnings
 
 import numpy as np
+import trimesh
 
+from skrobot.model.primitives import Box
 from skrobot.model.primitives import LineString
 from skrobot.viewers import _viser as viser_module
 from skrobot.viewers import ViserViewer
@@ -18,9 +20,14 @@ class _RecordingScene(object):
 
     def __init__(self):
         self.line_segments_calls = []
+        self.mesh_trimesh_calls = []
 
     def add_line_segments(self, name, **kwargs):
         self.line_segments_calls.append((name, kwargs))
+        return object()
+
+    def add_mesh_trimesh(self, name, **kwargs):
+        self.mesh_trimesh_calls.append((name, kwargs))
         return object()
 
 
@@ -154,6 +161,61 @@ class TestViserLineString(unittest.TestCase):
             self.assertEqual(kwargs['thickness'], 0.004)
         else:
             self.assertNotIn('thickness', kwargs)
+
+
+class TestViserAlphaBlending(unittest.TestCase):
+
+    def _mesh(self, face_colors):
+        return Box(extents=(0.2, 0.2, 0.2), face_colors=face_colors).visual_mesh
+
+    def test_opaque_mesh_is_passed_through_untouched(self):
+        mesh = self._mesh((255, 0, 0, 255))
+        self.assertIs(viser_module._alpha_blended_mesh(mesh), mesh)
+
+    def test_translucent_color_visuals_get_blend_material(self):
+        mesh = self._mesh((255, 0, 0, 128))
+        blended = viser_module._alpha_blended_mesh(mesh)
+
+        self.assertIsNot(blended, mesh)
+        self.assertEqual(blended.visual.material.alphaMode, 'BLEND')
+        # The original RGBA survives as a vertex attribute, so it is still
+        # exported as COLOR_0 alongside the new material.
+        np.testing.assert_array_equal(
+            blended.visual.vertex_attributes['color'], mesh.visual.vertex_colors)
+        # The link's own mesh must not be modified.
+        self.assertIsInstance(mesh.visual, trimesh.visual.ColorVisuals)
+
+    def test_translucent_material_is_copied_before_blending(self):
+        mesh = trimesh.creation.box((1.0, 1.0, 1.0))
+        material = trimesh.visual.material.PBRMaterial(
+            baseColorFactor=[255, 0, 0, 90])
+        mesh.visual = trimesh.visual.TextureVisuals(material=material)
+
+        blended = viser_module._alpha_blended_mesh(mesh)
+
+        self.assertEqual(blended.visual.material.alphaMode, 'BLEND')
+        self.assertIsNone(material.alphaMode)
+
+    def test_already_blended_mesh_is_passed_through_untouched(self):
+        mesh = trimesh.creation.box((1.0, 1.0, 1.0))
+        mesh.visual = trimesh.visual.TextureVisuals(
+            material=trimesh.visual.material.PBRMaterial(
+                baseColorFactor=[255, 0, 0, 90], alphaMode='BLEND'))
+        self.assertIs(viser_module._alpha_blended_mesh(mesh), mesh)
+
+    def test_add_link_blends_translucent_primitive(self):
+        viewer = _viewer()
+        viewer._linkid_to_handle = dict()
+        viewer._linkid_to_link = dict()
+        viewer._obstacle_link_ids = set()
+        viewer._obstacle_original_colors = dict()
+
+        box = Box(extents=(0.2, 0.2, 0.2), face_colors=(0, 0, 255, 100))
+        viewer._add_link(box)
+
+        calls = viewer._server.scene.mesh_trimesh_calls
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][1]['mesh'].visual.material.alphaMode, 'BLEND')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`ViserViewer` sends meshes to the browser as GLB. trimesh writes no material at all for `ColorVisuals`, so the exported file falls back to the glTF default `alphaMode: OPAQUE` and the alpha of `face_colors=(r, g, b, a)` is dropped on the floor, even though it does survive the export as `COLOR_0`.

`_add_link` now attaches a `PBRMaterial(alphaMode='BLEND')` to a copy of any translucent mesh, keeping the RGBA as a vertex attribute so the colors are preserved and the link's own visual mesh is never modified. Opaque meshes are passed straight through, so their rendering is unchanged.

Test plan: `pytest tests/skrobot_tests/viewers_tests/` (5 new cases), `ruff check skrobot/ tests/ examples/`, plus a manual browser check of boxes at alpha 255/180/128/60 wrapped around an opaque one.