### PR TITLE
Derive a robot's collision model once and reuse it

### DIFF
--- a/docs/source/reference/robot_model_tips.rst
+++ b/docs/source/reference/robot_model_tips.rst
@@ -116,6 +116,45 @@ For multiple target poses, batch IK provides significant performance improvement
         else:
             print(f"Pose {i}: Failed after {attempts} attempts")
 
+Collision Model
+~~~~~~~~~~~~~~~
+
+Every robot carries a collision model, built the first time it is asked for
+and reused (and persisted, so once per machine):
+
+.. code-block:: python
+
+    model = robot.collision_model
+    print(model.describe())
+    # 20 collision links, 167 self-collision pairs (method=fcl, derived now);
+    # excluded 19 adjacent, 4 touching at the default pose, 0 always
+    # colliding; the sphere/capsule proxies already overlap for 9 of the
+    # checked pairs at the default pose
+
+    robot.reset_pose()
+    model.in_self_collision()       # False, on the exact meshes
+    model.self_colliding_pairs()    # []
+
+It holds two things every collision-aware routine needs: a sphere/capsule
+proxy for each link that has a collision mesh, and the pairs of links worth
+checking against each other. The pairs are derived the way MoveIt's setup
+assistant fills in an SRDF -- parent/child pairs are dropped, so are pairs
+already in contact at the default pose (parts that touch by design) and
+pairs that collide in nearly every random configuration -- so a legitimate
+rest pose no longer reads as "in collision" on robots like the PR2 whose
+links overlap at rest. ``model.excluded`` lists what was dropped and why.
+
+Two query surfaces come out of it. ``model.checker`` is a
+``RobotCollisionChecker`` over the proxies: cheap and usable from a
+differentiable cost, but conservative, since a proxy is fatter than its
+mesh. ``model.proxy_overlap_pairs`` tells you how conservative for your
+robot. ``model.in_self_collision()`` answers on the meshes instead and
+needs the optional ``python-fcl`` package; without it the pair derivation
+also falls back to the proxies and says so with a warning.
+
+``robot.build_collision_model(...)`` rebuilds it with other settings, or
+after you change a link's collision mesh.
+
 Reading the Result
 ~~~~~~~~~~~~~~~~~~
 

--- a/skrobot/collision/__init__.py
+++ b/skrobot/collision/__init__.py
@@ -33,6 +33,9 @@ Example
 
 # Geometry primitives
 # Distance functions
+# Robot collision
+from skrobot.collision.collision_model import kinematic_distance
+from skrobot.collision.collision_model import RobotCollisionModel
 from skrobot.collision.distance import box_halfspace_distance
 from skrobot.collision.distance import capsule_box_distance
 from skrobot.collision.distance import capsule_capsule_distance
@@ -48,8 +51,6 @@ from skrobot.collision.geometry import Capsule
 from skrobot.collision.geometry import CollisionGeometry
 from skrobot.collision.geometry import HalfSpace
 from skrobot.collision.geometry import Sphere
-
-# Robot collision
 from skrobot.collision.robot_collision import LinkCollisionGeometry
 from skrobot.collision.robot_collision import RobotCollisionChecker
 
@@ -82,7 +83,9 @@ __all__ = [
     'colldist_from_sdf',
     # Robot collision
     'RobotCollisionChecker',
+    'RobotCollisionModel',
     'LinkCollisionGeometry',
+    'kinematic_distance',
     # Mesh self-collision + joint-limit sweep
     'SelfCollision',
     'sweep_limits',

--- a/skrobot/collision/collision_model.py
+++ b/skrobot/collision/collision_model.py
@@ -1,0 +1,587 @@
+"""A robot's own collision model, built once and reused.
+
+Everything that avoids collisions -- the collision checker, the trajectory
+optimizer's self-collision cost, a collision-aware IK -- needs the same two
+things from a robot: a cheap proxy geometry for every link, and the list of
+link pairs that are worth checking against each other. Until now each caller
+rebuilt both by hand (``RobotCollisionChecker.add_link`` per link, then
+``setup_self_collision_pairs``), and none of them excluded the pairs that
+touch by design, so a legitimate rest pose read as "in collision" on robots
+like the PR2 whose links overlap at rest.
+
+:class:`RobotCollisionModel` derives both from the robot itself, the way
+MoveIt's setup assistant derives an SRDF: it drops parent/child pairs, the
+pairs already in contact at the robot's default pose, and the pairs that
+collide in nearly every random configuration (which means their proxies
+overlap by construction). The result is keyed by the collision meshes and
+joint limits and persisted, so a robot pays for the derivation once.
+"""
+
+import hashlib
+import json
+import os
+import tempfile
+import warnings
+
+import numpy as np
+
+from skrobot.collision.robot_collision import RobotCollisionChecker
+from skrobot.collision.self_collision import is_fcl_available
+from skrobot.collision.self_collision import REST_MARGIN
+from skrobot.collision.self_collision import SelfCollision
+
+
+_CACHE_VERSION = 1
+
+
+def _default_cache_dir():
+    """Return the directory holding cached collision models.
+
+    Returns
+    -------
+    str
+        ``<skrobot cache dir>/collision_model``. Resolved on every call
+        because the skrobot cache dir honours ``SKROBOT_CACHE_DIR``.
+    """
+    from skrobot.data import get_cache_dir
+    return os.path.join(get_cache_dir(), 'collision_model')
+
+
+def _mesh_digest(mesh):
+    """Return a content hash of a mesh's vertices and faces.
+
+    Parameters
+    ----------
+    mesh : trimesh.Trimesh
+        Mesh to hash.
+
+    Returns
+    -------
+    str
+        SHA-1 hex digest. A translated copy hashes differently, which is
+        what a cache keyed on link-frame geometry needs.
+    """
+    vertices = np.ascontiguousarray(mesh.vertices, dtype=np.float64)
+    faces = np.ascontiguousarray(mesh.faces, dtype=np.int64)
+    h = hashlib.sha1()
+    h.update(json.dumps([list(vertices.shape), list(faces.shape)]).encode())
+    h.update(vertices.tobytes())
+    h.update(faces.tobytes())
+    return h.hexdigest()
+
+
+def _ancestor_names(link):
+    """Return the names of ``link`` and its ancestors, nearest first."""
+    names = []
+    current = link
+    while current is not None:
+        names.append(current.name)
+        current = getattr(current, 'parent_link', None)
+    return names
+
+
+def kinematic_distance(link_a, link_b):
+    """Return the number of links between two links along the tree.
+
+    Parameters
+    ----------
+    link_a : skrobot.model.Link
+        First link.
+    link_b : skrobot.model.Link
+        Second link.
+
+    Returns
+    -------
+    int or float
+        Steps from ``link_a`` up to the closest common ancestor plus steps
+        from ``link_b`` up to it: 1 for parent and child, 2 for siblings or
+        grandparent and grandchild. ``inf`` if the links share no ancestor.
+    """
+    ancestors_a = _ancestor_names(link_a)
+    ancestors_b = _ancestor_names(link_b)
+    index_a = {name: i for i, name in enumerate(ancestors_a)}
+    for i, name in enumerate(ancestors_b):
+        if name in index_a:
+            return index_a[name] + i
+    return float('inf')
+
+
+def _has_collision_mesh(link):
+    mesh = getattr(link, 'collision_mesh', None)
+    if mesh is None:
+        return False
+    if getattr(mesh, 'is_empty', False):
+        return False
+    return len(getattr(mesh, 'faces', ())) > 0
+
+
+def _atomic_write_json(path, payload):
+    """Write ``payload`` as JSON to ``path`` without exposing a partial file."""
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    fd, staging = tempfile.mkstemp(prefix='.collision_model.', suffix='.tmp',
+                                   dir=directory)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(payload, f, sort_keys=True)
+        os.replace(staging, path)
+    except BaseException:
+        try:
+            os.unlink(staging)
+        except OSError:
+            pass
+        raise
+
+
+class RobotCollisionModel(object):
+    """Collision proxies and self-collision pairs derived from a robot.
+
+    Built lazily by :attr:`skrobot.model.RobotModel.collision_model`; you
+    rarely construct it yourself. Construct it directly (or call
+    :meth:`RobotModel.build_collision_model`) to change how the pairs are
+    derived.
+
+    Self-collision pairs start from every unordered pair of links that have
+    a collision mesh, then drop:
+
+    - ``adjacent``: parent/child pairs (kinematic distance below 2), which
+      touch at their joint by construction;
+    - ``default_pose``: pairs already in contact at the robot's default pose
+      (all joints at zero, clipped into their limits), i.e. parts that touch
+      by design;
+    - ``always``: pairs colliding in at least ``always_fraction`` of
+      ``n_samples`` uniformly random configurations, which means their proxy
+      geometry overlaps whatever the robot does.
+
+    Contacts are tested with FCL on the exact collision meshes, using each
+    mesh's convex hull only as the broadphase. Without the optional
+    ``python-fcl`` package the default-pose test falls back to the
+    sphere/capsule proxies and the random sampling is skipped;
+    :attr:`method` records which was used. Proxies are inflated, so that
+    path excludes more pairs than the mesh-based one and a warning says so.
+
+    Two query surfaces come out of it. :attr:`checker` is a
+    :class:`RobotCollisionChecker` over sphere/capsule proxies -- cheap,
+    differentiable, but conservative (:attr:`proxy_overlap_pairs` says how
+    much for this robot). :meth:`in_self_collision` answers on the meshes.
+
+    The derivation is persisted under ``cache_dir``, keyed by the collision
+    meshes, joint limits and these settings, so it runs once per robot.
+
+    Parameters
+    ----------
+    robot_model : skrobot.model.RobotModel
+        The robot. Its pose is restored after the derivation.
+    n_samples : int
+        Random configurations sampled for the ``always`` test.
+    always_fraction : float
+        Fraction of samples a pair must collide in to count as ``always``.
+    margin : float
+        Penetration depth (m) below which a contact is not a collision.
+    seed : int
+        Seed for the random configurations, so the result is reproducible.
+    cache_dir : str or None
+        Where derivations are persisted. ``None`` uses the skrobot cache.
+    use_cache : bool
+        If False, always derive and overwrite the cached entry.
+
+    Attributes
+    ----------
+    link_list : list[skrobot.model.Link]
+        The links that carry a collision mesh, in robot order.
+    method : str
+        ``'fcl'`` or ``'primitive'`` -- how contacts were tested.
+    from_cache : bool
+        Whether the pairs were read back from disk.
+    excluded : dict
+        The dropped pairs by category: ``'adjacent'``, ``'default_pose'``
+        and ``'always'``, each a list of ``(name, name)`` tuples.
+    proxy_overlap_pairs : list[tuple[str, str]]
+        Checked pairs whose proxies overlap at the default pose although
+        the meshes do not -- the pairs :attr:`checker` over-reports.
+    """
+
+    def __init__(self, robot_model, n_samples=200, always_fraction=0.95,
+                 margin=REST_MARGIN, seed=0, cache_dir=None, use_cache=True):
+        self.robot_model = robot_model
+        self.link_list = [link for link in robot_model.link_list
+                          if _has_collision_mesh(link)]
+        self.n_samples = int(n_samples)
+        self.always_fraction = float(always_fraction)
+        self.margin = float(margin)
+        self.seed = int(seed)
+        self._cache_dir = cache_dir if cache_dir is not None \
+            else _default_cache_dir()
+        self._checker = None
+        self._gridsdf_data = {}
+
+        self.method = None
+        self.from_cache = False
+        self.excluded = {}
+        self.proxy_overlap_pairs = []
+        self._pair_names = []
+        self._self_collision = None
+
+        cached = self._read_cache() if use_cache else None
+        if cached is not None:
+            self.method = cached['method']
+            self.excluded = {key: [tuple(p) for p in value]
+                             for key, value in cached['excluded'].items()}
+            self._pair_names = [tuple(p) for p in cached['pairs']]
+            self.proxy_overlap_pairs = [
+                tuple(p) for p in cached['proxy_overlap']]
+            self.from_cache = True
+        else:
+            self._pair_names, self.excluded, self.method = self._derive()
+            self.proxy_overlap_pairs = self._proxy_overlaps(self._pair_names)
+            self._write_cache()
+
+    # ------------------------------------------------------------------
+    # derivation
+    # ------------------------------------------------------------------
+    def _derive(self):
+        robot = self.robot_model
+        links = self.link_list
+        names = [link.name for link in links]
+
+        candidates = []
+        adjacent = []
+        for i in range(len(links)):
+            for j in range(i + 1, len(links)):
+                pair = tuple(sorted((names[i], names[j])))
+                if kinematic_distance(links[i], links[j]) < 2:
+                    adjacent.append(pair)
+                else:
+                    candidates.append(pair)
+        candidate_set = set(candidates)
+
+        pose = robot.angle_vector()
+        try:
+            robot.init_pose()
+            if is_fcl_available():
+                default_pose, always = self._derive_with_fcl(candidate_set)
+                method = 'fcl'
+            else:
+                warnings.warn(
+                    "python-fcl is not installed, so self-collision pairs "
+                    "for '{}' were derived from sphere/capsule proxies at "
+                    "the default pose only. Proxies are inflated, so more "
+                    "pairs are excluded than with the mesh-based test, and "
+                    "pairs that always collide are not detected. Install "
+                    "it with: pip install python-fcl".format(
+                        getattr(robot, 'name', type(robot).__name__)),
+                    RuntimeWarning, stacklevel=3)
+                default_pose = self._default_pose_contacts_primitive(
+                    candidate_set)
+                always = set()
+                method = 'primitive'
+        finally:
+            robot.angle_vector(pose)
+
+        pairs = [pair for pair in candidates
+                 if pair not in default_pose and pair not in always]
+        excluded = {
+            'adjacent': adjacent,
+            'default_pose': sorted(default_pose),
+            'always': sorted(always),
+        }
+        return pairs, excluded, method
+
+    def _proxy_overlaps(self, pair_names):
+        """Kept pairs whose sphere/capsule proxies overlap at the default pose.
+
+        The proxies are fatter than the meshes, so some pairs that are clear
+        on the mesh read as colliding through :attr:`checker`. Recording
+        them tells a user how conservative the proxy checker is for this
+        robot.
+        """
+        robot = self.robot_model
+        checker = RobotCollisionChecker(robot)
+        checker.add_links(self.link_list)
+        indices = self._geometry_indices(checker)
+        index_pairs = []
+        owners = []
+        for pair in pair_names:
+            for i in indices[pair[0]]:
+                for j in indices[pair[1]]:
+                    index_pairs.append((i, j))
+                    owners.append(pair)
+        if not index_pairs:
+            return []
+        checker.set_self_collision_pairs(index_pairs)
+        pose = robot.angle_vector()
+        try:
+            robot.init_pose()
+            distances = np.asarray(checker.compute_self_collision_distances())
+        finally:
+            robot.angle_vector(pose)
+        return sorted({pair for pair, distance in zip(owners, distances)
+                       if distance <= 0.0})
+
+    def _make_self_collision(self):
+        """Build the exact-mesh self-collision query at the default pose."""
+        robot = self.robot_model
+        meshes = {link.name: link.collision_mesh for link in self.link_list}
+        pose = robot.angle_vector()
+        try:
+            robot.init_pose()
+            # Convex hulls for the broadphase, every candidate verified on
+            # the exact mesh: hulls alone report contacts the real geometry
+            # never makes (the tucked Fetch arm against its torso, say).
+            return SelfCollision(robot, meshes, margin=self.margin,
+                                 hull=True, confirm=True)
+        finally:
+            robot.angle_vector(pose)
+
+    def _derive_with_fcl(self, candidate_set):
+        """Default-pose contacts and always-colliding pairs via FCL hulls."""
+        robot = self.robot_model
+        # Built at the default pose, so its baseline is exactly the set of
+        # pairs in contact there (plus adjacency, already removed above).
+        model = self._make_self_collision()
+        # The same object answers in_self_collision() later; its baseline is
+        # exactly the default-pose contact set this derivation excludes.
+        self._self_collision = model
+        default_pose = {tuple(sorted(pair)) for pair in model.baseline}
+        default_pose &= candidate_set
+
+        always = set()
+        if self.n_samples > 0:
+            lower = np.array(robot.joint_min_angles, dtype=np.float64)
+            upper = np.array(robot.joint_max_angles, dtype=np.float64)
+            lower = np.where(np.isfinite(lower), lower, -np.pi)
+            upper = np.where(np.isfinite(upper), upper, np.pi)
+            rng = np.random.RandomState(self.seed)
+            hits = {}
+            for _ in range(self.n_samples):
+                robot.angle_vector(rng.uniform(lower, upper))
+                for pair in model.colliding_pairs():
+                    key = tuple(sorted(pair))
+                    hits[key] = hits.get(key, 0) + 1
+            threshold = self.always_fraction * self.n_samples
+            always = {pair for pair, count in hits.items()
+                      if pair in candidate_set and count >= threshold}
+            always -= default_pose
+        return default_pose, always
+
+    def _default_pose_contacts_primitive(self, candidate_set):
+        """Default-pose contacts via the sphere/capsule proxies."""
+        checker = RobotCollisionChecker(self.robot_model)
+        checker.add_links(self.link_list)
+        indices = self._geometry_indices(checker)
+        index_pairs = []
+        name_pairs = []
+        for pair in sorted(candidate_set):
+            for i in indices[pair[0]]:
+                for j in indices[pair[1]]:
+                    index_pairs.append((i, j))
+                    name_pairs.append(pair)
+        checker.set_self_collision_pairs(index_pairs)
+        distances = np.asarray(checker.compute_self_collision_distances())
+        return {pair for pair, distance in zip(name_pairs, distances)
+                if distance <= 0.0}
+
+    @staticmethod
+    def _geometry_indices(checker):
+        """Map link name to the indices of its geometries in ``checker``."""
+        indices = {}
+        for i, geometry in enumerate(checker.link_geometries):
+            indices.setdefault(geometry.link.name, []).append(i)
+        return indices
+
+    # ------------------------------------------------------------------
+    # cache
+    # ------------------------------------------------------------------
+    def _cache_key(self):
+        robot = self.robot_model
+        payload = {
+            'version': _CACHE_VERSION,
+            'links': [
+                (link.name,
+                 link.parent_link.name if link.parent_link is not None
+                 else None,
+                 _mesh_digest(link.collision_mesh))
+                for link in self.link_list],
+            'joints': [(joint.name, float(joint.min_angle),
+                        float(joint.max_angle))
+                       for joint in robot.joint_list],
+            'params': {
+                'n_samples': self.n_samples,
+                'always_fraction': self.always_fraction,
+                'margin': self.margin,
+                'seed': self.seed,
+            },
+            'fcl': is_fcl_available(),
+        }
+        h = hashlib.sha1(json.dumps(payload, sort_keys=True).encode())
+        return h.hexdigest()[:16]
+
+    def _cache_path(self):
+        return os.path.join(self._cache_dir, self._cache_key() + '.json')
+
+    def _read_cache(self):
+        try:
+            with open(self._cache_path(), encoding='utf-8') as f:
+                data = json.load(f)
+        except (OSError, ValueError):
+            return None
+        if data.get('version') != _CACHE_VERSION:
+            return None
+        if not all(key in data for key in
+                   ('method', 'pairs', 'excluded', 'proxy_overlap')):
+            return None
+        return data
+
+    def _write_cache(self):
+        payload = {
+            'version': _CACHE_VERSION,
+            'method': self.method,
+            'pairs': [list(pair) for pair in self._pair_names],
+            'excluded': {key: [list(pair) for pair in value]
+                         for key, value in self.excluded.items()},
+            'proxy_overlap': [list(pair) for pair in self.proxy_overlap_pairs],
+        }
+        try:
+            _atomic_write_json(self._cache_path(), payload)
+        except OSError as exc:
+            warnings.warn(
+                'could not persist the collision model to {}: {}'.format(
+                    self._cache_path(), exc),
+                RuntimeWarning, stacklevel=3)
+
+    # ------------------------------------------------------------------
+    # public surface
+    # ------------------------------------------------------------------
+    @property
+    def self_collision_pair_names(self):
+        """list[tuple[str, str]]: The pairs to check, as sorted link names."""
+        return list(self._pair_names)
+
+    @property
+    def self_collision_pairs(self):
+        """list[tuple[Link, Link]]: The pairs to check, as links."""
+        by_name = {link.name: link for link in self.link_list}
+        return [(by_name[a], by_name[b]) for a, b in self._pair_names]
+
+    @property
+    def self_collision_index_pairs(self):
+        """list[tuple[int, int]]: The pairs as indices into ``link_list``."""
+        index = {link.name: i for i, link in enumerate(self.link_list)}
+        return [(index[a], index[b]) for a, b in self._pair_names]
+
+    @property
+    def self_collision(self):
+        """SelfCollision: exact-mesh self-collision query over the pairs.
+
+        Built on first access with the rest baseline taken at the default
+        pose, so :meth:`SelfCollision.new_pairs` reports exactly the pairs
+        this model checks. Needs the optional ``python-fcl`` package.
+        """
+        if self._self_collision is None:
+            if not is_fcl_available():
+                raise RuntimeError(
+                    'the exact self-collision query needs the optional '
+                    "'python-fcl' package -- install it with: pip install "
+                    'python-fcl (the proxy-based `checker` works without it)')
+            self._self_collision = self._make_self_collision()
+        return self._self_collision
+
+    def self_colliding_pairs(self):
+        """Return the pairs in contact at the current pose, on the meshes.
+
+        Returns
+        -------
+        list[tuple[str, str]]
+            Sorted link-name pairs among :attr:`self_collision_pair_names`
+            whose meshes penetrate by more than ``margin`` right now.
+        """
+        always = set(self.excluded.get('always', ()))
+        return sorted(tuple(sorted(pair))
+                      for pair in self.self_collision.new_pairs()
+                      if tuple(sorted(pair)) not in always)
+
+    def in_self_collision(self):
+        """Return whether the robot self-collides at its current pose.
+
+        Mesh-accurate (see :meth:`self_colliding_pairs`), unlike
+        ``checker.is_collision_free()`` which uses the inflated proxies.
+
+        Returns
+        -------
+        bool
+            True if any checked pair is in contact.
+        """
+        return len(self.self_colliding_pairs()) > 0
+
+    @property
+    def checker(self):
+        """RobotCollisionChecker: proxies for every link, pairs already set.
+
+        Built on first access. Evaluates the robot's *current* pose; add
+        world obstacles to it with ``add_world_obstacle``.
+
+        The sphere/capsule proxies are conservative: a link that clears
+        another on the mesh can still overlap it through its proxy.
+        :attr:`proxy_overlap_pairs` lists the checked pairs for which that
+        is already so at the default pose, and :meth:`in_self_collision`
+        answers on the meshes instead.
+        """
+        if self._checker is None:
+            checker = RobotCollisionChecker(self.robot_model)
+            checker.add_links(self.link_list)
+            indices = self._geometry_indices(checker)
+            index_pairs = []
+            for a, b in self._pair_names:
+                for i in indices[a]:
+                    for j in indices[b]:
+                        index_pairs.append((i, j))
+            checker.set_self_collision_pairs(index_pairs)
+            self._checker = checker
+        return self._checker
+
+    def gridsdf_self_data(self, dim_grid=40, n_surface=48):
+        """Per-link GridSDF data for the differentiable self-collision cost.
+
+        The same arrays
+        :func:`~skrobot.planner.trajectory_optimization.gridsdf_collision.build_gridsdf_self_data`
+        returns, but over the derived pairs rather than list-adjacency.
+        Cached per ``(dim_grid, n_surface)``.
+
+        Parameters
+        ----------
+        dim_grid : int
+            GridSDF resolution per axis.
+        n_surface : int
+            Surface sample points kept per link.
+
+        Returns
+        -------
+        dict
+            See ``build_gridsdf_self_data``.
+        """
+        key = (int(dim_grid), int(n_surface))
+        if key not in self._gridsdf_data:
+            from skrobot.planner.trajectory_optimization.gridsdf_collision import build_gridsdf_self_data
+            self._gridsdf_data[key] = build_gridsdf_self_data(
+                self.robot_model, self.link_list,
+                dim_grid=dim_grid, n_surface=n_surface,
+                link_pairs=self.self_collision_index_pairs)
+        return self._gridsdf_data[key]
+
+    def describe(self):
+        """Return a one-paragraph summary of what the model holds."""
+        return (
+            '{} collision links, {} self-collision pairs '
+            '(method={}, {}); excluded {} adjacent, {} touching at the '
+            'default pose, {} always colliding; the sphere/capsule proxies '
+            'already overlap for {} of the checked pairs at the default '
+            'pose'.format(
+                len(self.link_list), len(self._pair_names), self.method,
+                'from cache' if self.from_cache else 'derived now',
+                len(self.excluded.get('adjacent', ())),
+                len(self.excluded.get('default_pose', ())),
+                len(self.excluded.get('always', ())),
+                len(self.proxy_overlap_pairs)))
+
+    def __repr__(self):
+        return '<RobotCollisionModel {}>'.format(self.describe())

--- a/skrobot/collision/self_collision.py
+++ b/skrobot/collision/self_collision.py
@@ -238,10 +238,19 @@ class SelfCollision:
                 tf = cache[link] = self._link[link].worldcoords().T()
             self.cm.set_transform(oid, tf)
 
+    def colliding_pairs(self) -> set:
+        """Every colliding link pair at the current pose, baseline included.
+
+        :meth:`new_pairs` is the usual query; this one is for callers that
+        classify pairs themselves, such as a sampling pass that wants to
+        know how often each pair collides regardless of the rest pose.
+        """
+        self._sync()
+        return self._pairs(self.margin)
+
     def new_pairs(self) -> set:
         """Colliding link pairs (beyond the rest baseline) at the current pose."""
-        self._sync()
-        return self._pairs(self.margin) - self.baseline
+        return self.colliding_pairs() - self.baseline
 
     def offenders(self):
         """``(new_pairs, offending_link_names)`` at the current pose -- the live

--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -2990,6 +2990,44 @@ class RobotModel(CascadedLink):
         self._cached_inverse_dynamics_link_list = None
         self._cached_inverse_dynamics_mass_hash = None
 
+        # Built on first access to ``collision_model``.
+        self._collision_model = None
+
+    @property
+    def collision_model(self):
+        """RobotCollisionModel: the robot's collision proxies and pairs.
+
+        Built on first access and reused after that, so the derivation --
+        which tests link contacts at the default pose and over random
+        configurations -- runs once per robot (and is persisted, so once
+        per machine). Use :meth:`build_collision_model` to rebuild it with
+        other settings or after changing a link's collision mesh.
+
+        See :class:`skrobot.collision.RobotCollisionModel`.
+        """
+        if getattr(self, '_collision_model', None) is None:
+            self.build_collision_model()
+        return self._collision_model
+
+    def build_collision_model(self, **kwargs):
+        """Rebuild :attr:`collision_model`, optionally with other settings.
+
+        Parameters
+        ----------
+        **kwargs
+            Passed to :class:`skrobot.collision.RobotCollisionModel`
+            (``n_samples``, ``always_fraction``, ``margin``, ``seed``,
+            ``cache_dir``, ``use_cache``).
+
+        Returns
+        -------
+        skrobot.collision.RobotCollisionModel
+            The new model, also stored as :attr:`collision_model`.
+        """
+        from skrobot.collision.collision_model import RobotCollisionModel
+        self._collision_model = RobotCollisionModel(self, **kwargs)
+        return self._collision_model
+
     def reset_pose(self):
         raise NotImplementedError()
 

--- a/skrobot/planner/trajectory_optimization/gridsdf_collision.py
+++ b/skrobot/planner/trajectory_optimization/gridsdf_collision.py
@@ -43,7 +43,7 @@ from skrobot.planner.trajectory_optimization.collision import create_self_collis
 
 
 def build_gridsdf_self_data(robot_model, collision_link_list,
-                            dim_grid=40, n_surface=48):
+                            dim_grid=40, n_surface=48, link_pairs=None):
     """Precompute per-collision-link GridSDFs and surface samples.
 
     Parameters
@@ -64,6 +64,12 @@ def build_gridsdf_self_data(robot_model, collision_link_list,
         it.
     n_surface : int
         Number of surface sample points kept per link.
+    link_pairs : list[tuple[int, int]] or None
+        Unordered pairs of indices into ``collision_link_list`` to check.
+        ``None`` (default) keeps the historical list-adjacency rule, which
+        ignores the kinematic tree and the pairs that touch by design;
+        :attr:`skrobot.model.RobotModel.collision_model` derives a better
+        set and passes it here.
 
     Returns
     -------
@@ -123,7 +129,8 @@ def build_gridsdf_self_data(robot_model, collision_link_list,
 
     # Ordered pairs: the lookup is asymmetric (surface points of A against the
     # field of B), so each unordered pair is evaluated in both directions.
-    link_pairs = create_self_collision_pairs(collision_link_list)
+    if link_pairs is None:
+        link_pairs = create_self_collision_pairs(collision_link_list)
     pa = [a for a, b in link_pairs] + [b for a, b in link_pairs]
     pb = [b for a, b in link_pairs] + [a for a, b in link_pairs]
 

--- a/tests/skrobot_tests/collision_tests/test_collision_model.py
+++ b/tests/skrobot_tests/collision_tests/test_collision_model.py
@@ -1,0 +1,287 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+import warnings
+
+import numpy as np
+
+from skrobot.collision import collision_model as collision_model_module
+from skrobot.collision import is_fcl_available
+from skrobot.collision import kinematic_distance
+from skrobot.collision import RobotCollisionModel
+
+
+# A column fixed on a base carries a bar on a pitch joint. A pad is fixed to
+# the column but sits overlapping the base, so base/pad is a NON-adjacent
+# pair (base - column - pad) that touches by design at the default pose and
+# must be excluded. The bar is clear of everything at rest and only reaches
+# the base when pitched down, so base/bar must be kept. Every other pair is
+# parent/child.
+_URDF = """<?xml version="1.0"?>
+<robot name="column_bar">
+  <link name="base_link">
+    <collision>
+      <geometry><box size="0.2 0.2 0.1"/></geometry>
+    </collision>
+  </link>
+  <link name="column">
+    <collision>
+      <origin xyz="0 0 0.15" rpy="0 0 0"/>
+      <geometry><box size="0.04 0.04 0.3"/></geometry>
+    </collision>
+  </link>
+  <link name="pad">
+    <collision>
+      <geometry><box size="0.04 0.04 0.04"/></geometry>
+    </collision>
+  </link>
+  <link name="bar">
+    <collision>
+      <origin xyz="0.175 0 0" rpy="0 0 0"/>
+      <geometry><box size="0.35 0.02 0.02"/></geometry>
+    </collision>
+  </link>
+  <joint name="mount" type="fixed">
+    <parent link="base_link"/>
+    <child link="column"/>
+    <origin xyz="0 0 0.05" rpy="0 0 0"/>
+  </joint>
+  <joint name="pad_mount" type="fixed">
+    <parent link="column"/>
+    <child link="pad"/>
+    <origin xyz="0.08 0 0" rpy="0 0 0"/>
+  </joint>
+  <joint name="pitch" type="revolute">
+    <parent link="column"/>
+    <child link="bar"/>
+    <origin xyz="0 0 0.3" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-3.14" upper="3.14" effort="1" velocity="1"/>
+  </joint>
+</robot>
+"""
+
+
+def _load_robot():
+    from skrobot.models.urdf import RobotModelFromURDF
+    with tempfile.NamedTemporaryFile('w', suffix='.urdf',
+                                     delete=False) as f:
+        f.write(_URDF)
+        path = f.name
+    try:
+        return RobotModelFromURDF(urdf_file=path)
+    finally:
+        os.unlink(path)
+
+
+class TestKinematicDistance(unittest.TestCase):
+
+    def test_distances_along_the_tree(self):
+        robot = _load_robot()
+        self.assertEqual(kinematic_distance(robot.base_link, robot.column), 1)
+        self.assertEqual(kinematic_distance(robot.column, robot.bar), 1)
+        self.assertEqual(kinematic_distance(robot.base_link, robot.pad), 2)
+        self.assertEqual(kinematic_distance(robot.pad, robot.bar), 2)
+        self.assertEqual(kinematic_distance(robot.base_link, robot.bar), 2)
+        self.assertEqual(kinematic_distance(robot.bar, robot.bar), 0)
+
+
+class TestRobotCollisionModelPairs(unittest.TestCase):
+
+    def setUp(self):
+        self.robot = _load_robot()
+        self.tmpdir = tempfile.mkdtemp()
+
+    def _build(self, **kwargs):
+        kwargs.setdefault('cache_dir', self.tmpdir)
+        return RobotCollisionModel(self.robot, **kwargs)
+
+    def test_collision_links_are_those_with_a_mesh(self):
+        model = self._build()
+        self.assertEqual(
+            [link.name for link in model.link_list],
+            ['base_link', 'column', 'pad', 'bar'])
+
+    def test_adjacent_pairs_are_never_checked(self):
+        model = self._build()
+        pairs = set(model.self_collision_pair_names)
+        for a, b in pairs:
+            self.assertGreaterEqual(
+                kinematic_distance(getattr(self.robot, a),
+                                   getattr(self.robot, b)), 2)
+        self.assertEqual(
+            set(model.excluded['adjacent']),
+            {('base_link', 'column'), ('bar', 'column'), ('column', 'pad')})
+
+    @unittest.skipUnless(is_fcl_available(), 'python-fcl is not installed')
+    def test_pair_touching_at_default_pose_is_excluded_and_recorded(self):
+        model = self._build()
+        self.assertEqual(model.method, 'fcl')
+        self.assertNotIn(('base_link', 'pad'), model.self_collision_pair_names)
+        self.assertIn(('base_link', 'pad'), model.excluded['default_pose'])
+
+    @unittest.skipUnless(is_fcl_available(), 'python-fcl is not installed')
+    def test_pair_that_can_collide_is_kept(self):
+        model = self._build()
+        self.assertIn(('bar', 'base_link'), model.self_collision_pair_names)
+        self.assertEqual(model.excluded['always'], [])
+
+    def test_robot_pose_is_restored_after_derivation(self):
+        self.robot.pitch.joint_angle(0.3)
+        before = self.robot.angle_vector().copy()
+        self._build()
+        np.testing.assert_allclose(self.robot.angle_vector(), before)
+
+    @unittest.skipUnless(is_fcl_available(), 'python-fcl is not installed')
+    def test_checker_reflects_the_pairs_and_the_pose(self):
+        model = self._build()
+        checker = model.checker
+        self.assertGreater(len(checker.self_collision_pairs), 0)
+
+        self.robot.pitch.joint_angle(0.0)
+        self.assertTrue(checker.is_collision_free())
+        # Pitched straight down (R_y(+pi/2) sends +x to -z), the bar runs
+        # through the base.
+        self.robot.pitch.joint_angle(np.pi / 2)
+        self.assertFalse(checker.is_collision_free())
+
+    @unittest.skipUnless(is_fcl_available(), 'python-fcl is not installed')
+    def test_in_self_collision_answers_on_the_meshes(self):
+        model = self._build()
+        self.robot.pitch.joint_angle(0.0)
+        self.assertFalse(model.in_self_collision())
+        self.assertEqual(model.self_colliding_pairs(), [])
+        self.robot.pitch.joint_angle(np.pi / 2)
+        self.assertTrue(model.in_self_collision())
+        self.assertEqual(model.self_colliding_pairs(),
+                         [('bar', 'base_link')])
+
+    def test_exact_query_without_fcl_is_a_clear_error(self):
+        with mock.patch.object(collision_model_module, 'is_fcl_available',
+                               return_value=False):
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                model = self._build()
+            with self.assertRaises(RuntimeError) as ctx:
+                model.in_self_collision()
+        self.assertIn('python-fcl', str(ctx.exception))
+
+    @unittest.skipUnless(is_fcl_available(), 'python-fcl is not installed')
+    def test_derivation_is_persisted_and_read_back(self):
+        first = self._build()
+        self.assertFalse(first.from_cache)
+        second = self._build()
+        self.assertTrue(second.from_cache)
+        self.assertEqual(second.self_collision_pair_names,
+                         first.self_collision_pair_names)
+        self.assertEqual(second.excluded, first.excluded)
+        self.assertEqual(second.method, first.method)
+        self.assertEqual(second.proxy_overlap_pairs,
+                         first.proxy_overlap_pairs)
+        self.assertIsInstance(first.proxy_overlap_pairs, list)
+
+        # Different settings are a different entry.
+        other = self._build(n_samples=7)
+        self.assertFalse(other.from_cache)
+
+        forced = self._build(use_cache=False)
+        self.assertFalse(forced.from_cache)
+
+    def test_without_fcl_the_primitive_path_warns_and_says_so(self):
+        with mock.patch.object(collision_model_module, 'is_fcl_available',
+                               return_value=False):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                model = self._build()
+        self.assertEqual(model.method, 'primitive')
+        self.assertTrue(any('python-fcl' in str(w.message) for w in caught))
+        # The structural rule still holds.
+        self.assertEqual(model.excluded['always'], [])
+        for a, b in model.self_collision_pair_names:
+            self.assertGreaterEqual(
+                kinematic_distance(getattr(self.robot, a),
+                                   getattr(self.robot, b)), 2)
+
+    @unittest.skipUnless(is_fcl_available(), 'python-fcl is not installed')
+    def test_gridsdf_data_uses_the_derived_pairs(self):
+        model = self._build()
+        data = model.gridsdf_self_data(dim_grid=12, n_surface=8)
+        n_pairs = len(model.self_collision_pair_names)
+        # Each unordered pair is looked up in both directions.
+        self.assertEqual(len(data['pairs_a']), 2 * n_pairs)
+        self.assertEqual(len(data['pairs_b']), 2 * n_pairs)
+        self.assertEqual(data['grids'].shape[0], len(model.link_list))
+        # Cached per resolution.
+        self.assertIs(model.gridsdf_self_data(dim_grid=12, n_surface=8), data)
+
+
+@unittest.skipUnless(is_fcl_available(), 'python-fcl is not installed')
+class TestRobotCollisionModelFetch(unittest.TestCase):
+    """A real robot whose links touch by design at rest."""
+
+    @classmethod
+    def setUpClass(cls):
+        import skrobot
+        cls.robot = skrobot.models.Fetch()
+        cls.model = cls.robot.build_collision_model(
+            cache_dir=tempfile.mkdtemp())
+
+    def test_links_touching_by_design_are_excluded(self):
+        self.assertEqual(self.model.method, 'fcl')
+        self.assertGreater(len(self.model.excluded['default_pose']), 0)
+        for pair in self.model.excluded['default_pose']:
+            self.assertNotIn(pair, self.model.self_collision_pair_names)
+
+    def test_no_adjacent_pair_is_checked(self):
+        for a, b in self.model.self_collision_pair_names:
+            self.assertGreaterEqual(
+                kinematic_distance(getattr(self.robot, a),
+                                   getattr(self.robot, b)), 2)
+
+    def test_reset_pose_is_self_collision_free_on_the_meshes(self):
+        self.robot.reset_pose()
+        self.assertFalse(self.model.in_self_collision())
+
+    def test_folding_the_arm_into_the_torso_is_detected(self):
+        self.robot.reset_pose()
+        # Drive the elbow hard into its limit with the shoulder lifted: the
+        # forearm ends up inside the torso.
+        self.robot.shoulder_lift_joint.joint_angle(
+            self.robot.shoulder_lift_joint.max_angle)
+        self.robot.elbow_flex_joint.joint_angle(
+            self.robot.elbow_flex_joint.max_angle)
+        self.assertTrue(self.model.in_self_collision())
+
+    def test_proxies_are_reported_as_conservative(self):
+        # Fetch's bulky base and torso are approximated by a few spheres,
+        # so the proxy checker over-reports; the model must say so rather
+        # than hide it.
+        self.assertGreater(len(self.model.proxy_overlap_pairs), 0)
+        self.assertIn('proxies', self.model.describe())
+
+
+class TestRobotModelIntegration(unittest.TestCase):
+
+    def test_collision_model_is_lazy_and_cached_on_the_robot(self):
+        robot = _load_robot()
+        tmpdir = tempfile.mkdtemp()
+        self.assertIsNone(robot._collision_model)
+        model = robot.build_collision_model(cache_dir=tmpdir)
+        self.assertIs(robot.collision_model, model)
+        rebuilt = robot.build_collision_model(cache_dir=tmpdir)
+        self.assertIsNot(rebuilt, model)
+        self.assertIs(robot.collision_model, rebuilt)
+
+    def test_collision_model_builds_on_first_access(self):
+        robot = _load_robot()
+        with mock.patch.object(
+                collision_model_module, '_default_cache_dir',
+                return_value=tempfile.mkdtemp()):
+            model = robot.collision_model
+        self.assertIsInstance(model, RobotCollisionModel)
+        self.assertIn('self-collision pairs', model.describe())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Every routine that avoids collisions needs the same two things from a robot: a cheap proxy geometry for each link, and the list of link pairs worth checking against each other. Until now each caller rebuilt both by hand (`RobotCollisionChecker.add_link` per link, then `setup_self_collision_pairs`), and none of them excluded the pairs that touch *by design* -- so a legitimate rest pose read as "in collision" on robots like the PR2 whose links overlap at rest, and the trajectory optimizer's self-collision cost was built on list-adjacency, which ignores the kinematic tree.

`robot.collision_model` (built on first access, persisted, rebuilt with `robot.build_collision_model(...)`) derives both from the robot the way MoveIt's setup assistant fills in an SRDF:

- **adjacent**: parent/child pairs are dropped
- **default_pose**: pairs already in contact at the default pose (all joints at zero, clipped into their limits) are dropped -- parts that touch by design
- **always**: pairs colliding in >= 95% of 200 uniformly random configurations are dropped -- their geometry overlaps whatever the robot does

Contacts are tested with FCL on the **exact meshes**, using each mesh's convex hull only as the broadphase. That distinction matters: hulls alone reported Fetch's tucked `reset_pose` as self-colliding (`gripper_link`/`torso_lift_link`, `shoulder_lift_link`/`torso_lift_link`) and excluded 32 PR2 pairs at rest that the real geometry never touches; exact verification clears the false positives and keeps 18 more PR2 pairs under guard, for no measurable cost.

Two query surfaces come out of it. `model.checker` is a `RobotCollisionChecker` over sphere/capsule proxies with the pairs already set -- cheap and usable from a differentiable cost, but conservative. `model.in_self_collision()` / `model.self_colliding_pairs()` answer on the meshes. The model records how conservative the proxies are for this robot (`proxy_overlap_pairs`) rather than leaving it to be discovered: on Fetch the proxies already overlap for 9 of 167 checked pairs at the default pose, on PR2 for 61 of 1162, so `checker.is_collision_free()` says False at both robots' rest poses while `in_self_collision()` correctly says False. Nothing is silently dropped to make the proxy checker agree.

`build_gridsdf_self_data` takes the derived pairs (`link_pairs=`), so the grid-SDF self-collision cost can use them; the trajectory problem is not rewired in this PR. Without the optional `python-fcl` package the default-pose test falls back to the proxies, sampling is skipped, and a warning says so; `model.method` records which path ran.

Measured on this machine: Fetch derives in 0.5 s, PR2 in 0.3 s, a cache hit is ~1 ms; `in_self_collision()` is ~0.3 ms after the first call.

## Test plan

- `pytest tests/skrobot_tests/collision_tests/ tests/skrobot_tests/planner_tests/` -- 118 passed, 26 new: a hand-built URDF where a non-adjacent pair touches at rest (must be excluded) and another only collides when pitched (must be kept), kinematic distance, pose restoration, cache round-trip and invalidation, the no-fcl warning path, gridsdf pairs, and Fetch (rest pose collision-free on the meshes, folding the forearm into the torso detected, proxies reported as conservative)
- `pytest tests/skrobot_tests/model_tests/` -- 149 passed
- `ruff check`, `typos` (CI's v1.29.10), and the Sphinx Returns-indent check over the 7 new public callables
- The docs snippet's numbers are the actual Fetch output