### PR TITLE
Fix marginal test thresholds and retry only the failed tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,22 +222,30 @@ jobs:
         fi
     - name: Run Pytest
       run: |
-        for i in {1..3}; do
-          # --timeout: per-test timeout in seconds (300s = 5 minutes)
-          # --durations=0: show duration of all tests to identify slow ones
-          if xvfb-run pytest -v -n auto --dist loadscope --timeout=300 --durations=0 tests; then
-            echo "Tests passed on attempt $i"
-            break
-          else
-            echo "Tests failed on attempt $i"
-            if [ "$i" -eq 3 ]; then
-              echo "All retry attempts failed"
-              exit 1
-            fi
-            echo "Retrying in 10 seconds..."
-            sleep 10
+        # --timeout: per-test timeout in seconds (300s = 5 minutes)
+        # --durations=0: show duration of all tests to identify slow ones
+        PYTEST="xvfb-run pytest -v -n auto --dist loadscope --timeout=300 --durations=0"
+        if $PYTEST tests; then
+          exit 0
+        fi
+        # Retry only the tests that just failed (--last-failed) rather than the
+        # whole suite. A genuinely flaky test clears in seconds instead of
+        # costing another full ~3 min run, and a real failure still fails the
+        # job. The rerun keeps the same '-n auto --dist loadscope' setup on
+        # purpose: dropping to a serial rerun would turn every parallel-execution
+        # bug into a green tick.
+        failed=""
+        for attempt in 2 3; do
+          failed=$(python -c "import json; print(' '.join(json.load(open('.pytest_cache/v/cache/lastfailed'))))" 2>/dev/null || true)
+          echo "::warning::attempt $((attempt - 1)) failed; rerunning only: ${failed:-<no lastfailed record, rerunning everything>}"
+          sleep 10
+          if $PYTEST --last-failed tests; then
+            echo "::warning::FLAKY: failed on attempt $((attempt - 1)), passed on attempt $attempt: $failed"
+            exit 0
           fi
         done
+        echo "::error::the same tests failed on all 3 attempts, so this is not flakiness: $failed"
+        exit 1
 
   ros2-tests:
     name: Run ROS 2 Unit Tests (${{ matrix.ros-distribution }})

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -410,6 +410,21 @@ class GridSDF(SignedDistanceFunction):
             fill_value=fill_value)
         self.origin = origin
 
+    @property
+    def resolution(self):
+        """Edge length of one grid cell, in the SDF's own frame.
+
+        This is the finest detail the grid can represent, so it is also the
+        scale of the error to expect from a query: a point on the surface
+        comes back within roughly one cell of zero, not exactly zero.
+
+        Returns
+        -------
+        resolution : float
+            Grid spacing the SDF was built with.
+        """
+        return self._resolution
+
     def is_out_of_bounds(self, points_world):
         """check if the the input points is out of bounds
 

--- a/tests/skrobot_tests/test_sdf.py
+++ b/tests/skrobot_tests/test_sdf.py
@@ -296,11 +296,25 @@ class TestSDF(unittest.TestCase):
         vertices = bunny_mesh.vertices * 10.0
         sd_vals = robot_sdf(vertices)
 
-        # If sdf is properly computed, abs(sdf) for all vertices
-        # must be small enough
-        lb, lu = np.min(vertices, axis=0), np.max(vertices, axis=0)
-        eps = np.min(lu - lb) * 1e-2
-        self.assertTrue(np.all(np.abs(sd_vals) < eps))
+        # If sdf is properly computed, abs(sdf) for all vertices must be
+        # small enough. "Small enough" is one grid cell: a GridSDF samples the
+        # distance field on a dim_grid**3 lattice and interpolates, so a point
+        # on the surface comes back within about one cell of zero and no
+        # tolerance below that is meaningful. The old tolerance -- 1% of the
+        # smallest bounding-box side -- worked out to 0.012 against a 0.0172
+        # cell, i.e. 0.70 of a cell, tighter than the grid itself, which left
+        # the measured worst vertex (0.0094, 0.55 of a cell) passing by 22%
+        # and flipping between CI runs. The regression this guards, the URDF
+        # mesh scale being ignored, misses by far more than a cell: the
+        # vertices land outside the grid entirely and come back inf.
+        resolution = max(sdf.resolution for sdf in robot_sdf.sdf_list
+                         if isinstance(sdf, GridSDF))
+        eps = 1.5 * resolution
+        worst = np.max(np.abs(sd_vals))
+        self.assertTrue(
+            np.all(np.abs(sd_vals) < eps),
+            'worst |sdf| is {} ({:.2f} grid cells of {}), tolerance {}'.format(
+                worst, worst / resolution, resolution, eps))
 
     def test_trimesh2sdf(self):
         # non-primitive mesh with file_path

--- a/tests/skrobot_tests/viewers_tests/test_mitsuba_viewer.py
+++ b/tests/skrobot_tests/viewers_tests/test_mitsuba_viewer.py
@@ -338,7 +338,13 @@ class TestMitsubaViewerRender(unittest.TestCase):
         self.viewer.set_camera(eye=[1.5, -1.5, 1.0], target=[0.0, 0.0, 0.5])
         start = [0.30, -0.20, 0.30]
         goal = [0.52, 0.20, 0.34]
-        extents = [0.08, 0.08, 0.08]
+        # Sized to move about as many pixels as the sibling marker tests do.
+        # At 0.08 m the box was the odd one out: moving it changed the frame
+        # by a mean of 1.36 against the 1.0 asserted below, where the sphere
+        # marker moves 4.21 and the joint 5.35, so the margin here was a
+        # twentieth of theirs and CI measured 0.76 and failed. 0.16 m brings
+        # it to 5.01, in line with the other two.
+        extents = [0.16, 0.16, 0.16]
         color = (0.85, 0.15, 0.15)
         self.viewer.add_box(start, extents, color=color, name='cube')
         before = self.viewer.render()
@@ -352,7 +358,11 @@ class TestMitsubaViewerRender(unittest.TestCase):
         full = fresh.render()
 
         moved = np.abs(incremental.astype(int) - before.astype(int)).mean()
-        self.assertGreater(moved, 1.0)
+        rebuilt = np.abs(full.astype(int) - before.astype(int)).mean()
+        self.assertGreater(
+            moved, 1.0,
+            'incremental render moved the frame by {:.4f}; a full rebuild of '
+            'the same move gives {:.4f}'.format(moved, rebuilt))
         diff = np.abs(incremental.astype(int) - full.astype(int)).mean()
         self.assertLess(diff, 3.0)
 
@@ -1058,15 +1068,26 @@ class TestMitsubaViewerRender(unittest.TestCase):
             (skrobot.models.PR2(), [2.5, -2.4, 1.8], [0.0, 0.0, 0.9]),
         ]
         for robot, eye, target in scenes:
-            viewer = MitsubaViewer(resolution=(64, 48), spp=1)
-            viewer.add(robot)
-            viewer.set_camera(eye=eye, target=target)
-            key = viewer._scene_dict()['key']['to_world']
-            scale = _transform_uniform_scale(key)
-            height = _transform_matrix_element(
-                key, 2, 3) - float(np.asarray(viewer._camera[1])[2])
-            self.assertAlmostEqual(scale, 1.5, places=6)
-            self.assertAlmostEqual(height, 2.0, places=6)
+            with self.subTest(robot=type(robot).__name__):
+                viewer = MitsubaViewer(resolution=(64, 48), spp=1)
+                viewer.add(robot)
+                viewer.set_camera(eye=eye, target=target)
+                key = viewer._scene_dict()['key']['to_world']
+                scale = _transform_uniform_scale(key)
+                height = _transform_matrix_element(
+                    key, 2, 3) - float(np.asarray(viewer._camera[1])[2])
+                # Both constants hold only while the scene radius stays under
+                # the 1.0 m floor of the one-sided clamp, and PR2 clears it by
+                # 0.7% (0.9930 m) against Panda's 0.5575 m. So a failure here
+                # says the scene was bigger than the model should be, not that
+                # the light maths changed -- report the geometry that produced
+                # the radius so the next failure names the culprit.
+                points = viewer._collect_world_points()
+                detail = 'radius={:.5f} shapes={} extent={}'.format(
+                    viewer._auto_light_radius(), len(viewer._links),
+                    np.ptp(points, axis=0))
+                self.assertAlmostEqual(scale, 1.5, places=6, msg=detail)
+                self.assertAlmostEqual(height, 2.0, places=6, msg=detail)
 
     def test_key_light_radius_is_clamped_for_tiny_scenes(self):
         viewer = MitsubaViewer(resolution=(64, 48), spp=1)


### PR DESCRIPTION
Three tests asserted against thresholds tighter than the resolution of what they measured, so they flipped between CI runs; this ties them to the underlying resolution and reruns only the failed tests instead of the whole suite.