### PR TITLE
Say which group to reach with when a robot has no end_coords

### DIFF
--- a/skrobot/model/robot_model.py
+++ b/skrobot/model/robot_model.py
@@ -2990,6 +2990,48 @@ class RobotModel(CascadedLink):
         self._cached_inverse_dynamics_link_list = None
         self._cached_inverse_dynamics_mass_hash = None
 
+    def _default_move_target(self, caller):
+        """The model's ``end_coords``, or a message saying where to find one.
+
+        Parameters
+        ----------
+        caller : str
+            Name of the method asking, for the message.
+
+        Returns
+        -------
+        skrobot.coordinates.CascadedCoords or list
+            This model's ``end_coords``.
+
+        Raises
+        ------
+        AttributeError
+            When the model has none, naming a sub-model that does. A
+            two-armed robot has no single end-effector to default to, so
+            ``robot.inverse_kinematics(target)`` used to fail with a bare
+            ``'PR2' object has no attribute 'end_coords'``.
+        """
+        target = getattr(self, 'end_coords', None)
+        if target is not None:
+            return target
+        groups = []
+        for name in ('rarm', 'larm', 'rleg', 'lleg', 'head', 'torso'):
+            try:
+                group = getattr(self, name)
+            except Exception:
+                continue
+            if getattr(group, 'end_coords', None) is not None:
+                groups.append(name)
+        hint = ''
+        if groups:
+            hint = (' Call it on the group that has one, for example '
+                    'robot.{}.{}(...), or pass move_target='
+                    'robot.{}_end_coords.'.format(groups[0], caller,
+                                                  groups[0]))
+        raise AttributeError(
+            '{} has no end_coords, so {}() has no end-effector to move.{}'
+            .format(type(self).__name__, caller, hint))
+
     def reset_pose(self):
         raise NotImplementedError()
 
@@ -3790,7 +3832,7 @@ class RobotModel(CascadedLink):
             Batch/retrying IK with configurable initial seeds.
         """
         if move_target is None:
-            move_target = self.end_coords
+            move_target = self._default_move_target('inverse_kinematics')
         if link_list is None and joint_list is None:
             if not isinstance(move_target, list):
                 link_list = self.link_lists(move_target.parent)
@@ -4064,7 +4106,8 @@ class RobotModel(CascadedLink):
             use_current_angles = False
 
         if move_target is None:
-            move_target = self.end_coords
+            move_target = self._default_move_target(
+                'batch_inverse_kinematics')
         if link_list is None:
             if not isinstance(move_target, list):
                 link_list = self.link_lists(move_target.parent)

--- a/tests/skrobot_tests/model_tests/test_robot_model.py
+++ b/tests/skrobot_tests/model_tests/test_robot_model.py
@@ -354,6 +354,21 @@ class TestRobotModel(unittest.TestCase):
                           fetch.wrist_flex_link,
                           fetch.wrist_roll_link])
 
+    def test_default_move_target_names_a_group_to_call(self):
+        pr2 = self.pr2
+        target = pr2.rarm.end_coords.copy_worldcoords()
+        for call in ('inverse_kinematics', 'batch_inverse_kinematics'):
+            argument = target if call == 'inverse_kinematics' else [target]
+            with self.assertRaises(AttributeError) as ctx:
+                getattr(pr2, call)(argument)
+            message = str(ctx.exception)
+            self.assertIn('has no end_coords', message)
+            self.assertIn('robot.rarm.{}'.format(call), message)
+        # A model that has one is unaffected.
+        fetch = self.fetch
+        self.assertIs(fetch._default_move_target('inverse_kinematics'),
+                      fetch.end_coords)
+
     def test_inverse_kinematics_args(self):
         kuka = self.kuka
         kuka.inverse_kinematics_args()


### PR DESCRIPTION
`robot.inverse_kinematics(target)` and `robot.batch_inverse_kinematics(targets)` fell over with `'PR2' object has no attribute 'end_coords'` on any robot that defines no single end-effector.

They now raise a message that names a group carrying one, so the fix is in the error: `Call it on the group that has one, for example robot.rarm.inverse_kinematics(...), or pass move_target=robot.rarm_end_coords.`

A model that does have `end_coords` is untouched.