### PR TITLE
Drop the requirements sorting check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,15 +69,6 @@ jobs:
       run: |
         make latexpdf
 
-  requirements-formatting:
-    name: Check Requirements Formatting
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Check Formatting
-      run: |
-        sort -C requirements.txt
-
   tests-3x:
     name: Run Unit Tests (Python 3.x)
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The `Check Requirements Formatting` job ran `sort -C requirements.txt`, which prints nothing at all when it fails: a contributor saw a red check with an empty log and no hint that a line was out of order or how to reorder it.

Keeping requirements.txt sorted is worth little enough that an unexplained red check costs more than the ordering, so the job goes rather than growing a message.

requirements.txt itself is untouched and still sorted.