### PR TITLE
ci(release): read the version instead of installing to import it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,30 +80,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          # tomllib is 3.11+.  Nothing here imports the package, so the version
+          # this job runs on is unrelated to the ones the package supports.
+          python-version: '3.x'
 
-      - name: Wait for apt-get lock
-        run: |
-          while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
-            echo "Waiting for apt lock release..."
-            sleep 1
-          done
-
-      - name: Install APT On Linux
-        run: |
-          sudo apt-get update -qq -y
-          sudo apt-get install -qq -y libspatialindex-dev freeglut3-dev libsuitesparse-dev libblas-dev liblapack-dev
-          sudo apt-get install -qq -y xvfb # for headless testing
-
-      - name: Install package
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install .\[all\]
-
-      - name: Get version from package
+      # Read the version as the literal it is.  This used to install the whole
+      # 'all' extra -- pybullet, open3d, jax, mitsuba -- so it could import
+      # skrobot for __version__, which put a minute of dependency resolution and
+      # a system apt install in front of every release and made an unrelated
+      # optional dependency able to block one.
+      - name: Get version from pyproject.toml
         id: get_version
         run: |
-          VERSION=$(python -c "import skrobot; print(skrobot.__version__)")
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "Detected version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Tagging a release spent 83 of its 92 seconds installing system libraries and the whole `all` extra — pybullet, open3d, jax, mitsuba — so it could `import skrobot` and read `__version__`. Since packaging moved to `pyproject.toml` the version is a literal sitting in that file. This also removes a way for a release to fail that has nothing to do with the release: an optional dependency that stops resolving on the runner could block the tag.

## Test plan

- `actionlint` — 0 errors
- Confirmed both methods agree on the current version: `tomllib` on `pyproject.toml` gives `0.3.36`, and `import skrobot` on the released `scikit-robot==0.3.36` also gives `0.3.36`, matching tag `v0.3.36`
- The 83s figure is subtraction from the last run's measured steps (`Install APT` 16s + `Install package` 67s); the real saving is observable on the next release