### PR TITLE
Let the JAX backend be asked not to change the process precision

### DIFF
--- a/skrobot/backend/jax_backend.py
+++ b/skrobot/backend/jax_backend.py
@@ -39,9 +39,6 @@ def _ensure_jax():
         _jnp = jnp
         _lax = lax
 
-        # Enable float64 by default
-        jax.config.update("jax_enable_x64", True)
-
 
 class JaxBackend:
     """JAX backend for differentiable array operations.
@@ -52,7 +49,14 @@ class JaxBackend:
     Parameters
     ----------
     enable_x64 : bool
-        Enable 64-bit floating point precision. Default is True.
+        Turn JAX's 64-bit floating point mode on. Default is True, which
+        is what the rest of scikit-robot's JAX code expects.
+
+        ``jax_enable_x64`` is a process-wide setting, so ``False`` means
+        "leave it as it is" rather than "turn it off": a library has no
+        business switching double precision off underneath whatever else
+        shares the interpreter. Pass ``False`` when the process already
+        chose its own precision.
 
     Examples
     --------

--- a/tests/skrobot_tests/test_backend.py
+++ b/tests/skrobot_tests/test_backend.py
@@ -255,3 +255,36 @@ class TestBackendDynamicsJax(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestJaxBackendPrecision(unittest.TestCase):
+    """The backend must not decide the precision of the whole process."""
+
+    @staticmethod
+    def _in_fresh_process(body):
+        import subprocess
+        import sys
+        code = ('import jax\n'
+                'from skrobot.backend.jax_backend import JaxBackend\n'
+                + body
+                + 'print(jax.config.jax_enable_x64)\n')
+        try:
+            out = subprocess.check_output(
+                [sys.executable, '-c', code], stderr=subprocess.DEVNULL)
+        except subprocess.CalledProcessError:
+            return None
+        return out.decode().strip().splitlines()[-1]
+
+    def test_asking_for_no_x64_leaves_the_process_alone(self):
+        got = self._in_fresh_process(
+            'b = JaxBackend(enable_x64=False)\n'
+            'b.array([1.0, 2.0])\n')
+        if got is None:
+            self.skipTest('JAX not available')
+        self.assertEqual(got, 'False')
+
+    def test_the_default_still_turns_x64_on(self):
+        got = self._in_fresh_process('JaxBackend()\n')
+        if got is None:
+            self.skipTest('JAX not available')
+        self.assertEqual(got, 'True')


### PR DESCRIPTION
`JaxBackend` documents an `enable_x64` argument, but `_ensure_jax()` already turned `jax_enable_x64` on before `__init__` ever read it. Passing `enable_x64=False` therefore did nothing, and merely importing and using the backend moved any other JAX code in the same interpreter to float64.

The flag is now set only where the argument is read. The default is unchanged, so existing callers keep double precision.

`False` means "leave the process setting as it is" rather than "turn it off" — `jax_enable_x64` is process-wide and a library should not switch it off underneath whatever else shares the interpreter. The docstring now says so.