### PR TITLE
Force a working BLAS kernel on the runners that need one

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,6 +199,47 @@ jobs:
         else
           pip install scipy==${{ matrix.scipy-version }}
         fi
+    - name: Work around a wrong OpenBLAS dgemm on some runners
+      # Part of the runner pool -- an Intel Xeon 6973P-C, about one job in
+      # twelve -- returns wrong numbers from numpy's bundled OpenBLAS, which
+      # detects it as Cooperlake.  The (4, 4) by (4, n) product every
+      # trimesh.transform_points call makes comes back as [10*x + 10, 0, 0]
+      # for most rows once n passes roughly 128: the homogeneous row folded
+      # into the first column and the other two zeroed.  Every mesh a URDF
+      # scales goes through that call, so the model loads misshapen and lands
+      # as an unexplained geometry failure somewhere downstream -- it was
+      # showing up as test_sdf_from_robot_with_scale_parameter measuring a
+      # grid 7.4 times too wide, and as the Mitsuba viewer sizing a Panda
+      # scene wrong in the same job.
+      #
+      # Measured on the affected runner: HASWELL, SKYLAKEX and NEHALEM all
+      # give exact results, SAPPHIRERAPIDS does not, and OPENBLAS_NUM_THREADS=1
+      # makes no difference, so it is the kernel and not a race.  HASWELL is
+      # the one to force because this has to be harmless on the runners it is
+      # not aimed at, and SKYLAKEX would put AVX-512 kernels on the EPYC 7763s
+      # that make up much of the pool and do not have it.
+      #
+      # Only set on a runner that actually fails the multiply, so the rest
+      # keep their own kernels. OpenBLAS reads the variable when it loads, so
+      # this cannot be done from inside the test session; it has to be here.
+      run: |
+        if ! python - <<'PY'
+        import sys
+
+        import numpy as np
+
+        n = 2503
+        V = np.random.default_rng(0).random((n, 3))
+        M = np.eye(4)
+        M[:3, :3] = np.diag([10.0, 10.0, 10.0])
+        stack = np.column_stack((V, np.ones(n)))
+        got = np.dot(M, stack.T).T[:, :3]
+        sys.exit(int(np.abs(got - V * 10.0).max() > 1e-9))
+        PY
+        then
+          echo "::warning::$(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2-) returns wrong results from numpy's BLAS; forcing OPENBLAS_CORETYPE=HASWELL"
+          echo "OPENBLAS_CORETYPE=HASWELL" >> "$GITHUB_ENV"
+        fi
     - name: Install matplotlib for examples
       run: |
         # Required for differential_wrist_joint_limit_demo.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,52 @@
+"""Session-wide checks that run before any test does.
+
+Right now there is one, and it exists because the failure it catches is
+otherwise unreadable: a machine whose BLAS returns wrong numbers produces a
+misshapen robot and a test failure several layers away from the cause.
+"""
+
+import sys
+
+import numpy as np
+
+
+def _homogeneous_product_is_correct():
+    """Return whether this machine multiplies a homogeneous transform right.
+
+    ``trimesh.transform_points`` -- and so every mesh a URDF scales or
+    places -- stacks a column of ones onto the points and multiplies the
+    (4, 4) transform by the resulting (4, n).  Some of GitHub's runners, an
+    Intel Xeon 6973P-C that numpy's bundled OpenBLAS detects as Cooperlake,
+    get that product wrong for n past roughly 128: most rows come back as
+    ``[10*x + 10, 0, 0]``, the homogeneous row folded into the first column
+    and the other two zeroed.  A scale of 10 then yields a mesh that is not
+    the original scaled by anything, and the first thing to notice is a
+    signed distance field built on a grid 7.4 times too wide.
+
+    Returns
+    -------
+    correct : bool
+        Whether the product matches multiplying the points by the scale
+        directly, which does not go through BLAS.
+    """
+    n = 2503
+    points = np.random.default_rng(0).random((n, 3))
+    matrix = np.eye(4)
+    matrix[:3, :3] = np.diag([10.0, 10.0, 10.0])
+    stacked = np.column_stack((points, np.ones(n)))
+    product = np.dot(matrix, stacked.T).T[:, :3]
+    return np.abs(product - points * 10.0).max() <= 1e-9
+
+
+def pytest_sessionstart(session):
+    if _homogeneous_product_is_correct():
+        return
+    sys.stderr.write(
+        '\nnumpy on this machine returns wrong results for the matrix '
+        'product behind every mesh transform, so the models these tests '
+        'build are not the shapes they are meant to be and the failures '
+        'would not point here.\n\n'
+        'Set a working kernel before starting python -- OpenBLAS reads this '
+        'when it loads, so it cannot be done from inside the session:\n\n'
+        '    OPENBLAS_CORETYPE=HASWELL pytest ...\n\n')
+    raise SystemExit(1)


### PR DESCRIPTION
`test_sdf_from_robot_with_scale_parameter` has been going red on some runs of a commit and green on others, most recently on 15d396f, which produced one failing run and one clean one. The assertion said the signed distance field had been built on a grid 7.4 times too wide:

```
worst |sdf| is 0.5357201464651443 (4.19 grid cells of 0.127984),
tolerance 0.19197599999999998
```

It is not scipy 1.8.0, which is what the failing cells had in common by coincidence. In run 34554196186 the numpy-latest/scipy-1.8.0 cell passed while numpy-1.23.5/scipy-1.8.0 failed; in 34552744465 the numpy-latest/scipy-1.8.0 cell failed.

## What it is

numpy's bundled OpenBLAS detects the `Intel(R) Xeon(R) 6973P-C` as `Core: Cooperlake`, and that kernel returns wrong results for `(4, 4)` by `(4, n)` double-precision products once `n` passes roughly 128. Most rows come back as `[10*x + 10, 0, 0]`: the homogeneous row folded into the first column and the other two zeroed. 2311 of 2503 rows on the sample.

That is the product `trimesh.transform_points` makes, so every mesh a URDF scales or places is built from it. The collision mesh comes out a shape the bunny never had, SDFGen sizes the grid from its bounding box, and the failure surfaces four layers from the cause. The Mitsuba viewer sizing a Panda scene wrong in the same job was this too.

Minimal reproducer:

```python
import numpy as np
n = 2503
V = np.random.default_rng(0).random((n, 3))
M = np.eye(4); M[:3, :3] = np.diag([10.0, 10.0, 10.0])
stack = np.column_stack((V, np.ones(n)))
print(np.abs(np.dot(M, stack.T).T[:, :3] - V * 10.0).max())
# 0.0 anywhere healthy, 10.0 on a Xeon 6973P-C
```

## How it was pinned down

One runner per job, 145 jobs over five batches, printing the diagnostics whether or not the assertion held, because a machine can carry the defect and still pass: an over-wide grid on its own only moves the worst vertex to about half a cell, measured at four grid sizes.

| CPU | runners | result |
| --- | --- | --- |
| Intel Xeon 6973P-C | 10 | all reproduced the failure, to the last digit of both the resolution and the worst vertex |
| AMD EPYC 7763 / 9V45 / 9V74 | 120 | all clean |
| Intel Xeon Platinum 8573C | 15 | all clean |

On an affected runner:

| | max abs diff |
| --- | --- |
| `np.dot` (2503, 3) x (3, 3) | 0.0 |
| (4, 4) x (4, n), n = 4, 16, 64 | 0.0 |
| (4, 4) x (4, n), n = 256 | 10.0, 128 of 256 rows |
| (4, 4) x (4, n), n = 2503 | 10.0, 2311 of 2503 rows |
| einsum, which does not use BLAS | 0.0 |
| `OPENBLAS_NUM_THREADS=1` | 10.0 |
| `OPENBLAS_CORETYPE=HASWELL` | 0.0 |
| `OPENBLAS_CORETYPE=SKYLAKEX` | 0.0 |
| `OPENBLAS_CORETYPE=NEHALEM` | 0.0 |
| `OPENBLAS_CORETYPE=SAPPHIRERAPIDS` | 10.0 |

Single threads make no difference, so it is not a race. einsum and the `(3, 3)` product are exact, so it is that kernel and that shape.

## What this changes

The workflow checks that product after installing numpy and scipy, and sets `OPENBLAS_CORETYPE=HASWELL` only on a runner that fails it, with a warning annotation naming the CPU. Haswell rather than SkylakeX because the setting has to be harmless on the machines it is not aimed at, and the EPYC 7763s that are most of the pool have no AVX-512. Healthy runners keep their own kernels. It cannot be done from inside the session: OpenBLAS reads the variable when it loads.

Confirmed end to end on a batch of forty runners: five were 6973P-C, the guard tripped on exactly those five, and all forty then produced the correct grid.

`tests/conftest.py` runs the same check at session start and stops with the reason and the command to set, so the same machine under someone's desk costs a sentence rather than an afternoon.

## What this does not change

- **The test.** It was right. The field really was wrong, and widening the tolerance to 4.19 grid cells would have taught it to accept a misshapen robot.
- **skrobot or trimesh.** Both are correct; the multiply is not. Routing `Link.collision_mesh` around the matrix product would only make a broken machine look like it was working.
- **The Windows job.** There is no evidence the affected CPU is in that pool, and an untested cross-platform version of this guard is the riskier change. Worth revisiting if unexplained geometry failures turn up there.

Not reported upstream. The closest existing reports are OpenBLAS [#2168](https://github.com/OpenMathLib/OpenBLAS/issues/2168), [#3454](https://github.com/OpenMathLib/OpenBLAS/issues/3454), [#5267](https://github.com/OpenMathLib/OpenBLAS/issues/5267) and [#2769](https://github.com/OpenMathLib/OpenBLAS/issues/2769); none names this CPU.
